### PR TITLE
LatestVersionURL added to DatasetLandingPage

### DIFF
--- a/mapper/mapper.go
+++ b/mapper/mapper.go
@@ -70,6 +70,7 @@ func CreateFilterableLandingPage(ctx context.Context, d dataset.Model, ver datas
 
 	p.DatasetLandingPage.Edition = ver.Edition
 	p.DatasetLandingPage.IsLatest = d.Links.LatestVersion.URL == ver.Links.Self.URL
+	p.DatasetLandingPage.LatestVersionURL = d.Links.LatestVersion.URL
 	p.DatasetLandingPage.QMIURL = d.QMI.URL
 	p.DatasetLandingPage.IsNationalStatistic = d.NationalStatistic
 	p.DatasetLandingPage.ReleaseFrequency = strings.Title(d.ReleaseFrequency)

--- a/vendor/github.com/ONSdigital/dp-frontend-models/model/datasetLandingPageFilterable/model.go
+++ b/vendor/github.com/ONSdigital/dp-frontend-models/model/datasetLandingPageFilterable/model.go
@@ -19,6 +19,7 @@ type DatasetLandingPage struct {
 	Edition             string        `json:"edition"`
 	ReleaseFrequency    string        `json:"release_frequency"`
 	IsLatest            bool          `json:"is_latest"`
+	LatestVersionURL    string        `json:"latest_version_url"`
 	QMIURL              string        `json:"qmi_url"`
 	IsNationalStatistic bool          `json:"is_national_statistic"`
 	Publications        []Publication `json:"publications"`

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -15,10 +15,10 @@
 			"revisionTime": "2017-11-09T10:51:17Z"
 		},
 		{
-			"checksumSHA1": "Y1clnS/Ty7ierUy21ZbQtPVVpxI=",
+			"checksumSHA1": "OzbZZHdF+rBV9z4JsWXMyzuG0eQ=",
 			"path": "github.com/ONSdigital/dp-frontend-models/model/datasetLandingPageFilterable",
-			"revision": "133fc573d67b36784b60102b0c45ca2d560910ed",
-			"revisionTime": "2017-12-15T15:29:52Z"
+			"revision": "3b7c2e7fd7147937e7a8c887018112b79767deef",
+			"revisionTime": "2019-05-02T11:57:08Z"
 		},
 		{
 			"checksumSHA1": "2Ww7ArlxDH4Cs/1S01vx1heMAow=",


### PR DESCRIPTION
### What

Latest release alert should appear on all editions

### How to review

- Check out the following branches from the below PRs:
    - https://github.com/ONSdigital/dp-frontend-models/pull/32
    - https://github.com/ONSdigital/dp-frontend-renderer/pull/280
- Load the latest edition you should see a blue banner saying this is the latest data
- Load an edition that isn't the latest, you should see an amber banner stating it is not the latest.
- Check out the links to ensure they work.

Note I am not 100% sure this has been done for the correct pages, as it states the latest edition, but it is the latest version of the addition.

Please compare this with the prototype: 
https://onsdigital.github.io/dp-filter-a-dataset-prototype/v2/editions . Note that corrections are not being added to the alert and that the alert is the only item to be changed.

### Who can review

Anyone except me
