### PR TITLE
Add mapper to map api response to frontend model for the landing page

### DIFF
--- a/data/data.go
+++ b/data/data.go
@@ -1,0 +1,29 @@
+package data
+
+// Dataset ...
+type Dataset struct {
+	ID          string  `json:"id"`
+	Title       string  `json:"title"`
+	URL         string  `json:"url"`
+	ReleaseDate string  `json:"release_date"`
+	NextRelease string  `json:"next_release"`
+	Edition     string  `json:"edition"`
+	Version     string  `json:"version"`
+	Contact     Contact `json:"contact"`
+}
+
+// Contact ...
+type Contact struct {
+	Name      string `json:"name"`
+	Telephone string `json:"telephone"`
+	Email     string `json:"email"`
+}
+
+// Dimension ...
+type Dimension struct {
+	CodeListID string   `json:"code_list_id"`
+	ID         string   `json:"id"`
+	Name       string   `json:"name"`
+	Type       string   `json:"type"`
+	Values     []string `json:"values"`
+}

--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -98,11 +98,14 @@ func landing(w http.ResponseWriter, req *http.Request, zc ZebedeeClient, cfg con
 
 	m := zebedeeMapper.MapZebedeeDatasetLandingPageToFrontendModel(dlp, bc, ds)
 
-	//m.FilterID = "filterable" // This information should be coming from zebedee but isn't implemented as of yet
+	m.FilterID = "filterable" // TODO: This information should be coming from zebedee but isn't implemented as of yet
+	m.DatasetLandingPage.DatasetID = "12345"
+
 	var templateJSON []byte
 
 	if m.FilterID == "filterable" {
 
+		// TODO: This information will be coming from the dataset api when it is implemented
 		datasets := []filterdata.Dataset{
 			{
 				ID:          "12345",
@@ -155,8 +158,6 @@ func landing(w http.ResponseWriter, req *http.Request, zc ZebedeeClient, cfg con
 			return
 		}
 	}
-
-	log.Debug("json", log.Data{"json": string(templateJSON)})
 
 	templateHTML, err := render(templateJSON, m.FilterID, cfg)
 	if err != nil {

--- a/handlers/handlers_test.go
+++ b/handlers/handlers_test.go
@@ -56,7 +56,7 @@ func TestUnitHandlers(t *testing.T) {
 			cfg := config.Get()
 			req.AddCookie(&http.Cookie{Name: "access_token", Value: "12345"})
 
-			legacyLanding(w, req, mockClient, cfg)
+			landing(w, req, mockClient, cfg)
 
 			So(w.Body.String(), ShouldEqual, `{"some_json":true}`)
 		})
@@ -70,7 +70,7 @@ func TestUnitHandlers(t *testing.T) {
 			So(err, ShouldBeNil)
 			cfg := config.Get()
 
-			legacyLanding(w, req, mockClient, cfg)
+			landing(w, req, mockClient, cfg)
 
 			So(w.Code, ShouldEqual, http.StatusInternalServerError)
 		})
@@ -94,7 +94,7 @@ func TestUnitHandlers(t *testing.T) {
 			So(err, ShouldBeNil)
 			cfg := config.Get()
 
-			legacyLanding(w, req, mockClient, cfg)
+			landing(w, req, mockClient, cfg)
 
 			So(w.Code, ShouldEqual, http.StatusOK)
 			So(w.Body.String(), ShouldEqual, `<html><body><h1>Some HTML from renderer!</h1></body></html>`)
@@ -110,7 +110,7 @@ func TestUnitHandlers(t *testing.T) {
 			So(err, ShouldBeNil)
 			cfg := config.Get()
 
-			legacyLanding(w, req, mockClient, cfg)
+			landing(w, req, mockClient, cfg)
 			So(w.Code, ShouldEqual, http.StatusInternalServerError)
 		})
 
@@ -125,7 +125,7 @@ func TestUnitHandlers(t *testing.T) {
 			So(err, ShouldBeNil)
 			cfg := config.Get()
 
-			legacyLanding(w, req, mockClient, cfg)
+			landing(w, req, mockClient, cfg)
 			So(w.Code, ShouldEqual, http.StatusInternalServerError)
 		})
 
@@ -145,7 +145,7 @@ func TestUnitHandlers(t *testing.T) {
 			So(err, ShouldBeNil)
 			cfg := config.Get()
 
-			legacyLanding(w, req, mockClient, cfg)
+			landing(w, req, mockClient, cfg)
 
 			So(w.Code, ShouldEqual, http.StatusInternalServerError)
 		})

