### PR TITLE
Feature/dataset editions page

### DIFF
--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -209,7 +209,6 @@ func filterableLanding(w http.ResponseWriter, req *http.Request, dc DatasetClien
 }
 
 func editionsList(w http.ResponseWriter, req *http.Request, dc DatasetClient, cfg config.Config) {
-	log.Debug("EDITIONSLIST FUNC!!!", nil)
 	vars := mux.Vars(req)
 	datasetID := vars["datasetID"]
 
@@ -228,7 +227,6 @@ func editionsList(w http.ResponseWriter, req *http.Request, dc DatasetClient, cf
 	}
 
 	m := mapper.CreateEditionsList(datasetModel, datasetEditions, datasetID)
-	fmt.Printf("%+v\n", m)
 
 	b, err := json.Marshal(m)
 	if err != nil {
@@ -237,7 +235,7 @@ func editionsList(w http.ResponseWriter, req *http.Request, dc DatasetClient, cf
 		return
 	}
 
-	templateHTML, err := render(b, "DEL", cfg)
+	templateHTML, err := render(b, "editions-list", cfg)
 	if err != nil {
 		log.ErrorR(req, err, log.Data{"setting-response-status": http.StatusInternalServerError})
 		w.WriteHeader(http.StatusInternalServerError)
@@ -299,7 +297,7 @@ func legacyLanding(w http.ResponseWriter, req *http.Request, zc ZebedeeClient, c
 		return
 	}
 
-	templateHTML, err := render(templateJSON, m.FilterID, cfg)
+	templateHTML, err := render(templateJSON, "legacy-dataset", cfg)
 	if err != nil {
 		log.ErrorR(req, err, log.Data{"setting-response-status": http.StatusInternalServerError})
 		w.WriteHeader(http.StatusInternalServerError)
@@ -311,14 +309,14 @@ func legacyLanding(w http.ResponseWriter, req *http.Request, zc ZebedeeClient, c
 
 }
 
-func render(data []byte, filterID string, cfg config.Config) ([]byte, error) {
+func render(data []byte, pageType string, cfg config.Config) ([]byte, error) {
 	rdr := bytes.NewReader(data)
 
 	var rendererReq *http.Request
 	var err error
-	if filterID == "" {
+	if pageType == "legacy-dataset" {
 		rendererReq, err = http.NewRequest("POST", cfg.RendererURL+"/dataset-landing-page-static", rdr)
-	} else if filterID == "DEL" {
+	} else if pageType == "editions-list" {
 		rendererReq, err = http.NewRequest("POST", cfg.RendererURL+"/dataset-edition-list", rdr)
 	} else {
 		rendererReq, err = http.NewRequest("POST", cfg.RendererURL+"/dataset-landing-page-filterable", rdr)

--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -117,6 +117,14 @@ func FilterableLanding(dc DatasetClient) http.HandlerFunc {
 	}
 }
 
+// EditionsList will load a list of editions for a filterable dataset
+func EditionsList(dc DatasetClient) http.HandlerFunc {
+	return func(w http.ResponseWriter, req *http.Request) {
+		cfg := config.Get()
+		editionsList(w, req, dc, cfg)
+	}
+}
+
 func filterableLanding(w http.ResponseWriter, req *http.Request, dc DatasetClient, cfg config.Config) {
 	vars := mux.Vars(req)
 	datasetID := vars["datasetID"]
@@ -200,6 +208,47 @@ func filterableLanding(w http.ResponseWriter, req *http.Request, dc DatasetClien
 
 }
 
+func editionsList(w http.ResponseWriter, req *http.Request, dc DatasetClient, cfg config.Config) {
+	log.Debug("EDITIONSLIST FUNC!!!", nil)
+	vars := mux.Vars(req)
+	datasetID := vars["datasetID"]
+
+	datasetModel, err := dc.Get(datasetID)
+	if err != nil {
+		log.ErrorR(req, err, log.Data{"setting-response-status": http.StatusInternalServerError})
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	datasetEditions, err := dc.GetEditions(datasetID)
+	if err != nil {
+		log.ErrorR(req, err, log.Data{"setting-response-status": http.StatusInternalServerError})
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	m := mapper.CreateEditionsList(datasetModel, datasetEditions, datasetID)
+	fmt.Printf("%+v\n", m)
+
+	b, err := json.Marshal(m)
+	if err != nil {
+		log.ErrorR(req, err, log.Data{"setting-response-status": http.StatusInternalServerError})
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	templateHTML, err := render(b, "DEL", cfg)
+	if err != nil {
+		log.ErrorR(req, err, log.Data{"setting-response-status": http.StatusInternalServerError})
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	w.Write(templateHTML)
+	return
+
+}
+
 func legacyLanding(w http.ResponseWriter, req *http.Request, zc ZebedeeClient, cfg config.Config) {
 	if c, err := req.Cookie("access_token"); err == nil && len(c.Value) > 0 {
 		zc.SetAccessToken(c.Value)
@@ -269,6 +318,8 @@ func render(data []byte, filterID string, cfg config.Config) ([]byte, error) {
 	var err error
 	if filterID == "" {
 		rendererReq, err = http.NewRequest("POST", cfg.RendererURL+"/dataset-landing-page-static", rdr)
+	} else if filterID == "DEL" {
+		rendererReq, err = http.NewRequest("POST", cfg.RendererURL+"/dataset-edition-list", rdr)
 	} else {
 		rendererReq, err = http.NewRequest("POST", cfg.RendererURL+"/dataset-landing-page-filterable", rdr)
 	}

--- a/main.go
+++ b/main.go
@@ -32,8 +32,15 @@ func main() {
 
 	router.Path("/healthcheck").HandlerFunc(healthcheck.Do)
 
-	router.Path("/datasets/{datasetID}").Methods("GET").HandlerFunc(handlers.FilterableLanding(dc))
-	router.Path("/datasets/{datasetID}/{uri:.*}").Methods("GET").HandlerFunc(handlers.FilterableLanding(dc))
+	// with editions page
+	router.Path("/datasets/{datasetID}").Methods("GET").HandlerFunc(handlers.EditionsList(dc))
+	router.Path("/datasets/{datasetID}/{uri:.*}").Methods("GET").HandlerFunc(handlers.EditionsList(dc))
+	router.Path("/datasets/{datasetID}/editions/{editionID}/versions/{versionID}").Methods("GET").HandlerFunc(handlers.FilterableLanding(dc))
+
+	// without editions page
+	// router.Path("/datasets/{datasetID}").Methods("GET").HandlerFunc(handlers.FilterableLanding(dc))
+	// router.Path("/datasets/{datasetID}/{uri:.*}").Methods("GET").HandlerFunc(handlers.FilterableLanding(dc))
+
 	router.Path("/datasets/{datasetID}/editions/{editionID}/versions/{versionID}/filter").Methods("POST").HandlerFunc(handlers.CreateFilterID(f, dc))
 
 	if len(cfg.SlackToken) > 0 {

--- a/main.go
+++ b/main.go
@@ -34,8 +34,8 @@ func main() {
 
 	// with editions page
 	router.Path("/datasets/{datasetID}").Methods("GET").HandlerFunc(handlers.EditionsList(dc))
-	router.Path("/datasets/{datasetID}/{uri:.*}").Methods("GET").HandlerFunc(handlers.EditionsList(dc))
 	router.Path("/datasets/{datasetID}/editions/{editionID}/versions/{versionID}").Methods("GET").HandlerFunc(handlers.FilterableLanding(dc))
+	router.Path("/datasets/{datasetID}/{uri:.*}").Methods("GET").HandlerFunc(handlers.EditionsList(dc))
 
 	// without editions page
 	// router.Path("/datasets/{datasetID}").Methods("GET").HandlerFunc(handlers.FilterableLanding(dc))

--- a/mapper/mapper.go
+++ b/mapper/mapper.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/ONSdigital/dp-frontend-models/model/datasetEditionsList"
 	"github.com/ONSdigital/dp-frontend-models/model/datasetLandingPageFilterable"
 	"github.com/ONSdigital/go-ns/clients/dataset"
 	"github.com/ONSdigital/go-ns/log"
@@ -130,6 +131,39 @@ func CreateFilterableLandingPage(d dataset.Model, versions []dataset.Version, da
 			}
 
 			p.DatasetLandingPage.Dimensions = append(p.DatasetLandingPage.Dimensions, pDim)
+		}
+	}
+
+	return p
+}
+
+// CreateEditionsList creates a editions list page based on api model responses
+func CreateEditionsList(d dataset.Model, editions []dataset.Edition, datasetID string) datasetEditionsList.Page {
+	p := datasetEditionsList.Page{}
+	p.Type = "dataset_edition_list"
+	p.Metadata.Title = d.Title
+	p.URI = d.Links.Self.URL
+	p.Metadata.Description = d.Description
+	p.TaxonomyDomain = os.Getenv("TAXONOMY_DOMAIN")
+
+	if len(d.Contacts) > 0 {
+		p.Metadata.Footer.Contact = d.Contacts[0].Name
+		p.ContactDetails.Name = d.Contacts[0].Name
+		p.ContactDetails.Telephone = d.Contacts[0].Telephone
+		p.ContactDetails.Email = d.Contacts[0].Email
+	}
+
+	p.Metadata.Footer.DatasetID = datasetID
+	p.DatasetLandingPage.DatasetLandingPage.NextRelease = d.NextRelease
+	p.DatasetLandingPage.DatasetID = datasetID
+
+	if len(editions) > 0 {
+		for _, edition := range editions {
+			var e datasetEditionsList.Edition
+			e.Title = edition.Edition
+			e.URL = edition.Links.Self.URL
+
+			p.Editions = append(p.Editions, e)
 		}
 	}
 

--- a/mapper/mapper.go
+++ b/mapper/mapper.go
@@ -159,9 +159,17 @@ func CreateEditionsList(d dataset.Model, editions []dataset.Edition, datasetID s
 
 	if len(editions) > 0 {
 		for _, edition := range editions {
+
+			var latestVersionURL, err = url.Parse(edition.Links.LatestVersion.URL)
+			if err != nil {
+				log.Error(err, nil)
+			}
+			var latestVersionPath = latestVersionURL.Path
+			fmt.Println(latestVersionPath)
+
 			var e datasetEditionsList.Edition
 			e.Title = edition.Edition
-			e.URL = edition.Links.Self.URL
+			e.LatestVersionURL = latestVersionPath
 
 			p.Editions = append(p.Editions, e)
 		}

--- a/vendor/github.com/ONSdigital/dp-frontend-models/model/datasetEditionsList/model.go
+++ b/vendor/github.com/ONSdigital/dp-frontend-models/model/datasetEditionsList/model.go
@@ -1,0 +1,18 @@
+package datasetEditionsList
+
+import (
+	"github.com/ONSdigital/dp-frontend-models/model"
+	"github.com/ONSdigital/dp-frontend-models/model/datasetLandingPageFilterable"
+)
+
+type Page struct {
+	model.Page
+	datasetLandingPageFilterable.DatasetLandingPage
+	ContactDetails model.ContactDetails `json:"contact_details"`
+	Editions       []Edition            `json:"editions"`
+}
+
+type Edition struct {
+	Title string `json:"title"`
+	URL   string `json:"url"`
+}

--- a/vendor/github.com/ONSdigital/dp-frontend-models/model/datasetEditionsList/model.go
+++ b/vendor/github.com/ONSdigital/dp-frontend-models/model/datasetEditionsList/model.go
@@ -13,6 +13,6 @@ type Page struct {
 }
 
 type Edition struct {
-	Title string `json:"title"`
-	URL   string `json:"url"`
+	Title            string `json:"title"`
+	LatestVersionURL string `json:"url"`
 }

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -9,6 +9,12 @@
 			"revisionTime": "2017-10-05T07:32:47Z"
 		},
 		{
+			"checksumSHA1": "Fot8U5Zp1fj6YvwXse5Sf0HmcBA=",
+			"path": "github.com/ONSdigital/dp-frontend-models/model/datasetEditionsList",
+			"revision": "d5005a8cb73c03ca98004c4021a99f2b05906a20",
+			"revisionTime": "2017-10-30T09:01:34Z"
+		},
+		{
 			"checksumSHA1": "5OKmSZA+YLvS7/L0SUuhNozfeao=",
 			"path": "github.com/ONSdigital/dp-frontend-models/model/datasetLandingPageFilterable",
 			"revision": "bb3aa88cefc1b32f0c431d6773407983fc69e6bb",

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -9,10 +9,10 @@
 			"revisionTime": "2017-10-05T07:32:47Z"
 		},
 		{
-			"checksumSHA1": "Fot8U5Zp1fj6YvwXse5Sf0HmcBA=",
+			"checksumSHA1": "Ri1nZntkbdc+S7p7baJJie9pXxU=",
 			"path": "github.com/ONSdigital/dp-frontend-models/model/datasetEditionsList",
-			"revision": "d5005a8cb73c03ca98004c4021a99f2b05906a20",
-			"revisionTime": "2017-10-30T09:01:34Z"
+			"revision": "ae1b7451a12930cbe9bde0e13cc27faeb3214bd8",
+			"revisionTime": "2017-11-09T10:51:17Z"
 		},
 		{
 			"checksumSHA1": "5OKmSZA+YLvS7/L0SUuhNozfeao=",


### PR DESCRIPTION
### What

Added handler and template for dataset editions list page

### How to review

- Pull `feature/dataset-editions-page` branch on dp-frontend-renderer
- Pull the latest `cmd-develop` of the dataset API and make sure the editions end point returns the latest_version url for each edition, e.g. 
```
{
     edition: "2016",
          links: {
               dataset: {
                    id: "95c4669b-3ae9-4ba7-b690-87e890a1c67c",
                    href: "http://localhost:22000/datasets/95c4669b-3ae9-4ba7-b690-87e890a1c67c"
               },
               latest_version: {
                    href: "http://localhost:22000/datasets/95c4669b-3ae9-4ba7-b690-87e890a1c67c/editions/2016/versions/2"
               },
               self: {
                    href: "http://localhost:22000/datasets/95c4669b-3ae9-4ba7-b690-87e890a1c67c/editions/2016"
               },
               versions: {
                    href: "http://localhost:22000/datasets/95c4669b-3ae9-4ba7-b690-87e890a1c67c/editions/2016/versions"
               }
          },
     state: "published"
}
```
- Creating a new instance for the edition should create the latest_version field or it can be added to MongoDB manually (e.g. Robo3T) 

### Who can review
Anyone
