### PR TITLE
Get service from URL query for feedback

### DIFF
--- a/handlers/feedback.go
+++ b/handlers/feedback.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
+	"io/ioutil"
 	"net/http"
 	"net/smtp"
 	"regexp"
@@ -71,6 +73,18 @@ func GetFeedback(w http.ResponseWriter, req *http.Request) {
 func getFeedback(w http.ResponseWriter, req *http.Request, url, errorType, purpose, description, name, email string) {
 	var p feedback.Page
 	mapper.SetTaxonomyDomain(&p.Page)
+
+	var services = make(map[string]string)
+	services["cmd"] = "Customising data by applying filters"
+	services["dev"] = "ONS developer website"
+
+	service := services[req.URL.Query().Get("service")]
+	if service == "" {
+		io.Copy(ioutil.Discard, req.Body)
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+	p.ServiceDescription = service
 
 	p.Metadata.Title = "Feedback"
 	p.Metadata.Description = url

--- a/vendor/github.com/ONSdigital/dp-frontend-models/model/feedback/feedback.go
+++ b/vendor/github.com/ONSdigital/dp-frontend-models/model/feedback/feedback.go
@@ -5,11 +5,12 @@ import "github.com/ONSdigital/dp-frontend-models/model"
 // Page contains data reused for feedback model
 type Page struct {
 	model.Page
-	Radio       string `json:"radio"`
-	Purpose     string `json:"purpose"`
-	Feedback    string `json:"feedback"`
-	Name        string `json:"name"`
-	Email       string `json:"email"`
-	ErrorType   string `json:"error_type"`
-	PreviousURL string `json:"previous_url"`
+	Radio              string `json:"radio"`
+	Purpose            string `json:"purpose"`
+	Feedback           string `json:"feedback"`
+	Name               string `json:"name"`
+	Email              string `json:"email"`
+	ErrorType          string `json:"error_type"`
+	PreviousURL        string `json:"previous_url"`
+	ServiceDescription string `json:"service_description"`
 }

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -33,10 +33,10 @@
 			"revisionTime": "2017-11-27T09:31:24Z"
 		},
 		{
-			"checksumSHA1": "rbnq39XnNVgNsR711GTVh0LiiB4=",
+			"checksumSHA1": "HqVWBwIqPXqBB0OnBJLFhAq8YDo=",
 			"path": "github.com/ONSdigital/dp-frontend-models/model/feedback",
-			"revision": "c9d656ffaaf639a01d892da2d4ea3f9978776160",
-			"revisionTime": "2017-12-05T14:37:49Z"
+			"revision": "f6aedb9b3db83ff9810c467bfe72277300a1f51b",
+			"revisionTime": "2018-02-19T11:44:16Z"
 		},
 		{
 			"checksumSHA1": "zgQXB6EtoNdvUCvMjxA6U9cfDDI=",


### PR DESCRIPTION
### What

Add a service description to the feedback page data, depending on what `service` parameter value is given in the page's URL.

### How to review

1) Checkout `feature/configurable-feedback-service` branch on the frontend renderer and dataset controller. Also pull the latest version of Sixteens `cmd-develop`.
2) Go to `/feedback?service=cmd`.
3) Verify that the second radio button gives a description of CMD.
4) Go to `/feedback`
5) Should return an error because no service for the feedback page is given.

### Who can review

Anyone but me.