--- a/mapper/mapper.go
+++ b/mapper/mapper.go
@@ -1,0 +1,47 @@
+package mapper
+
+import (
+	"github.com/ONSdigital/dp-frontend-dataset-controller/data"
+	"github.com/ONSdigital/dp-frontend-models/model/datasetLandingPageFilterable"
+	"github.com/ONSdigital/go-ns/zebedee/zebedeeMapper"
+)
+
+// CreateFilterableLandingPage ...
+func CreateFilterableLandingPage(ds []data.Dataset, dims []data.Dimension, sp zebedeeMapper.StaticDatasetLandingPage) datasetLandingPageFilterable.Page {
+	p := datasetLandingPageFilterable.Page{}
+	p.Type = sp.Type
+	p.URI = sp.URI
+	p.Metadata = sp.Metadata
+	p.DatasetLandingPage.DatasetLandingPage = sp.DatasetLandingPage
+	p.Breadcrumb = sp.Breadcrumb
+	p.ContactDetails = sp.ContactDetails
+
+	for i, d := range ds {
+		var v datasetLandingPageFilterable.Version
+		v.Title = d.Title
+		v.Description = sp.DatasetLandingPage.MetaDescription
+		v.Edition = d.Edition
+		v.Version = d.Version
+		v.ReleaseDate = d.ReleaseDate
+
+		if len(sp.DatasetLandingPage.Datasets)-1 >= i {
+			for _, download := range sp.DatasetLandingPage.Datasets[i].Downloads {
+				dwnld := datasetLandingPageFilterable.Download(download)
+				v.Downloads = append(v.Downloads, dwnld)
+			}
+		}
+
+		p.DatasetLandingPage.Versions = append(p.DatasetLandingPage.Versions, v)
+	}
+
+	for _, dim := range dims {
+		var pDim datasetLandingPageFilterable.Dimension
+
+		pDim.Title = dim.Name
+		pDim.Values = dim.Values
+
+		p.DatasetLandingPage.Dimensions = append(p.DatasetLandingPage.Dimensions, pDim)
+	}
+
+	return p
+}

