### PR TITLE
Update use of dataset client to use different name for string func

### DIFF
--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -469,7 +469,7 @@ func metadataText(w http.ResponseWriter, req *http.Request, dc DatasetClient) {
 func getText(dc DatasetClient, datasetID, edition, version string, metadata dataset.Metadata, dimensions dataset.Dimensions, req *http.Request) ([]byte, error) {
 	var b bytes.Buffer
 
-	b.WriteString(metadata.String())
+	b.WriteString(metadata.ToString())
 	b.WriteString("Dimensions:\n")
 	for _, dimension := range dimensions.Items {
 		options, err := dc.GetOptions(req.Context(), datasetID, edition, version, dimension.Name)

--- a/mapper/mapper_test.go
+++ b/mapper/mapper_test.go
@@ -40,7 +40,7 @@ func TestUnitMapper(t *testing.T) {
 			},
 			NextRelease:      "11-11-2018",
 			ReleaseFrequency: "Yearly",
-			Publisher: dataset.Publisher{
+			Publisher: &dataset.Publisher{
 				URL:  "ons.gov.uk",
 				Name: "ONS",
 				Type: "Government Agency",

--- a/vendor/github.com/ONSdigital/go-ns/clients/dataset/data.go
+++ b/vendor/github.com/ONSdigital/go-ns/clients/dataset/data.go
@@ -19,7 +19,7 @@ type Model struct {
 	NationalStatistic bool             `json:"national_statistic"`
 	NextRelease       string           `json:"next_release"`
 	Publications      []Publication    `json:"publications"`
-	Publisher         Publisher        `json:"publisher"`
+	Publisher         *Publisher       `json:"publisher"`
 	QMI               Publication      `json:"qmi"`
 	RelatedDatasets   []RelatedDataset `json:"related_datasets"`
 	ReleaseFrequency  string           `json:"release_frequency"`
@@ -28,11 +28,16 @@ type Model struct {
 	Title             string           `json:"title"`
 	UnitOfMeasure     string           `json:"unit_of_measure"`
 	URI               string           `json:"uri"`
+	UsageNotes        *[]UsageNote     `json:"usage_notes,omitempty"`
+}
+
+type ModelCollection struct {
+	Items []Model `json:"items"`
 }
 
 // Version represents a version within a dataset
 type Version struct {
-	Alerts        []Alert             `json:"alerts"`
+	Alerts        *[]Alert            `json:"alerts"`
 	CollectionID  string              `json:"collection_id"`
 	Downloads     map[string]Download `json:"downloads"`
 	Edition       string              `json:"edition"`
@@ -58,6 +63,13 @@ type Metadata struct {
 	Model
 }
 
+// DownloadList represents a list of objects of containing information on the downloadable files
+type DownloadList struct {
+	CSV  *Download `bson:"csv,omitempty" json:"csv,omitempty"`
+	CSVW *Download `bson:"csvw,omitempty" json:"csvw,omitempty"`
+	XLS  *Download `bson:"xls,omitempty" json:"xls,omitempty"`
+}
+
 // Download represents a version download from the dataset api
 type Download struct {
 	URL     string `json:"href"`
@@ -79,6 +91,12 @@ type Publisher struct {
 	URL  string `json:"href"`
 	Name string `json:"name"`
 	Type string `json:"type"`
+}
+
+// UsageNote represents a note containing extra information associated to the resource
+type UsageNote struct {
+	Title string `json:"title,omitempty"`
+	Note  string `json:"note,omitempty"`
 }
 
 // Links represent the Links within a dataset model
@@ -151,10 +169,11 @@ func (d Items) Less(i, j int) bool {
 
 // Dimension represents a response model for a dimension endpoint
 type Dimension struct {
-	Name        string `json:"dimension"`
+	Name        string `json:"name"`
 	Links       Links  `json:"links"`
 	Description string `json:"description"`
 	Label       string `json:"label"`
+	URL         string `json:"href,omitempty"`
 }
 
 // Options represents a list of options from the dataset api
@@ -211,7 +230,7 @@ type Temporal struct {
 	Frequency string `json:"frequency"`
 }
 
-func (m Metadata) String() string {
+func (m Metadata) ToString() string {
 	var b bytes.Buffer
 
 	b.WriteString(fmt.Sprintf("Title: %s\n", m.Title))

--- a/vendor/github.com/ONSdigital/go-ns/clients/dataset/dataset.go
+++ b/vendor/github.com/ONSdigital/go-ns/clients/dataset/dataset.go
@@ -109,7 +109,7 @@ func (c *Client) Get(ctx context.Context, id string) (m Model, err error) {
 	// TODO: Authentication will sort this problem out for us. Currently
 	// the shape of the response body is different if you are authenticated
 	// so return the "next" item only
-	if next, ok := body["next"]; ok {
+	if next, ok := body["next"]; ok && common.IsCallerPresent(ctx) {
 		b, err = json.Marshal(next)
 		if err != nil {
 			return
@@ -117,6 +117,41 @@ func (c *Client) Get(ctx context.Context, id string) (m Model, err error) {
 	}
 
 	err = json.Unmarshal(b, &m)
+	return
+}
+
+// GetDatasets returns the list of datasets
+func (c *Client) GetDatasets(ctx context.Context) (m ModelCollection, err error) {
+	uri := fmt.Sprintf("%s/datasets", c.url)
+
+	clientlog.Do(ctx, "retrieving datasets", service, uri)
+
+	req, err := http.NewRequest("GET", uri, nil)
+	if err != nil {
+		return
+	}
+
+	resp, err := c.cli.Do(ctx, req)
+	if err != nil {
+		return
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		err = NewDatasetAPIResponse(resp, uri)
+		return
+	}
+
+	b, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return
+	}
+	defer resp.Body.Close()
+
+	var body map[string]interface{}
+	if err = json.Unmarshal(b, &body); err != nil {
+		return
+	}
+
 	return
 }
 
@@ -342,9 +377,14 @@ func (c *Client) PutVersion(ctx context.Context, datasetID, edition, version str
 	return nil
 }
 
+// GetMetadataURL returns the URL for the metadata of a given dataset id, edition and version
+func (c *Client) GetMetadataURL(id, edition, version string) string {
+	return fmt.Sprintf("%s/datasets/%s/editions/%s/versions/%s/metadata", c.url, id, edition, version)
+}
+
 // GetVersionMetadata returns the metadata for a given dataset id, edition and version
 func (c *Client) GetVersionMetadata(ctx context.Context, id, edition, version string) (m Metadata, err error) {
-	uri := fmt.Sprintf("%s/datasets/%s/editions/%s/versions/%s/metadata", c.url, id, edition, version)
+	uri := c.GetMetadataURL(id, edition, version)
 
 	clientlog.Do(ctx, "retrieving dataset version metadata", service, uri)
 

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -45,10 +45,10 @@
 			"revisionTime": "2018-06-07T13:26:14Z"
 		},
 		{
-			"checksumSHA1": "KA3u5cF0LtNR3eI6KhXmZcAeP5k=",
+			"checksumSHA1": "aRud33IADXVFY7YocAA+ND5wFhE=",
 			"path": "github.com/ONSdigital/go-ns/clients/dataset",
-			"revision": "491470a66fbb2471ff3fd02f8159b7158d9281ab",
-			"revisionTime": "2018-06-07T13:26:14Z"
+			"revision": "14e9258eac958bf8ae790ba0a7468f9775f27d14",
+			"revisionTime": "2018-07-16T14:44:21Z"
 		},
 		{
 			"checksumSHA1": "WV/zB0kOhzbyUiDri+MlLyOs/hs=",


### PR DESCRIPTION
### What

The String() namespace is used by JSON marshalling, so omits fields when marshalling. Moving the function to a different namespace allows it to exist for this case but not cause unexpected behaviour in others.

### How to review

Check the txt file still generates as expected in all locations.

### Who can review

anyone
