### PR TITLE
Switch feedback to email rather than slack

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -10,7 +10,12 @@ type Config struct {
 	RendererURL   string `env:"RENDERER_URL"`
 	FilterAPIURL  string `env:"FILTER_API_URL"`
 	DatasetAPIURL string `env:"DATASET_API_URL"`
-	SlackToken    string `env:"SLACK_TOKEN"`
+	MailHost      string `env:"MAIL_HOST"`
+	MailUser      string `env:"MAIL_USER"`
+	MailPassword  string `env:"MAIL_PASSWORD"`
+	MailPort      string `env:"MAIL_PORT"`
+	FeedbackTo    string `env:"FEEDBACK_TO"`
+	FeedbackFrom  string `env:"FEEDBACK_FROM"`
 }
 
 func init() {
@@ -20,7 +25,12 @@ func init() {
 		RendererURL:   "http://localhost:20010",
 		FilterAPIURL:  "http://localhost:22100",
 		DatasetAPIURL: "http://localhost:22000",
-		SlackToken:    "",
+		MailHost:      "",
+		MailPort:      "",
+		MailUser:      "",
+		MailPassword:  "",
+		FeedbackTo:    "",
+		FeedbackFrom:  "",
 	}
 	err := gofigure.Gofigure(&cfg)
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"context"
+	"fmt"
+	"net/smtp"
 	"os"
 	"os/signal"
 	"time"
@@ -15,12 +17,10 @@ import (
 	"github.com/ONSdigital/go-ns/server"
 	"github.com/ONSdigital/go-ns/zebedee/client"
 	"github.com/gorilla/mux"
-	"github.com/nlopes/slack"
 )
 
 func main() {
 	cfg := config.Get()
-	log.Debug("got service configuration", log.Data{"config": cfg})
 
 	log.Namespace = "frontend-dataset-controller"
 
@@ -38,11 +38,19 @@ func main() {
 	router.Path("/datasets/{datasetID}/editions/{editionID}/versions/{versionID}").HandlerFunc(handlers.FilterableLanding(dc))
 	router.Path("/datasets/{datasetID}/editions/{editionID}/versions/{versionID}/filter").Methods("POST").HandlerFunc(handlers.CreateFilterID(f, dc))
 
-	if len(cfg.SlackToken) > 0 {
+	if len(cfg.MailHost) > 0 {
+		auth := smtp.PlainAuth(
+			"",
+			cfg.MailUser,
+			cfg.MailPassword,
+			cfg.MailHost,
+		)
+
+		mailAddr := fmt.Sprintf("%s:%s", cfg.MailHost, cfg.MailPort)
+
 		log.Debug("adding feedback routes", nil)
-		slackAPI := slack.New(cfg.SlackToken)
-		router.Path("/feedback").Methods("POST").HandlerFunc(handlers.AddFeedback(slackAPI, false))
-		router.Path("/feedback/positive").Methods("POST").HandlerFunc(handlers.AddFeedback(slackAPI, true))
+		router.Path("/feedback").Methods("POST").HandlerFunc(handlers.AddFeedback(auth, mailAddr, cfg.FeedbackTo, cfg.FeedbackFrom, false))
+		router.Path("/feedback/positive").Methods("POST").HandlerFunc(handlers.AddFeedback(auth, mailAddr, cfg.FeedbackTo, cfg.FeedbackFrom, true))
 		router.Path("/feedback").Methods("GET").HandlerFunc(handlers.GetFeedback)
 		router.Path("/feedback/thanks").Methods("GET").HandlerFunc(handlers.FeedbackThanks)
 	}
@@ -50,9 +58,12 @@ func main() {
 	router.HandleFunc("/{uri:.*}", handlers.LegacyLanding(zc))
 
 	log.Debug("Starting server", log.Data{
-		"bind_addr":    cfg.BindAddr,
-		"zebedee_url":  cfg.ZebedeeURL,
-		"renderer_url": cfg.RendererURL,
+		"bind_addr":       cfg.BindAddr,
+		"zebedee_url":     cfg.ZebedeeURL,
+		"renderer_url":    cfg.RendererURL,
+		"dataset_api_url": cfg.DatasetAPIURL,
+		"mail_host":       cfg.MailHost,
+		"filter_api_url":  cfg.FilterAPIURL,
 	})
 
 	s := server.New(cfg.BindAddr, router)


### PR DESCRIPTION
### What

Switch feedback to go to email

### How to test

Checkout this branch
Run `go get github.com/mailhog/Mailhog`
Run `Mailhog`
Set the following environment variables:

```
export MAIL_HOST=localhost
export MAIL_PORT=1025
export FEEDBACK_FROM=cmd-feedback@onsdigital.co.uk
export FEEDBACK_TO=feedback@onsdigital.co.uk
```

Submit feedback on website as usual
Visit http://localhost:8025 to check email sent

### Who
Anyone