--- a/mapper/mapper_test.go
+++ b/mapper/mapper_test.go
@@ -1,0 +1,89 @@
+package mapper
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"testing"
+
+	"github.com/ONSdigital/dp-frontend-dataset-controller/data"
+	"github.com/ONSdigital/dp-frontend-models/model/datasetLandingPageFilterable"
+	"github.com/ONSdigital/go-ns/zebedee/zebedeeMapper"
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestUnitMapper(t *testing.T) {
+	Convey("test CreateFilterableLandingPage", t, func() {
+		ds := getTestDatasets()
+		dims := getTestDimensions()
+		sp := getTestStaticLandingPage()
+
+		p := CreateFilterableLandingPage(ds, dims, sp)
+		So(p.Type, ShouldEqual, sp.Type)
+		So(p.URI, ShouldEqual, sp.URI)
+		So(p.Metadata, ShouldResemble, sp.Metadata)
+		So(p.DatasetLandingPage.DatasetLandingPage, ShouldResemble, sp.DatasetLandingPage)
+		So(p.Breadcrumb, ShouldResemble, sp.Breadcrumb)
+		So(p.ContactDetails, ShouldResemble, sp.ContactDetails)
+
+		v0 := p.DatasetLandingPage.Versions[0]
+
+		So(v0.Title, ShouldEqual, ds[0].Title)
+		So(v0.Description, ShouldEqual, sp.DatasetLandingPage.MetaDescription)
+		So(v0.Edition, ShouldEqual, ds[0].Edition)
+		So(v0.Version, ShouldEqual, ds[0].Version)
+		So(v0.ReleaseDate, ShouldEqual, ds[0].ReleaseDate)
+		So(v0.Downloads[0], ShouldResemble, datasetLandingPageFilterable.Download(sp.DatasetLandingPage.Datasets[0].Downloads[0]))
+
+		d0 := p.DatasetLandingPage.Dimensions[0]
+
+		So(d0.Title, ShouldResemble, dims[0].Name)
+		So(d0.Values, ShouldResemble, dims[0].Values)
+	})
+}
+
+func getTestDatasets() []data.Dataset {
+	return []data.Dataset{
+		{
+			ID:          "12345",
+			Title:       "Dataset title",
+			URL:         "google.com",
+			ReleaseDate: "11 November 2017",
+			NextRelease: "11 November 2018",
+			Edition:     "2017",
+			Version:     "1",
+			Contact: data.Contact{
+				Name:      "Matt Rout",
+				Telephone: "012346 382012",
+				Email:     "matt@gmail.com",
+			},
+		},
+	}
+}
+
+func getTestDimensions() []data.Dimension {
+	return []data.Dimension{
+		{
+			CodeListID: "ABDCSKA",
+			ID:         "siojxuidhc",
+			Name:       "Geography",
+			Type:       "Hierarchy",
+			Values:     []string{"Region", "County"},
+		},
+		{
+			CodeListID: "AHDHSID",
+			ID:         "eorihfieorf",
+			Name:       "Age List",
+			Type:       "List",
+			Values:     []string{"0", "1", "2"},
+		},
+	}
+}
+
+func getTestStaticLandingPage() zebedeeMapper.StaticDatasetLandingPage {
+	var sdlp zebedeeMapper.StaticDatasetLandingPage
+
+	f, _ := ioutil.ReadFile("testdata/staticlandingpage.json")
+
+	json.Unmarshal(f, &sdlp)
+	return sdlp
+}

--- a/mapper/testdata/staticlandingpage.json
+++ b/mapper/testdata/staticlandingpage.json
@@ -1,0 +1,75 @@
+{
+	"type": "dataset_landing_page",
+	"uri": "/employmentandlabourmarket/peopleinwork/workplacedisputesandworkingconditions/datasets/labourdisputesbysectorlabd02",
+	"taxonomy": null,
+	"breadcrumb": [{
+		"title": "Home",
+		"uri": "/"
+	}, {
+		"title": "Employment and labour market",
+		"uri": "/employmentandlabourmarket"
+	}, {
+		"title": "People in work",
+		"uri": "/employmentandlabourmarket/peopleinwork"
+	}, {
+		"title": "Workplace disputes and working conditions",
+		"uri": "/employmentandlabourmarket/peopleinwork/workplacedisputesandworkingconditions"
+	}],
+	"service_message": "",
+	"metadata": {
+		"title": "Labour disputes by sector: LABD02",
+		"description": "Labour disputes by sector.",
+		"keywords": null,
+		"footer": {
+			"enabled": false,
+			"contact": "",
+			"release_date": "",
+			"next_release": "",
+			"dataset_id": ""
+		}
+	},
+	"search_disabled": false,
+	"data": {
+		"dataset_id": "",
+		"filter_id": "",
+		"related": {
+			"related_publications": [{
+				"title": "",
+				"uri": "/employmentandlabourmarket/peopleinwork/employmentandemployeetypes/bulletins/uklabourmarket/2015-07-15"
+			}],
+			"related_datasets": [{
+				"title": "Labour disputes: LABD01",
+				"uri": "/employmentandlabourmarket/peopleinwork/workplacedisputesandworkingconditions/datasets/labourdisputeslabd01"
+			}, {
+				"title": "Stoppages of work: LABD03",
+				"uri": "/employmentandlabourmarket/peopleinwork/workplacedisputesandworkingconditions/datasets/stoppagesofworklabd03"
+			}],
+			"related_methodology": null,
+			"related_links": null
+		},
+		"markdown": "",
+		"meta_description": "",
+		"national_statistic": true,
+		"release_date": "2015-07-14T23:00:00.000Z",
+		"next_release": "12 August 2015",
+		"is_timeseries": false,
+		"corrections": null,
+		"notices": null,
+		"parent_path": "Workplace disputes and working conditions",
+    "datasets": [
+      {
+        "downloads": [
+          {
+            "extension": "csv",
+            "size": "483920",
+            "uri": "/somedownload"
+          }
+        ]
+      }
+    ]
+	},
+	"filter_id": "",
+	"name": "Richard Clegg\n",
+	"email": "richard.clegg@ons.gsi.gov.uk\n",
+	"telephone": "+44 (0)1633 455400 \n"
+}

