### PR TITLE
Add breadcrumb to landing page if taxonomy URI is available

### DIFF
--- a/main.go
+++ b/main.go
@@ -50,9 +50,9 @@ func main() {
 
 	router.StrictSlash(true).Path("/datasets/{datasetID}").Methods("GET").HandlerFunc(handlers.EditionsList(dc, rend))
 	router.StrictSlash(true).Path("/datasets/{datasetID}/editions").Methods("GET").HandlerFunc(handlers.EditionsList(dc, rend))
-	router.StrictSlash(true).Path("/datasets/{datasetID}/editions/{editionID}").Methods("GET").HandlerFunc(handlers.FilterableLanding(dc, rend))
+	router.StrictSlash(true).Path("/datasets/{datasetID}/editions/{editionID}").Methods("GET").HandlerFunc(handlers.FilterableLanding(dc, rend, zc))
 	router.StrictSlash(true).Path("/datasets/{datasetID}/editions/{edition}/versions").Methods("GET").HandlerFunc(handlers.VersionsList(dc, rend))
-	router.StrictSlash(true).Path("/datasets/{datasetID}/editions/{editionID}/versions/{versionID}").Methods("GET").HandlerFunc(handlers.FilterableLanding(dc, rend))
+	router.StrictSlash(true).Path("/datasets/{datasetID}/editions/{editionID}/versions/{versionID}").Methods("GET").HandlerFunc(handlers.FilterableLanding(dc, rend, zc))
 	router.StrictSlash(true).Path("/datasets/{datasetID}/editions/{edition}/versions/{version}/metadata.txt").Methods("GET").HandlerFunc(handlers.MetadataText(dc))
 
 	router.StrictSlash(true).Path("/datasets/{datasetID}/editions/{editionID}/versions/{versionID}/filter").Methods("POST").HandlerFunc(handlers.CreateFilterID(f, dc))

--- a/mapper/mapper.go
+++ b/mapper/mapper.go
@@ -15,6 +15,7 @@ import (
 	"github.com/ONSdigital/dp-frontend-models/model/datasetVersionsList"
 	"github.com/ONSdigital/go-ns/clients/dataset"
 	"github.com/ONSdigital/go-ns/log"
+	"github.com/ONSdigital/go-ns/zebedee/data"
 )
 
 // SetTaxonomyDomain will set the taxonomy domain for a given pages
@@ -44,7 +45,7 @@ func (p TimeSlice) Swap(i, j int) {
 }
 
 // CreateFilterableLandingPage creates a filterable dataset landing page based on api model responses
-func CreateFilterableLandingPage(d dataset.Model, ver dataset.Version, datasetID string, opts []dataset.Options, dims dataset.Dimensions, displayOtherVersionsLink bool) datasetLandingPageFilterable.Page {
+func CreateFilterableLandingPage(d dataset.Model, ver dataset.Version, datasetID string, opts []dataset.Options, dims dataset.Dimensions, displayOtherVersionsLink bool, breadcrumbs []data.Breadcrumb) datasetLandingPageFilterable.Page {
 	p := datasetLandingPageFilterable.Page{}
 	SetTaxonomyDomain(&p.Page)
 	p.Type = "dataset_landing_page"
@@ -55,6 +56,13 @@ func CreateFilterableLandingPage(d dataset.Model, ver dataset.Version, datasetID
 	p.ShowFeedbackForm = true
 	p.DatasetId = datasetID
 	p.ReleaseDate = ver.ReleaseDate
+
+	for _, breadcrumb := range breadcrumbs {
+		p.Page.Breadcrumb = append(p.Page.Breadcrumb, model.TaxonomyNode{
+			Title: breadcrumb.Description.Title,
+			URI:   breadcrumb.URI,
+		})
+	}
 
 	if len(d.Contacts) > 0 {
 		p.ContactDetails.Name = d.Contacts[0].Name
@@ -106,7 +114,7 @@ func CreateFilterableLandingPage(d dataset.Model, ver dataset.Version, datasetID
 	v.Description = d.Description
 	v.Edition = ver.Edition
 	v.Version = strconv.Itoa(ver.Version)
-	
+
 	p.DatasetLandingPage.HasOlderVersions = displayOtherVersionsLink
 
 	for k, download := range ver.Downloads {

--- a/vendor/github.com/ONSdigital/go-ns/identity/identity.go
+++ b/vendor/github.com/ONSdigital/go-ns/identity/identity.go
@@ -15,7 +15,13 @@ var zebedeeURL = os.Getenv("ZEBEDEE_URL")
 func Handler(doAuth bool) func(http.Handler) http.Handler {
 	return func(h http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-			if doAuth && len(req.Header.Get("X-Florence-Token")) > 0 && len(zebedeeURL) > 0 {
+			if doAuth && len(req.Header.Get("X-Florence-Token")) > 0 {
+
+				// set a default zebedee value if it isn't set
+				if len(zebedeeURL) == 0 {
+					zebedeeURL = "http://localhost:8082"
+				}
+
 				cli := rchttp.DefaultClient
 
 				zebReq, err := http.NewRequest("GET", zebedeeURL+"/permission", nil)
@@ -33,6 +39,8 @@ func Handler(doAuth bool) func(http.Handler) http.Handler {
 					w.WriteHeader(http.StatusInternalServerError)
 					return
 				}
+
+				log.Debug("Zebedee permissions req response", log.Data{"status code": resp.StatusCode})
 
 				// Check to see if the florence user is authorised
 				if resp.StatusCode != http.StatusOK {

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -81,10 +81,10 @@
 			"revisionTime": "2017-08-30T09:50:52Z"
 		},
 		{
-			"checksumSHA1": "mZbyvsoM+r0Vi+4g2/pYoKUmBN4=",
+			"checksumSHA1": "LvSUftADjhblr93ou4eMEww35E4=",
 			"path": "github.com/ONSdigital/go-ns/identity",
-			"revision": "4e0856cfc45ba7e5055256151d29c1037ef51f88",
-			"revisionTime": "2018-02-07T11:04:46Z"
+			"revision": "43fe99bc4eee69f9939d4f073d849d8fef7d7a0c",
+			"revisionTime": "2018-02-16T12:59:39Z"
 		},
 		{
 			"checksumSHA1": "AjbjbhFVAOP/1NU5HL+uy+X/yJo=",


### PR DESCRIPTION
## What's been changed?
If a dataset has a value for the URI of the dataset landing page that is published in the taxonomy, then a breadcrumb will be shown.

## How to review
1) Ensure you have dataset with at least one valid version
2) Make sure the `uri` property in a dataset points to a valid dataset landing page on the taxonomy in Zebedee.
3) A breadcrumb should display and links should work.
4) If the URI is removed from the dataset then no breadcrumb displays.
5) If an error occurs getting the breadcrumb from Zebedee (e.g. 404) then the breadcrumb just doesn't display.

