### PR TITLE
updated vendoring to fix legacy dataset download links

### DIFF
--- a/vendor/github.com/ONSdigital/go-ns/LICENSE.md
+++ b/vendor/github.com/ONSdigital/go-ns/LICENSE.md
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2018 Office for National Statistics
+Copyright ©‎ 2018, Crown Copyright (Office for National Statistics)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/vendor/github.com/ONSdigital/go-ns/zebedee/zebedeeMapper/mapper.go
+++ b/vendor/github.com/ONSdigital/go-ns/zebedee/zebedeeMapper/mapper.go
@@ -63,6 +63,7 @@ func MapZebedeeDatasetLandingPageToFrontendModel(dlp data.DatasetLandingPage, bc
 	for i, d := range ds {
 		var dataset datasetLandingPageStatic.Dataset
 		for _, value := range d.Downloads {
+			dataset.URI = d.URI
 			dataset.Downloads = append(dataset.Downloads, datasetLandingPageStatic.Download{
 				URI:       value.File,
 				Extension: strings.TrimPrefix(filepath.Ext(value.File), "."),

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -123,10 +123,10 @@
 			"revisionTime": "2017-07-11T09:58:36Z"
 		},
 		{
-			"checksumSHA1": "ibnuCletV4wKSZ91XUv+/fAi0Rg=",
+			"checksumSHA1": "1ItKI2owz8pIpBWxmqK49eR3JqE=",
 			"path": "github.com/ONSdigital/go-ns/zebedee/zebedeeMapper",
-			"revision": "4e5fe4def49c96376743b20fe698c683a86d4b75",
-			"revisionTime": "2017-07-11T09:58:36Z"
+			"revision": "fa025aaeb8a18c2bd97a15a5905dc5b7d184d400",
+			"revisionTime": "2018-11-23T13:13:48Z"
 		},
 		{
 			"checksumSHA1": "/5JpULDw51Em+1+OJHcfDkbw/e0=",


### PR DESCRIPTION
Updated `go-ns/zebedeeMapper` vendor dependency to fix broken legacy dataset download links