### PR TITLE
Ensure taxonomy domain is set through a method

### DIFF
--- a/handlers/feedback.go
+++ b/handlers/feedback.go
@@ -9,6 +9,7 @@ import (
 	"regexp"
 
 	"github.com/ONSdigital/dp-frontend-dataset-controller/config"
+	"github.com/ONSdigital/dp-frontend-dataset-controller/mapper"
 	"github.com/ONSdigital/dp-frontend-models/model"
 	"github.com/ONSdigital/dp-frontend-models/model/feedback"
 	"github.com/ONSdigital/go-ns/clients/renderer"
@@ -31,6 +32,7 @@ type Feedback struct {
 // FeedbackThanks loads the Feedback Thank you page
 func FeedbackThanks(w http.ResponseWriter, req *http.Request) {
 	var p model.Page
+	mapper.SetTaxonomyDomain(&p)
 
 	p.Metadata.Title = "Thank you"
 	returnTo := req.URL.Query().Get("returnTo")
@@ -68,6 +70,7 @@ func GetFeedback(w http.ResponseWriter, req *http.Request) {
 
 func getFeedback(w http.ResponseWriter, req *http.Request, url, errorType, purpose, description, name, email string) {
 	var p feedback.Page
+	mapper.SetTaxonomyDomain(&p.Page)
 
 	p.Metadata.Title = "Feedback"
 	p.Metadata.Description = url

--- a/mapper/mapper.go
+++ b/mapper/mapper.go
@@ -9,12 +9,18 @@ import (
 	"strings"
 	"time"
 
+	"github.com/ONSdigital/dp-frontend-models/model"
 	"github.com/ONSdigital/dp-frontend-models/model/datasetEditionsList"
 	"github.com/ONSdigital/dp-frontend-models/model/datasetLandingPageFilterable"
 	"github.com/ONSdigital/dp-frontend-models/model/datasetVersionsList"
 	"github.com/ONSdigital/go-ns/clients/dataset"
 	"github.com/ONSdigital/go-ns/log"
 )
+
+// SetTaxonomyDomain will set the taxonomy domain for a given pages
+func SetTaxonomyDomain(p *model.Page) {
+	p.TaxonomyDomain = os.Getenv("TAXONOMY_DOMAIN")
+}
 
 var dimensionTitleMapper = map[string]string{
 	"aggregate": "Goods and Services",
@@ -40,12 +46,12 @@ func (p TimeSlice) Swap(i, j int) {
 // CreateFilterableLandingPage creates a filterable dataset landing page based on api model responses
 func CreateFilterableLandingPage(d dataset.Model, ver dataset.Version, datasetID string, opts []dataset.Options, dims dataset.Dimensions, displayOtherVersionsLink bool) datasetLandingPageFilterable.Page {
 	p := datasetLandingPageFilterable.Page{}
+	SetTaxonomyDomain(&p.Page)
 	p.Type = "dataset_landing_page"
 	p.Metadata.Title = d.Title
 	p.URI = d.Links.Self.URL
 	p.DatasetLandingPage.UnitOfMeasurement = d.UnitOfMeasure
 	p.Metadata.Description = d.Description
-	p.TaxonomyDomain = os.Getenv("TAXONOMY_DOMAIN")
 	p.ShowFeedbackForm = true
 	p.DatasetId = datasetID
 
@@ -208,6 +214,7 @@ func CreateFilterableLandingPage(d dataset.Model, ver dataset.Version, datasetID
 // CreateVersionsList creates a versions list page based on api model responses
 func CreateVersionsList(d dataset.Model, edition dataset.Edition, versions []dataset.Version) datasetVersionsList.Page {
 	var p datasetVersionsList.Page
+	SetTaxonomyDomain(&p.Page)
 	p.Metadata.Title = "Previous versions"
 	uri, err := url.Parse(edition.Links.LatestVersion.URL)
 	if err != nil {
@@ -244,11 +251,11 @@ func CreateVersionsList(d dataset.Model, edition dataset.Edition, versions []dat
 // CreateEditionsList creates a editions list page based on api model responses
 func CreateEditionsList(d dataset.Model, editions []dataset.Edition, datasetID string) datasetEditionsList.Page {
 	p := datasetEditionsList.Page{}
+	SetTaxonomyDomain(&p.Page)
 	p.Type = "dataset_edition_list"
 	p.Metadata.Title = d.Title
 	p.URI = d.Links.Self.URL
 	p.Metadata.Description = d.Description
-	p.TaxonomyDomain = os.Getenv("TAXONOMY_DOMAIN")
 	p.ShowFeedbackForm = true
 	p.DatasetId = datasetID
 

--- a/mapper/mapper_test.go
+++ b/mapper/mapper_test.go
@@ -5,11 +5,19 @@ import (
 	"strconv"
 	"testing"
 
+	"github.com/ONSdigital/dp-frontend-models/model"
 	"github.com/ONSdigital/go-ns/clients/dataset"
 	. "github.com/smartystreets/goconvey/convey"
 )
 
 func TestUnitMapper(t *testing.T) {
+	Convey("test SetTaxonomyDomain adds the taxonomy domain to page model", t, func() {
+		os.Setenv("TAXONOMY_DOMAIN", "https://www.ons.gov.uk")
+		p := model.Page{}
+		SetTaxonomyDomain(&p)
+		So(p.TaxonomyDomain, ShouldEqual, "https://www.ons.gov.uk")
+	})
+
 	Convey("test CreateFilterableLandingPage", t, func() {
 		d := dataset.Model{
 			CollectionID: "abcdefg",


### PR DESCRIPTION
### What

- Fix taxonomy issues from the beta

### How to review

- Set environment variable `export TAXONOMY_DOMAIN=https://www.ons.gov.uk`
- Verify that the taxonomy matches that of ons.gov.uk
- Verify that taxonomy successfully redirects on feedback form
- Verify that taxonomy successfully redirects on previous versions list
- Verify that clicking on the change language button redirects you to welsh website homepage

### Who can review

Anyone
  