### PR TITLE
Fix for versions list, protective programming added.

### DIFF
--- a/mapper/mapper.go
+++ b/mapper/mapper.go
@@ -278,14 +278,12 @@ func CreateVersionsList(ctx context.Context, d dataset.Model, edition dataset.Ed
 		const correctionAlertType = "correction"
 		if *ver.Alerts != nil {
 			for _, alert := range *ver.Alerts {
-				if &alert != nil {
-					if alert.Type == correctionAlertType {
-						correctionReasons = append(correctionReasons, alert.Description)
-					}
+				if &alert != nil && alert.Type == correctionAlertType {
+					correctionReasons = append(correctionReasons, alert.Description)
 				}
 			}
+			version.Reasons = correctionReasons
 		}
-		version.Reasons = correctionReasons
 
 		version.FilterURL = fmt.Sprintf("/datasets/%s/editions/%s/versions/%d/filter", ver.Links.Dataset.ID, ver.Edition, ver.Version)
 		p.Data.Versions = append(p.Data.Versions, version)

--- a/mapper/mapper.go
+++ b/mapper/mapper.go
@@ -276,9 +276,13 @@ func CreateVersionsList(ctx context.Context, d dataset.Model, edition dataset.Ed
 
 		var correctionReasons []string
 		const correctionAlertType = "correction"
-		for _, alert := range *ver.Alerts {
-			if alert.Type == correctionAlertType {
-				correctionReasons = append(correctionReasons, alert.Description)
+		if *ver.Alerts != nil {
+			for _, alert := range *ver.Alerts {
+				if &alert != nil {
+					if alert.Type == correctionAlertType {
+						correctionReasons = append(correctionReasons, alert.Description)
+					}
+				}
 			}
 		}
 		version.Reasons = correctionReasons


### PR DESCRIPTION
### What

Was an issue on environments trying to access a nil value causing the versions-list page to crash. It should look something like this (ignore the dates)
<img width="1034" alt="Screenshot 2019-06-21 at 10 24 09" src="https://user-images.githubusercontent.com/47502916/59912815-c3fb7380-940e-11e9-858f-4beb326db3d5.png">

### How to review

Checkout branch creates a version of an edition, then create another version of an edition but add a correction alert to the page. Then navigate to the versions list, reason(s) for change should appear.
 
### Who can review

Anyone except me
