### PR TITLE
Add redirect if only one edition exists

### DIFF
--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -358,9 +358,10 @@ func editionsList(w http.ResponseWriter, req *http.Request, dc DatasetClient, re
 		var latestVersionURL, err = url.Parse(datasetEditions[0].Links.LatestVersion.URL)
 		if err != nil {
 			log.Error(err, nil)
+		} else {
+			log.Info("only one edition, therefore redirecting to latest version", log.Data{"latestVersionPath": latestVersionURL.Path})
+			http.Redirect(w, req, latestVersionURL.Path, 302)
 		}
-		log.Info("only one edition, therefore redirecting to latest version", log.Data{"latestVersionPath": latestVersionURL.Path})
-		http.Redirect(w, req, latestVersionURL.Path, 302)
 	}
 
 	m := mapper.CreateEditionsList(req.Context(), datasetModel, datasetEditions, datasetID)

--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -5,11 +5,12 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/pkg/errors"
 	"net/http"
 	"net/url"
 	"regexp"
 	"strconv"
+
+	"github.com/pkg/errors"
 
 	"github.com/ONSdigital/dp-frontend-dataset-controller/helpers"
 	"github.com/ONSdigital/dp-frontend-models/model/datasetLandingPageFilterable"
@@ -350,6 +351,16 @@ func editionsList(w http.ResponseWriter, req *http.Request, dc DatasetClient, re
 				return
 			}
 		}
+	}
+
+	numberOfEditions := len(datasetEditions)
+	if numberOfEditions == 1 {
+		var latestVersionURL, err = url.Parse(datasetEditions[0].Links.LatestVersion.URL)
+		if err != nil {
+			log.Error(err, nil)
+		}
+		log.Info("only one edition, therefore redirecting to latest version", log.Data{"latestVersionPath": latestVersionURL.Path})
+		http.Redirect(w, req, latestVersionURL.Path, 302)
 	}
 
 	m := mapper.CreateEditionsList(req.Context(), datasetModel, datasetEditions, datasetID)


### PR DESCRIPTION
### What

Added redirect if only one edition exists

### How to review

Go to a dataset (e.g. `/dataset/<<datasetID>>`) that has one edition and you should get redirected to the latest version. Go to a dataset that has multiple editions and you should see the list of editions. 

### Who can review

Anyone
