### PR TITLE
Handle 404 when getting editions list

### DIFF
--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -327,8 +327,12 @@ func editionsList(w http.ResponseWriter, req *http.Request, dc DatasetClient, re
 
 	datasetEditions, err := dc.GetEditions(datasetID, datasetCfg...)
 	if err != nil {
-		setStatusCode(req, w, err)
-		return
+		if err, ok := err.(ClientError); ok {
+			if err.Code() != http.StatusNotFound {
+				setStatusCode(req, w, err)
+				return
+			}
+		}
 	}
 
 	m := mapper.CreateEditionsList(datasetModel, datasetEditions, datasetID)

--- a/mapper/mapper.go
+++ b/mapper/mapper.go
@@ -278,7 +278,7 @@ func CreateEditionsList(d dataset.Model, editions []dataset.Edition, datasetID s
 	p.DatasetLandingPage.DatasetLandingPage.NextRelease = d.NextRelease
 	p.DatasetLandingPage.DatasetID = datasetID
 
-	if len(editions) > 0 {
+	if editions != nil && len(editions) > 0 {
 		for _, edition := range editions {
 
 			var latestVersionURL, err = url.Parse(edition.Links.LatestVersion.URL)


### PR DESCRIPTION
### What

An empty editions list causes the dataset page to return a 404. Instead of returning the 404 we now ignore it and render an empty editions list

### How to review

Review changes / test

### Who can review

@jondewijones 
