### PR TITLE
Fix metadata download's URL

### DIFF
--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -11,6 +11,7 @@ import (
 	"strconv"
 
 	"github.com/ONSdigital/dp-frontend-dataset-controller/helpers"
+	"github.com/ONSdigital/dp-frontend-models/model/datasetLandingPageFilterable"
 
 	"github.com/gorilla/mux"
 
@@ -306,10 +307,11 @@ func filterableLanding(w http.ResponseWriter, req *http.Request, dc DatasetClien
 	// because the loop adds the download services domain to the URLs
 	// which this text file doesn't need because it's created on-the-fly
 	// by this app
-	ver.Downloads["Text"] = dataset.Download{
-		Size: strconv.Itoa(len(textBytes)),
-		URL:  fmt.Sprintf("/datasets/%s/editions/%s/versions/%s/metadata.txt", datasetID, edition, version),
-	}
+	m.DatasetLandingPage.Version.Downloads = append(m.DatasetLandingPage.Version.Downloads, datasetLandingPageFilterable.Download{
+		Extension: "txt",
+		Size:      strconv.Itoa(len(textBytes)),
+		URI:       fmt.Sprintf("/datasets/%s/editions/%s/versions/%s/metadata.txt", datasetID, edition, version),
+	})
 
 	b, err := json.Marshal(m)
 	if err != nil {

--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -287,11 +287,6 @@ func filterableLanding(w http.ResponseWriter, req *http.Request, dc DatasetClien
 		ver.Downloads = make(map[string]dataset.Download)
 	}
 
-	ver.Downloads["Text"] = dataset.Download{
-		Size: strconv.Itoa(len(textBytes)),
-		URL:  fmt.Sprintf("/datasets/%s/editions/%s/versions/%s/metadata.txt", datasetID, edition, version),
-	}
-
 	m := mapper.CreateFilterableLandingPage(req.Context(), datasetModel, ver, datasetID, opts, dims, displayOtherVersionsLink, bc)
 
 	for i, d := range m.DatasetLandingPage.Version.Downloads {
@@ -305,6 +300,15 @@ func filterableLanding(w http.ResponseWriter, req *http.Request, dc DatasetClien
 			d.URI = cfg.DownloadServiceURL + downloadURL.Path
 			m.DatasetLandingPage.Version.Downloads[i] = d
 		}
+	}
+
+	// This needs to be after the for-loop to add the download files,
+	// because the loop adds the download services domain to the URLs
+	// which this text file doesn't need because it's created on-the-fly
+	// by this app
+	ver.Downloads["Text"] = dataset.Download{
+		Size: strconv.Itoa(len(textBytes)),
+		URL:  fmt.Sprintf("/datasets/%s/editions/%s/versions/%s/metadata.txt", datasetID, edition, version),
 	}
 
 	b, err := json.Marshal(m)


### PR DESCRIPTION
### What

Stop metadata text files URL having the download service's domain prefixed to it.

### How to review

Check the text metadata file download under 'Other download options' on a [dataset landing page](https://beta.ons.gov.uk/datasets/mid-year-pop-est/editions/time-series/versions/1) doesn't have the download services domain. For example, it previously had:
```
https://download.beta.ons.gov.uk/datasets/mid-year-pop-est/editions/time-series/versions/1/metadata.txt
```
but it should now be:
```
https://beta.ons.gov.uk/datasets/mid-year-pop-est/editions/time-series/versions/1/metadata.txt
```

### Who can review

Anyone but me.
