### PR TITLE
beta banner now selectively displayed

### DIFF
--- a/mapper/mapper.go
+++ b/mapper/mapper.go
@@ -51,6 +51,7 @@ func CreateFilterableLandingPage(ctx context.Context, d dataset.Model, ver datas
 	p.ShowFeedbackForm = true
 	p.DatasetId = datasetID
 	p.ReleaseDate = ver.ReleaseDate
+	p.BetaBannerEnabled = true
 
 	for _, breadcrumb := range breadcrumbs {
 		p.Page.Breadcrumb = append(p.Page.Breadcrumb, model.TaxonomyNode{
@@ -251,6 +252,7 @@ func CreateVersionsList(ctx context.Context, d dataset.Model, edition dataset.Ed
 	var p datasetVersionsList.Page
 	SetTaxonomyDomain(&p.Page)
 	p.Metadata.Title = "Previous versions"
+	p.BetaBannerEnabled = true
 	uri, err := url.Parse(edition.Links.LatestVersion.URL)
 	if err != nil {
 		log.ErrorCtx(ctx, err, nil)
@@ -300,6 +302,7 @@ func CreateEditionsList(ctx context.Context, d dataset.Model, editions []dataset
 	p.Metadata.Description = d.Description
 	p.ShowFeedbackForm = true
 	p.DatasetId = datasetID
+	p.BetaBannerEnabled = true
 
 	if len(d.Contacts) > 0 {
 		p.ContactDetails.Name = d.Contacts[0].Name

--- a/vendor/github.com/ONSdigital/dp-frontend-models/model/metadata.go
+++ b/vendor/github.com/ONSdigital/dp-frontend-models/model/metadata.go
@@ -4,5 +4,6 @@ package model
 type Metadata struct {
 	Title       string   `json:"title"`
 	Description string   `json:"description"`
+	ServiceName string   `json:"serviceName"`
 	Keywords    []string `json:"keywords"`
 }

--- a/vendor/github.com/ONSdigital/dp-frontend-models/model/page.go
+++ b/vendor/github.com/ONSdigital/dp-frontend-models/model/page.go
@@ -9,6 +9,7 @@ type Page struct {
 	Taxonomy                         []TaxonomyNode `json:"taxonomy"`
 	TaxonomyDomain                   string         `json:"taxonomy_domain"`
 	Breadcrumb                       []TaxonomyNode `json:"breadcrumb"`
+	IsInFilterBreadcrumb             bool           `json:"is_in_filter_breadcrumb"`
 	ServiceMessage                   string         `json:"service_message"`
 	Metadata                         Metadata       `json:"metadata"`
 	SearchDisabled                   bool           `json:"search_disabled"`
@@ -18,4 +19,5 @@ type Page struct {
 	IncludeAssetsIntegrityAttributes bool           `json:"-"`
 	ShowFeedbackForm                 bool           `json:"show_feedback_form"`
 	ReleaseDate                      string         `json:"release_date"`
+	BetaBannerEnabled                bool           `json:"beta_banner_enabled"`
 }

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -3,10 +3,10 @@
 	"ignore": "test",
 	"package": [
 		{
-			"checksumSHA1": "QDHWtVBYrIsLSMqgwJy57QpcbsY=",
+			"checksumSHA1": "hEDY1K4lAova2Ej92ia5HeyQMME=",
 			"path": "github.com/ONSdigital/dp-frontend-models/model",
-			"revision": "cb4e58dfd37eb1aa358e2b0e096aa74e1d0f07dd",
-			"revisionTime": "2017-12-28T08:15:36Z"
+			"revision": "45cb171b8e0b9ea6c197afc7c43e0ac87816572c",
+			"revisionTime": "2019-06-19T09:55:20Z"
 		},
 		{
 			"checksumSHA1": "Ri1nZntkbdc+S7p7baJJie9pXxU=",


### PR DESCRIPTION
### What

The beta banner now selectively displayed
It should appear on the following types of pages 

- version
- versions list
- edition
- filter journey pages:
  -  Age
  -  Time
  -  Hierarchy
  -  Hierarchy Search
  -  Preview
  -  ListSelector
  -  Filter Overview

### How to review

Checkout the following PRs:
dp-frontend-models: https://github.com/ONSdigital/dp-frontend-models/pull/40
dp-frontend-renderer: https://github.com/ONSdigital/dp-frontend-renderer/pull/296
dp-frontend-filter-dataset-controller: https://github.com/ONSdigital/dp-frontend-filter-dataset-controller/pull/160

Run the CMD stack
Checkout different types of pages, ensure that the Beta banner only appears on CMD pages

### Who can review

Anyone except me
