### PR TITLE
Fix for banner appearing on datasetlanding pages

### DIFF
--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -258,7 +258,7 @@ func filterableLanding(w http.ResponseWriter, req *http.Request, dc DatasetClien
 		}
 	}
 
-	latestVersionOfEditionURL := fmt.Sprintf("/datasets/%s/editions/%s/versions/%s/", datasetID, edition, strconv.Itoa(latestVersionNumber))
+	latestVersionOfEditionURL := fmt.Sprintf("/datasets/%s/editions/%s/versions/%s", datasetID, edition, strconv.Itoa(latestVersionNumber))
 
 	ver, err := dc.GetVersion(req.Context(), datasetID, edition, version)
 	if err != nil {

--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -251,6 +251,15 @@ func filterableLanding(w http.ResponseWriter, req *http.Request, dc DatasetClien
 		displayOtherVersionsLink = true
 	}
 
+	latestVersionNumber := 1
+	for _, singleVersion := range allVers {
+		if singleVersion.Version > latestVersionNumber {
+			latestVersionNumber = singleVersion.Version
+		}
+	}
+
+	latestVersionOfEditionURL := fmt.Sprintf("/datasets/%s/editions/%s/versions/%s/", datasetID, edition, strconv.Itoa(latestVersionNumber))
+
 	ver, err := dc.GetVersion(req.Context(), datasetID, edition, version)
 	if err != nil {
 		setStatusCode(req, w, err)
@@ -290,7 +299,7 @@ func filterableLanding(w http.ResponseWriter, req *http.Request, dc DatasetClien
 		ver.Downloads = make(map[string]dataset.Download)
 	}
 
-	m := mapper.CreateFilterableLandingPage(req.Context(), datasetModel, ver, datasetID, opts, dims, displayOtherVersionsLink, bc)
+	m := mapper.CreateFilterableLandingPage(req.Context(), datasetModel, ver, datasetID, opts, dims, displayOtherVersionsLink, bc, latestVersionNumber, latestVersionOfEditionURL)
 
 	for i, d := range m.DatasetLandingPage.Version.Downloads {
 		if len(cfg.DownloadServiceURL) > 0 {

--- a/mapper/mapper.go
+++ b/mapper/mapper.go
@@ -40,7 +40,7 @@ func (p TimeSlice) Swap(i, j int) {
 }
 
 // CreateFilterableLandingPage creates a filterable dataset landing page based on api model responses
-func CreateFilterableLandingPage(ctx context.Context, d dataset.Model, ver dataset.Version, datasetID string, opts []dataset.Options, dims dataset.Dimensions, displayOtherVersionsLink bool, breadcrumbs []data.Breadcrumb) datasetLandingPageFilterable.Page {
+func CreateFilterableLandingPage(ctx context.Context, d dataset.Model, ver dataset.Version, datasetID string, opts []dataset.Options, dims dataset.Dimensions, displayOtherVersionsLink bool, breadcrumbs []data.Breadcrumb, latestVersionNumber int, latestVersionURL string) datasetLandingPageFilterable.Page {
 	p := datasetLandingPageFilterable.Page{}
 	SetTaxonomyDomain(&p.Page)
 	p.Type = "dataset_landing_page"
@@ -75,7 +75,8 @@ func CreateFilterableLandingPage(ctx context.Context, d dataset.Model, ver datas
 	}
 
 	p.DatasetLandingPage.IsLatest = d.Links.LatestVersion.URL == ver.Links.Self.URL
-	p.DatasetLandingPage.LatestVersionURL = d.Links.LatestVersion.URL
+	p.DatasetLandingPage.LatestVersionURL = latestVersionURL
+	p.DatasetLandingPage.IsLatestVersionOfEdition = latestVersionNumber == ver.Version
 	p.DatasetLandingPage.QMIURL = d.QMI.URL
 	p.DatasetLandingPage.IsNationalStatistic = d.NationalStatistic
 	p.DatasetLandingPage.ReleaseFrequency = strings.Title(d.ReleaseFrequency)

--- a/mapper/mapper_test.go
+++ b/mapper/mapper_test.go
@@ -124,7 +124,7 @@ func TestUnitMapper(t *testing.T) {
 					},
 				},
 			},
-		}, dataset.Dimensions{}, false, []data.Breadcrumb{breadcrumbItem})
+		}, dataset.Dimensions{}, false, []data.Breadcrumb{breadcrumbItem}, 1, "/datasets/83jd98fkflg/editions/124/versions/1")
 
 		So(p.Type, ShouldEqual, "dataset_landing_page")
 		So(p.Metadata.Title, ShouldEqual, d.Title)
