### PR TITLE
Allow authenticated access to unpublished datasets

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -5,12 +5,13 @@ import "github.com/ian-kent/gofigure"
 var cfg Config
 
 type Config struct {
-	BindAddr      string `env:"BIND_ADDR"`
-	ZebedeeURL    string `env:"ZEBEDEE_URL"`
-	RendererURL   string `env:"RENDERER_URL"`
-	FilterAPIURL  string `env:"FILTER_API_URL"`
-	DatasetAPIURL string `env:"DATASET_API_URL"`
-	SlackToken    string `env:"SLACK_TOKEN"`
+	BindAddr            string `env:"BIND_ADDR"`
+	ZebedeeURL          string `env:"ZEBEDEE_URL"`
+	RendererURL         string `env:"RENDERER_URL"`
+	FilterAPIURL        string `env:"FILTER_API_URL"`
+	DatasetAPIURL       string `env:"DATASET_API_URL"`
+	SlackToken          string `env:"SLACK_TOKEN"`
+	DatasetAPIAuthToken string `env:"DATASET_API_AUTH_TOKEN"`
 }
 
 func init() {

--- a/main.go
+++ b/main.go
@@ -29,6 +29,9 @@ func main() {
 	f := filter.New(cfg.FilterAPIURL)
 	zc := client.NewZebedeeClient(cfg.ZebedeeURL)
 	dc := dataset.New(cfg.DatasetAPIURL)
+	if len(cfg.DatasetAPIAuthToken) > 0 {
+		dc.SetInternalToken(cfg.DatasetAPIAuthToken)
+	}
 
 	router.Path("/healthcheck").HandlerFunc(healthcheck.Do)
 

--- a/vendor/github.com/ONSdigital/go-ns/clients/dataset/data.go
+++ b/vendor/github.com/ONSdigital/go-ns/clients/dataset/data.go
@@ -1,5 +1,7 @@
 package dataset
 
+import "unicode"
+
 // Model represents a response dataset model from the dataset api
 type Model struct {
 	CollectionID string    `json:"collection_id"`
@@ -79,7 +81,41 @@ type Contact struct {
 
 // Dimensions represent a list of dimensions from the dataset api
 type Dimensions struct {
-	Items []Dimension `json:"items"`
+	Items Items `json:"items"`
+}
+
+// Items represents a list of dimensions
+type Items []Dimension
+
+func (d Items) Len() int      { return len(d) }
+func (d Items) Swap(i, j int) { d[i], d[j] = d[j], d[i] }
+func (d Items) Less(i, j int) bool {
+	iRunes := []rune(d[i].ID)
+	jRunes := []rune(d[j].ID)
+
+	max := len(iRunes)
+	if max > len(jRunes) {
+		max = len(jRunes)
+	}
+
+	for idx := 0; idx < max; idx++ {
+		ir := iRunes[idx]
+		jr := jRunes[idx]
+
+		lir := unicode.ToLower(ir)
+		ljr := unicode.ToLower(jr)
+
+		if lir != ljr {
+			return lir < ljr
+		}
+
+		// the lowercase runes are the same, so compare the original
+		if ir != jr {
+			return ir < jr
+		}
+	}
+
+	return false
 }
 
 // Dimension represents a response model for a dimension endpoint

--- a/vendor/github.com/ONSdigital/go-ns/clients/dataset/dataset.go
+++ b/vendor/github.com/ONSdigital/go-ns/clients/dataset/dataset.go
@@ -5,8 +5,10 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"sort"
 
 	"github.com/ONSdigital/go-ns/clients/clientlog"
+	"github.com/ONSdigital/go-ns/log"
 	"github.com/ONSdigital/go-ns/rhttp"
 )
 
@@ -33,8 +35,9 @@ var _ error = ErrInvalidDatasetAPIResponse{}
 
 // Client is a dataset api client which can be used to make requests to the server
 type Client struct {
-	cli *rhttp.Client
-	url string
+	cli           *rhttp.Client
+	url           string
+	internalToken string
 }
 
 // New creates a new instance of Client with a given filter api url
@@ -42,6 +45,18 @@ func New(datasetAPIURL string) *Client {
 	return &Client{
 		cli: rhttp.DefaultClient,
 		url: datasetAPIURL,
+	}
+}
+
+// SetInternalToken will set an internal token to use for the dataset api
+func (c *Client) SetInternalToken(token string) {
+	c.internalToken = token
+}
+
+func (c *Client) setInternalTokenHeader(req *http.Request) {
+	if len(c.internalToken) > 0 {
+		log.Debug("setting internal token header", log.Data{"it": c.internalToken})
+		req.Header.Set("Internal-token", c.internalToken)
 	}
 }
 
@@ -65,7 +80,13 @@ func (c *Client) Get(id string) (m Model, err error) {
 
 	clientlog.Do("retrieving dataset", service, uri)
 
-	resp, err := c.cli.Get(uri)
+	req, err := http.NewRequest("GET", uri, nil)
+	if err != nil {
+		return
+	}
+	c.setInternalTokenHeader(req)
+
+	resp, err := c.cli.Do(req)
 	if err != nil {
 		return
 	}
@@ -81,6 +102,21 @@ func (c *Client) Get(id string) (m Model, err error) {
 	}
 	defer resp.Body.Close()
 
+	var body map[string]interface{}
+	if err = json.Unmarshal(b, &body); err != nil {
+		return
+	}
+
+	// TODO: Authentication will sort this problem out for us. Currently
+	// the shape of the response body is different if you are authenticated
+	// so return the "next" item only
+	if next, ok := body["next"]; ok && len(c.internalToken) > 0 {
+		b, err = json.Marshal(next)
+		if err != nil {
+			return
+		}
+	}
+
 	err = json.Unmarshal(b, &m)
 	return
 }
@@ -91,7 +127,13 @@ func (c *Client) GetEditions(id string) (m []Edition, err error) {
 
 	clientlog.Do("retrieving dataset editions", service, uri)
 
-	resp, err := c.cli.Get(uri)
+	req, err := http.NewRequest("GET", uri, nil)
+	if err != nil {
+		return
+	}
+	c.setInternalTokenHeader(req)
+
+	resp, err := c.cli.Do(req)
 	if err != nil {
 		return
 	}
@@ -121,7 +163,13 @@ func (c *Client) GetVersions(id, edition string) (m []Version, err error) {
 
 	clientlog.Do("retrieving dataset versions", service, uri)
 
-	resp, err := c.cli.Get(uri)
+	req, err := http.NewRequest("GET", uri, nil)
+	if err != nil {
+		return
+	}
+	c.setInternalTokenHeader(req)
+
+	resp, err := c.cli.Do(req)
 	if err != nil {
 		return
 	}
@@ -152,7 +200,13 @@ func (c *Client) GetVersion(id, edition, version string) (m Version, err error) 
 
 	clientlog.Do("retrieving dataset version", service, uri)
 
-	resp, err := c.cli.Get(uri)
+	req, err := http.NewRequest("GET", uri, nil)
+	if err != nil {
+		return
+	}
+	c.setInternalTokenHeader(req)
+
+	resp, err := c.cli.Do(req)
 	if err != nil {
 		return
 	}
@@ -178,7 +232,13 @@ func (c *Client) GetDimensions(id, edition, version string) (m Dimensions, err e
 
 	clientlog.Do("retrieving dataset version dimensions", service, uri)
 
-	resp, err := c.cli.Get(uri)
+	req, err := http.NewRequest("GET", uri, nil)
+	if err != nil {
+		return
+	}
+	c.setInternalTokenHeader(req)
+
+	resp, err := c.cli.Do(req)
 	if err != nil {
 		return
 	}
@@ -194,7 +254,12 @@ func (c *Client) GetDimensions(id, edition, version string) (m Dimensions, err e
 	}
 	defer resp.Body.Close()
 
-	err = json.Unmarshal(b, &m)
+	if err = json.Unmarshal(b, &m); err != nil {
+		return
+	}
+
+	sort.Sort(m.Items)
+
 	return
 }
 
@@ -204,7 +269,13 @@ func (c *Client) GetOptions(id, edition, version, dimension string) (m Options, 
 
 	clientlog.Do("retrieving options for dimension", service, uri)
 
-	resp, err := c.cli.Get(uri)
+	req, err := http.NewRequest("GET", uri, nil)
+	if err != nil {
+		return
+	}
+	c.setInternalTokenHeader(req)
+
+	resp, err := c.cli.Do(req)
 	if err != nil {
 		return
 	}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -27,10 +27,10 @@
 			"revisionTime": "2017-10-09T08:31:24Z"
 		},
 		{
-			"checksumSHA1": "RPDwmgi272KvRE5GhnoECptzgUA=",
+			"checksumSHA1": "ZXceia3GOXCyh1LnLQGR9Pf9P6g=",
 			"path": "github.com/ONSdigital/go-ns/clients/dataset",
-			"revision": "a1bd0a85bf8904441aa027164380a31c6583cec4",
-			"revisionTime": "2017-10-23T12:32:27Z"
+			"revision": "cf38837484cb627b256211362a52314b9a2a6f68",
+			"revisionTime": "2017-11-20T13:18:43Z"
 		},
 		{
 			"checksumSHA1": "MKOhkB+MWSWilvK9xy5mBjIbpzo=",


### PR DESCRIPTION
Allow authenticated access to unpublished datasets 

Must set env var:

`DATASET_API_AUTH_TOKEN=FD0108EA-825D-411C-9B1D-41EF7727F465`

first