--- a/vendor/github.com/ONSdigital/dp-frontend-models/model/datasetLandingPageFilterable/model.go
+++ b/vendor/github.com/ONSdigital/dp-frontend-models/model/datasetLandingPageFilterable/model.go
@@ -1,0 +1,43 @@
+package datasetLandingPageFilterable
+
+import (
+	"github.com/ONSdigital/dp-frontend-models/model"
+	"github.com/ONSdigital/dp-frontend-models/model/datasetLandingPageStatic"
+)
+
+type Page struct {
+	model.Page
+	DatasetLandingPage DatasetLandingPage   `json:"data"`
+	ContactDetails     model.ContactDetails `json:"contact_details"`
+}
+
+type DatasetLandingPage struct {
+	datasetLandingPageStatic.DatasetLandingPage
+	Dimensions []Dimension `json:"dimensions"`
+	Versions   []Version   `json:"versions"`
+}
+
+type Dimension struct {
+	Title       string   `json:"title"`
+	Values      []string `json:"values"`
+	Description string   `json:"description"`
+}
+
+type Version struct {
+	Title       string               `json:"title"`
+	Description string               `json:"description"`
+	URL         string               `json:"url"`
+	ReleaseDate string               `json:"release_date"`
+	NextRelease string               `json:"next_release"`
+	Downloads   []Download           `json:"downloads"`
+	Edition     string               `json:"edition"`
+	Version     string               `json:"version"`
+	Contact     model.ContactDetails `json:"contact"`
+}
+
+//Download has the details for the an individual dataset's downloadable files
+type Download struct {
+	Extension string `json:"extension"`
+	Size      string `json:"size"`
+	URI       string `json:"uri"`
+}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -9,6 +9,12 @@
 			"revisionTime": "2017-07-11T09:57:28Z"
 		},
 		{
+			"checksumSHA1": "dIN68DBlfqRmqv6L+TbRb3SNC+g=",
+			"path": "github.com/ONSdigital/dp-frontend-models/model/datasetLandingPageFilterable",
+			"revision": "6a64978573675919e135ba7403a83ee9ce718c69",
+			"revisionTime": "2017-07-20T12:08:57Z"
+		},
+		{
 			"checksumSHA1": "2Ww7ArlxDH4Cs/1S01vx1heMAow=",
 			"path": "github.com/ONSdigital/dp-frontend-models/model/datasetLandingPageStatic",
 			"revision": "68099c8c0a883488fb056b2ad1500c4c478bf883",


### PR DESCRIPTION
### What

Add a mapper to map api response to frontend renderer model

### How to review

- Run this service on this branch and renderer on feature/datsetlandingpage-filterable and all the other usual f/end services on cmd-develop
- Verify that you can visit a dataset landing page and the page contains correct content and a button to begin filter/download process

### Who can review

Anyone