@@ -166,7 +166,7 @@ func TestUnitMapper(t *testing.T) {
 	Convey("test taxonomy domain is set on page when environment variable is set", t, func() {
 		os.Setenv("TAXONOMY_DOMAIN", "my-domain")
 
-		p := CreateFilterableLandingPage(ctx, dataset.Model{}, dataset.Version{}, "", []dataset.Options{}, dataset.Dimensions{}, false, []data.Breadcrumb{})
+		p := CreateFilterableLandingPage(ctx, dataset.Model{}, dataset.Version{}, "", []dataset.Options{}, dataset.Dimensions{}, false, []data.Breadcrumb{}, 1, "/datasets/83jd98fkflg/editions/124/versions/1")
 
 		So(p.TaxonomyDomain, ShouldEqual, "my-domain")
 

--- a/vendor/github.com/ONSdigital/dp-frontend-models/model/datasetLandingPageFilterable/model.go
+++ b/vendor/github.com/ONSdigital/dp-frontend-models/model/datasetLandingPageFilterable/model.go
@@ -13,23 +13,24 @@ type Page struct {
 
 type DatasetLandingPage struct {
 	datasetLandingPageStatic.DatasetLandingPage
-	Dimensions          []Dimension   `json:"dimensions"`
-	Version             Version       `json:"version"`
-	HasOlderVersions    bool          `json:"has_older_versions"`
-	ShowEditionName     bool          `json:"show_edition_name"`
-	Edition             string        `json:"edition"`
-	ReleaseFrequency    string        `json:"release_frequency"`
-	IsLatest            bool          `json:"is_latest"`
-	LatestVersionURL    string        `json:"latest_version_url"`
-	QMIURL              string        `json:"qmi_url"`
-	IsNationalStatistic bool          `json:"is_national_statistic"`
-	Publications        []Publication `json:"publications"`
-	RelatedLinks        []Publication `json:"related_links"`
-	LatestChanges       []Change      `json:"latest_changes"`
-	Citation            string        `json:"citation"`
-	DatasetTitle        string        `json:"dataset_title"`
-	UnitOfMeasurement   string        `json:"unit_of_measurement"`
-	Methodologies       []Methodology `json:"methodology"`
+	Dimensions               []Dimension   `json:"dimensions"`
+	Version                  Version       `json:"version"`
+	HasOlderVersions         bool          `json:"has_older_versions"`
+	ShowEditionName          bool          `json:"show_edition_name"`
+	Edition                  string        `json:"edition"`
+	ReleaseFrequency         string        `json:"release_frequency"`
+	IsLatest                 bool          `json:"is_latest"`
+	LatestVersionURL         string        `json:"latest_version_url"`
+	IsLatestVersionOfEdition bool          `json:"is_latest_version_of_edition_url"`
+	QMIURL                   string        `json:"qmi_url"`
+	IsNationalStatistic      bool          `json:"is_national_statistic"`
+	Publications             []Publication `json:"publications"`
+	RelatedLinks             []Publication `json:"related_links"`
+	LatestChanges            []Change      `json:"latest_changes"`
+	Citation                 string        `json:"citation"`
+	DatasetTitle             string        `json:"dataset_title"`
+	UnitOfMeasurement        string        `json:"unit_of_measurement"`
+	Methodologies            []Methodology `json:"methodology"`
 }
 
 type Publication struct {

--- a/vendor/github.com/jtolds/gls/stack_tags.go
+++ b/vendor/github.com/jtolds/gls/stack_tags.go
@@ -51,22 +51,56 @@ func addStackTag(tag uint, context_call func()) {
 
 // these private methods are named this horrendous name so gopherjs support
 // is easier. it shouldn't add any runtime cost in non-js builds.
+
+//go:noinline
 func github_com_jtolds_gls_markS(tag uint, cb func()) { _m(tag, cb) }
+
+//go:noinline
 func github_com_jtolds_gls_mark0(tag uint, cb func()) { _m(tag, cb) }
+
+//go:noinline
 func github_com_jtolds_gls_mark1(tag uint, cb func()) { _m(tag, cb) }
+
+//go:noinline
 func github_com_jtolds_gls_mark2(tag uint, cb func()) { _m(tag, cb) }
+
+//go:noinline
 func github_com_jtolds_gls_mark3(tag uint, cb func()) { _m(tag, cb) }
+
+//go:noinline
 func github_com_jtolds_gls_mark4(tag uint, cb func()) { _m(tag, cb) }
+
+//go:noinline
 func github_com_jtolds_gls_mark5(tag uint, cb func()) { _m(tag, cb) }
+
+//go:noinline
 func github_com_jtolds_gls_mark6(tag uint, cb func()) { _m(tag, cb) }
+
+//go:noinline
 func github_com_jtolds_gls_mark7(tag uint, cb func()) { _m(tag, cb) }
+
+//go:noinline
 func github_com_jtolds_gls_mark8(tag uint, cb func()) { _m(tag, cb) }
+
+//go:noinline
 func github_com_jtolds_gls_mark9(tag uint, cb func()) { _m(tag, cb) }
+
+//go:noinline
 func github_com_jtolds_gls_markA(tag uint, cb func()) { _m(tag, cb) }
+
+//go:noinline
 func github_com_jtolds_gls_markB(tag uint, cb func()) { _m(tag, cb) }
+
+//go:noinline
 func github_com_jtolds_gls_markC(tag uint, cb func()) { _m(tag, cb) }
+
+//go:noinline
 func github_com_jtolds_gls_markD(tag uint, cb func()) { _m(tag, cb) }
+
+//go:noinline
 func github_com_jtolds_gls_markE(tag uint, cb func()) { _m(tag, cb) }
+
+//go:noinline
 func github_com_jtolds_gls_markF(tag uint, cb func()) { _m(tag, cb) }
 
 func _m(tag_remainder uint, cb func()) {

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -17,8 +17,8 @@
 		{
 			"checksumSHA1": "4TaDB6kxInXHJ12g3BTnTcRMY+M=",
 			"path": "github.com/ONSdigital/dp-frontend-models/model/datasetLandingPageFilterable",
-			"revision": "70eba2a60afcc3290eaccecb834e777c2591126a",
-			"revisionTime": "2019-06-14T11:12:16Z"
+			"revision": "7b030343aa885979ee333f32a1b3a0cd7db9d49a",
+			"revisionTime": "2019-06-18T12:31:28Z"
 		},
 		{
 			"checksumSHA1": "2Ww7ArlxDH4Cs/1S01vx1heMAow=",
@@ -182,10 +182,10 @@
 			"revisionTime": "2017-05-02T19:22:41Z"
 		},
 		{
-			"checksumSHA1": "Js/yx9fZ3+wH1wZpHNIxSTMIaCg=",
+			"checksumSHA1": "cIiyvAduLLFvu+tg1Qr5Jw3jeWo=",
 			"path": "github.com/jtolds/gls",
-			"revision": "77f18212c9c7edc9bd6a33d383a7b545ce62f064",
-			"revisionTime": "2017-05-03T22:40:06Z"
+			"revision": "b4936e06046bbecbb94cae9c18127ebe510a2cb9",
+			"revisionTime": "2018-11-10T20:28:10Z"
 		},
 		{
 			"checksumSHA1": "OBvAHqWjdI4NQVAqTkcQAdTuCFY=",

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -15,10 +15,10 @@
 			"revisionTime": "2017-11-09T10:51:17Z"
 		},
 		{
-			"checksumSHA1": "ofMAyp6edD8DkjIDi+DJP+FWSH4=",
+			"checksumSHA1": "4TaDB6kxInXHJ12g3BTnTcRMY+M=",
 			"path": "github.com/ONSdigital/dp-frontend-models/model/datasetLandingPageFilterable",
-			"revision": "fac76886a5fa5661eef3073f50d4cd896db3a3dd",
-			"revisionTime": "2019-05-28T15:16:23Z"
+			"revision": "70eba2a60afcc3290eaccecb834e777c2591126a",
+			"revisionTime": "2019-06-14T11:12:16Z"
 		},
 		{
 			"checksumSHA1": "2Ww7ArlxDH4Cs/1S01vx1heMAow=",


### PR DESCRIPTION
### What

Fix for banner appearing on dataset landing pages:
- Goes to the web page rather than the API when you click ‘previous’
- Clicking previous now goes to the correct version (not the latest version of published that uses the dataset (different edition)
- Correctly shows previous and latest version banner (was previously showing ‘this is not the latest’ when it was if there was a version of a different edition of that dataset published.

### How to review

Dependencies:
dp-frontend-models: https://github.com/ONSdigital/dp-frontend-dataset-controller/pull/116
dp-frontend-renderer: https://github.com/ONSdigital/dp-frontend-renderer/pull/293

1. Get a dataset, make an edition, make a version of the edition
2. Get the same dataset and the same edition, make a new version
3. Get the same dataset, make a new edition and create a version of that edition
4. Goto step 2 version and check the banner shows 'this is the latest' banner and the link is correct
5. Goto step 1 and check this shows 'this is not the latest' banner click link ensure it goes to the correct version of the correct edition

- Go test lib dependency also updated to be compatible with later versions of GO (1.12)

### Who can review

Anyone except me
