### PR TITLE
updated go-ns zebedee cli vendor and add missing error var and return…

### DIFF
--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/pkg/errors"
 	"net/http"
 	"net/url"
 	"regexp"
@@ -403,7 +404,11 @@ func legacyLanding(w http.ResponseWriter, req *http.Request, zc ZebedeeClient, r
 
 	var ds []data.Dataset
 	for _, v := range dlp.Datasets {
-		d, _ := zc.GetDataset(v.URI)
+		d, err := zc.GetDataset(v.URI)
+		if err != nil {
+			setStatusCode(req, w, errors.Wrap(err, "zebedee client legacy dataset returned an error"))
+			return
+		}
 		ds = append(ds, d)
 	}
 

--- a/vendor/github.com/ONSdigital/go-ns/zebedee/data/models.go
+++ b/vendor/github.com/ONSdigital/go-ns/zebedee/data/models.go
@@ -18,7 +18,7 @@ type Download struct {
 
 // FileSize represents a file size from zebedee
 type FileSize struct {
-	Size string `json:"fileSize"`
+	Size int `json:"fileSize"`
 }
 
 // PageTitle represents a page title from zebedee

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -111,16 +111,16 @@
 			"revisionTime": "2018-06-07T13:26:14Z"
 		},
 		{
-			"checksumSHA1": "6PTays/vOeb8TAksmAMsfrVb1Zk=",
+			"checksumSHA1": "cJWJF357pxg9moFdCiwYjbP7FCs=",
 			"path": "github.com/ONSdigital/go-ns/zebedee/client",
-			"revision": "d5343032adcc11ed59cf4a26ed809a752451900b",
-			"revisionTime": "2017-08-31T10:27:31Z"
+			"revision": "8f16ab9f96817f89e7a2e2791f6ff72346f15711",
+			"revisionTime": "2018-11-27T09:28:38Z"
 		},
 		{
-			"checksumSHA1": "rIM30lGXWnib/GfNjckv9eFSoug=",
+			"checksumSHA1": "9mWGEOFjfqNrlKofXt/asIRh8qc=",
 			"path": "github.com/ONSdigital/go-ns/zebedee/data",
-			"revision": "4e5fe4def49c96376743b20fe698c683a86d4b75",
-			"revisionTime": "2017-07-11T09:58:36Z"
+			"revision": "8f16ab9f96817f89e7a2e2791f6ff72346f15711",
+			"revisionTime": "2018-11-27T09:28:38Z"
 		},
 		{
 			"checksumSHA1": "1ItKI2owz8pIpBWxmqK49eR3JqE=",


### PR DESCRIPTION
### What

- Added missing `err` var and added handle error statement and added missing error handling code - this error is now handled instead of being swallowed.
- Updated `go-ns` vendoring to get latest Zebedee client to fix the missing download file size defect.

### How to review

Running the CMD stack go to a legacy dataset landing page

http://localhost:20000/economy/inflationandpriceindices/datasets/serviceproducerpriceindices

The file download buttons should now contain the file size.

### Who can review

Anyone.
