### PR TITLE
Update filter job creation to match new filter api spec

### DIFF
--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -36,7 +36,7 @@ func init() {
 // FilterClient is an interface with the methods required for a filter client
 type FilterClient interface {
 	healthcheck.Client
-	CreateJob(datasetFilterID string, names []string) (string, error)
+	CreateBlueprint(datasetFilterID string, names []string) (string, error)
 	AddDimension(id, name string) error
 	AddDimensionValue(filterID, name, value string) error
 }
@@ -89,7 +89,7 @@ func CreateFilterID(c FilterClient, dc DatasetClient) http.HandlerFunc {
 			}
 		}
 
-		fid, err := c.CreateJob(datasetModel.ID, names)
+		fid, err := c.CreateBlueprint(datasetModel.ID, names)
 		if err != nil {
 			log.ErrorR(req, err, log.Data{"setting-response-status": http.StatusInternalServerError})
 			w.WriteHeader(http.StatusInternalServerError)

--- a/handlers/handlers_test.go
+++ b/handlers/handlers_test.go
@@ -35,7 +35,7 @@ func TestUnitHandlers(t *testing.T) {
 	Convey("test CreateFilterID", t, func() {
 		Convey("test CreateFilterID handler, creates a filter id and redirects", func() {
 			mockClient := NewMockFilterClient(mockCtrl)
-			mockClient.EXPECT().CreateJob("87654321", []string{"aggregate", "time"}).Return("12345", nil)
+			mockClient.EXPECT().CreateBlueprint("87654321", []string{"aggregate", "time"}).Return("12345", nil)
 
 			mockDatasetClient := NewMockDatasetClient(mockCtrl)
 			dims := dataset.Dimensions{
@@ -73,7 +73,7 @@ func TestUnitHandlers(t *testing.T) {
 
 		Convey("test CreateFilterID returns 500 if unable to create filter job on filter api", func() {
 			mockClient := NewMockFilterClient(mockCtrl)
-			mockClient.EXPECT().CreateJob(gomock.Any(), gomock.Any()).Return("", errors.New("no filter job for you"))
+			mockClient.EXPECT().CreateBlueprint(gomock.Any(), gomock.Any()).Return("", errors.New("no filter job for you"))
 
 			mockDatasetClient := NewMockDatasetClient(mockCtrl)
 			mockDatasetClient.EXPECT().GetVersion("1234", "5678", "2017")

--- a/handlers/handlers_test.go
+++ b/handlers/handlers_test.go
@@ -71,9 +71,9 @@ func TestUnitHandlers(t *testing.T) {
 			So(location, ShouldEqual, "/filters/12345/dimensions")
 		})
 
-		Convey("test CreateFilterID returns 500 if unable to create filter job on filter api", func() {
+		Convey("test CreateFilterID returns 500 if unable to create a blueprint on filter api", func() {
 			mockClient := NewMockFilterClient(mockCtrl)
-			mockClient.EXPECT().CreateBlueprint(gomock.Any(), gomock.Any()).Return("", errors.New("no filter job for you"))
+			mockClient.EXPECT().CreateBlueprint(gomock.Any(), gomock.Any()).Return("", errors.New("unable to create filter blueprint"))
 
 			mockDatasetClient := NewMockDatasetClient(mockCtrl)
 			mockDatasetClient.EXPECT().GetVersion("1234", "5678", "2017")

--- a/handlers/handlers_test.go
+++ b/handlers/handlers_test.go
@@ -35,9 +35,7 @@ func TestUnitHandlers(t *testing.T) {
 	Convey("test CreateFilterID", t, func() {
 		Convey("test CreateFilterID handler, creates a filter id and redirects", func() {
 			mockClient := NewMockFilterClient(mockCtrl)
-			mockClient.EXPECT().CreateJob("87654321").Return("12345", nil)
-			mockClient.EXPECT().AddDimension("12345", "time")
-			mockClient.EXPECT().AddDimension("12345", "aggregate")
+			mockClient.EXPECT().CreateJob("87654321", []string{"aggregate", "time"}).Return("12345", nil)
 
 			mockDatasetClient := NewMockDatasetClient(mockCtrl)
 			dims := dataset.Dimensions{
@@ -75,10 +73,11 @@ func TestUnitHandlers(t *testing.T) {
 
 		Convey("test CreateFilterID returns 500 if unable to create filter job on filter api", func() {
 			mockClient := NewMockFilterClient(mockCtrl)
-			mockClient.EXPECT().CreateJob(gomock.Any()).Return("", errors.New("no filter job for you"))
+			mockClient.EXPECT().CreateJob(gomock.Any(), gomock.Any()).Return("", errors.New("no filter job for you"))
 
 			mockDatasetClient := NewMockDatasetClient(mockCtrl)
 			mockDatasetClient.EXPECT().GetVersion("1234", "5678", "2017")
+			mockDatasetClient.EXPECT().GetDimensions("1234", "5678", "2017").Return(dataset.Dimensions{}, nil)
 
 			testResponse(500, "", "/datasets/1234/editions/5678/versions/2017/filter", mockClient, mockDatasetClient, CreateFilterID(mockClient, mockDatasetClient))
 		})

--- a/handlers/mock_handlers.go
+++ b/handlers/mock_handlers.go
@@ -155,16 +155,16 @@ func (_mr *MockFilterClientMockRecorder) AddDimensionValue(arg0, arg1, arg2 inte
 }
 
 // CreateJob mocks base method
-func (_m *MockFilterClient) CreateJob(_param0 string) (string, error) {
-	ret := _m.ctrl.Call(_m, "CreateJob", _param0)
+func (_m *MockFilterClient) CreateJob(_param0 string, _param1 []string) (string, error) {
+	ret := _m.ctrl.Call(_m, "CreateJob", _param0, _param1)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // CreateJob indicates an expected call of CreateJob
-func (_mr *MockFilterClientMockRecorder) CreateJob(arg0 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateJob", arg0)
+func (_mr *MockFilterClientMockRecorder) CreateJob(arg0, arg1 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateJob", arg0, arg1)
 }
 
 // Healthcheck mocks base method

--- a/handlers/mock_handlers.go
+++ b/handlers/mock_handlers.go
@@ -154,17 +154,17 @@ func (_mr *MockFilterClientMockRecorder) AddDimensionValue(arg0, arg1, arg2 inte
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "AddDimensionValue", arg0, arg1, arg2)
 }
 
-// CreateJob mocks base method
-func (_m *MockFilterClient) CreateJob(_param0 string, _param1 []string) (string, error) {
-	ret := _m.ctrl.Call(_m, "CreateJob", _param0, _param1)
+// CreateBlueprint mocks base method
+func (_m *MockFilterClient) CreateBlueprint(_param0 string, _param1 []string) (string, error) {
+	ret := _m.ctrl.Call(_m, "CreateBlueprint", _param0, _param1)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// CreateJob indicates an expected call of CreateJob
-func (_mr *MockFilterClientMockRecorder) CreateJob(arg0, arg1 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateJob", arg0, arg1)
+// CreateBlueprint indicates an expected call of CreateBlueprint
+func (_mr *MockFilterClientMockRecorder) CreateBlueprint(arg0, arg1 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateBlueprint", arg0, arg1)
 }
 
 // Healthcheck mocks base method

--- a/vendor/github.com/ONSdigital/go-ns/clients/filter/data.go
+++ b/vendor/github.com/ONSdigital/go-ns/clients/filter/data.go
@@ -28,7 +28,9 @@ type Model struct {
 
 // Links represents a links object on the filter api response
 type Links struct {
-	Version Link `json:"version,omitempty"`
+	Version         Link `json:"version,omitempty"`
+	FilterOutputs   Link `json:"filter_output,omitempty"`
+	FilterBlueprint Link `json:"filter_blueprint,omitempty"`
 }
 
 // Link represents a single link within a links object

--- a/vendor/github.com/ONSdigital/go-ns/clients/filter/data.go
+++ b/vendor/github.com/ONSdigital/go-ns/clients/filter/data.go
@@ -14,7 +14,7 @@ type DimensionOption struct {
 
 // Model represents a model returned from the filter api
 type Model struct {
-	FilterID   string              `json:"filter_job_id"`
+	FilterID   string              `json:"filter_id"`
 	InstanceID string              `json:"instance_id"`
 	Links      Links               `json:"links"`
 	Dataset    string              `json:"dataset"`

--- a/vendor/github.com/ONSdigital/go-ns/clients/filter/filter.go
+++ b/vendor/github.com/ONSdigital/go-ns/clients/filter/filter.go
@@ -63,6 +63,32 @@ func (c *Client) Healthcheck() (string, error) {
 	return service, nil
 }
 
+// GetOutput returns a filter output job for a given filter output id
+func (c *Client) GetOutput(filterOutputID string) (m Model, err error) {
+	uri := fmt.Sprintf("%s/filter-outputs/%s", c.url, filterOutputID)
+
+	clientlog.Do("retrieving filter output", service, uri)
+
+	resp, err := c.cli.Get(uri)
+	if err != nil {
+		return
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		err = &ErrInvalidFilterAPIResponse{http.StatusOK, resp.StatusCode, uri}
+		return
+	}
+
+	b, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return
+	}
+	defer resp.Body.Close()
+
+	err = json.Unmarshal(b, &m)
+	return
+}
+
 // GetDimension returns information on a requested dimension name for a given filterID
 func (c *Client) GetDimension(filterID, name string) (dim Dimension, err error) {
 	uri := fmt.Sprintf("%s/filters/%s/dimensions/%s", c.url, filterID, name)
@@ -148,8 +174,8 @@ func (c *Client) GetDimensionOptions(filterID, name string) (opts []DimensionOpt
 	return
 }
 
-// CreateJob creates a filter job and returns the associated filterJobID
-func (c *Client) CreateJob(instanceID string, names []string) (string, error) {
+// CreateBlueprint creates a filter blueprint and returns the associated filterID
+func (c *Client) CreateBlueprint(instanceID string, names []string) (string, error) {
 	fj := Model{InstanceID: instanceID}
 
 	var dimensions []ModelDimension
@@ -165,7 +191,7 @@ func (c *Client) CreateJob(instanceID string, names []string) (string, error) {
 	}
 
 	uri := c.url + "/filters"
-	clientlog.Do("attemping to create filter job", service, uri, log.Data{
+	clientlog.Do("attemping to create filter blueprint", service, uri, log.Data{
 		"method":     "POST",
 		"instanceID": instanceID,
 	})
@@ -192,14 +218,18 @@ func (c *Client) CreateJob(instanceID string, names []string) (string, error) {
 	return fj.FilterID, nil
 }
 
-// UpdateJob will update a job with a given filter model
-func (c *Client) UpdateJob(m Model) error {
+// UpdateBlueprint will update a blueprint with a given filter model
+func (c *Client) UpdateBlueprint(m Model, doSubmit bool) (mdl Model, err error) {
 	b, err := json.Marshal(m)
 	if err != nil {
-		return err
+		return
 	}
 
 	uri := fmt.Sprintf("%s/filters/%s", c.url, m.FilterID)
+
+	if doSubmit {
+		uri = uri + "?submitted=true"
+	}
 
 	clientlog.Do("updating filter job", service, uri, log.Data{
 		"method": "PUT",
@@ -208,19 +238,28 @@ func (c *Client) UpdateJob(m Model) error {
 
 	req, err := http.NewRequest("PUT", uri, bytes.NewBuffer(b))
 	if err != nil {
-		return err
+		return
 	}
 
 	resp, err := c.cli.Do(req)
 	if err != nil {
-		return err
+		return
 	}
-
 	if resp.StatusCode != http.StatusOK {
-		return ErrInvalidFilterAPIResponse{http.StatusOK, resp.StatusCode, uri}
+		return m, ErrInvalidFilterAPIResponse{http.StatusOK, resp.StatusCode, uri}
 	}
 
-	return nil
+	defer resp.Body.Close()
+	b, err = ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return
+	}
+
+	if err = json.Unmarshal(b, &m); err != nil {
+		return
+	}
+
+	return m, nil
 }
 
 // AddDimensionValue adds a particular value to a filter job for a given filterID

--- a/vendor/github.com/ONSdigital/go-ns/clients/filter/filter.go
+++ b/vendor/github.com/ONSdigital/go-ns/clients/filter/filter.go
@@ -149,8 +149,15 @@ func (c *Client) GetDimensionOptions(filterID, name string) (opts []DimensionOpt
 }
 
 // CreateJob creates a filter job and returns the associated filterJobID
-func (c *Client) CreateJob(instanceID string) (string, error) {
-	fj := Model{InstanceID: instanceID, State: "created"}
+func (c *Client) CreateJob(instanceID string, names []string) (string, error) {
+	fj := Model{InstanceID: instanceID}
+
+	var dimensions []ModelDimension
+	for _, name := range names {
+		dimensions = append(dimensions, ModelDimension{Name: name})
+	}
+
+	fj.Dimensions = dimensions
 
 	b, err := json.Marshal(fj)
 	if err != nil {

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -33,10 +33,10 @@
 			"revisionTime": "2017-10-23T12:32:27Z"
 		},
 		{
-			"checksumSHA1": "ADHxr5KOZ4RPRAG7OJq4AgNYh98=",
+			"checksumSHA1": "6t+Wr76PlE0yOmNOpnjNu3tcV0Q=",
 			"path": "github.com/ONSdigital/go-ns/clients/filter",
-			"revision": "7813079448007391bafd94cd0ad15c447be591f3",
-			"revisionTime": "2017-10-09T12:09:44Z"
+			"revision": "a1bd0a85bf8904441aa027164380a31c6583cec4",
+			"revisionTime": "2017-10-23T12:32:27Z"
 		},
 		{
 			"checksumSHA1": "SE6Kslx9U8YhbeNOSQ5n0vvkuYI=",

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -33,10 +33,10 @@
 			"revisionTime": "2017-10-23T12:32:27Z"
 		},
 		{
-			"checksumSHA1": "6t+Wr76PlE0yOmNOpnjNu3tcV0Q=",
+			"checksumSHA1": "MKOhkB+MWSWilvK9xy5mBjIbpzo=",
 			"path": "github.com/ONSdigital/go-ns/clients/filter",
-			"revision": "a1bd0a85bf8904441aa027164380a31c6583cec4",
-			"revisionTime": "2017-10-23T12:32:27Z"
+			"revision": "87bd96905d0ea0531c0ea9753d9d06df5d7244da",
+			"revisionTime": "2017-11-03T10:07:44Z"
 		},
 		{
 			"checksumSHA1": "SE6Kslx9U8YhbeNOSQ5n0vvkuYI=",


### PR DESCRIPTION
### What

Update filter job creation to match new filter api spec
### How to review

Create a filter job through the web UI
Add dimension options to the job
Submit the job and verify the url changes to /filter-ouputs/{id}
Verify that when you click the adjust filter options button you return to /filters/{id}/dimensions

### Who can review

Anyone **DO NOT MERGE UNTIL BACKEND SERVICES HAVE BEEN MERGED**