### PR TITLE
Feature/add breadcrumbs to dataset pages

### DIFF
--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -217,7 +217,7 @@ func filterableLanding(w http.ResponseWriter, req *http.Request, dc DatasetClien
 
 	bc, err := zc.GetBreadcrumb(ctx, datasetModel.Links.Taxonomy.URL)
 	if err != nil {
-		log.ErrorCtx(req.Context(), err, log.Data{"Getting breadcrumb for dataset URI": datasetModel.URI})
+		log.ErrorCtx(req.Context(), err, log.Data{"Getting breadcrumb for dataset URI": datasetModel.Links.Taxonomy.URL})
 	}
 
 	if len(edition) == 0 {

--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -359,7 +359,7 @@ func editionsList(w http.ResponseWriter, req *http.Request, dc DatasetClient, zc
 
 	bc, err := zc.GetBreadcrumb(ctx, datasetModel.Links.Taxonomy.URL)
 	if err != nil {
-		log.ErrorCtx(ctx, err, log.Data{"Getting breadcrumb for dataset URI": datasetModel.URI})
+		log.ErrorCtx(ctx, err, log.Data{"Getting breadcrumb for dataset URI": datasetModel.Links.Taxonomy.URL})
 		return
 	}
 

--- a/handlers/handlers_test.go
+++ b/handlers/handlers_test.go
@@ -253,7 +253,7 @@ func TestUnitHandlers(t *testing.T) {
 			mockClient.EXPECT().GetOptions(ctx, "12345", "5678", "2017", "aggregate").Return(opts, nil)
 			mockClient.EXPECT().GetVersionMetadata(ctx, "12345", "5678", "2017")
 			mockClient.EXPECT().GetOptions(ctx, "12345", "5678", "2017", "aggregate").Return(opts, nil)
-			mockZebedeeClient.EXPECT().GetBreadcrumb(ctx, "/economy/grossdomesticproduct/datasets/gdpjanuary2018")
+			mockZebedeeClient.EXPECT().GetBreadcrumb(ctx, "")
 
 			mockRend := NewMockRenderClient(mockCtrl)
 			mockRend.EXPECT().Do("dataset-landing-page-filterable", gomock.Any()).Return([]byte(`<html><body><h1>Some HTML from renderer!</h1></body></html>`), nil)

--- a/main.go
+++ b/main.go
@@ -46,8 +46,8 @@ func main() {
 
 	router.StrictSlash(true).Path("/healthcheck").HandlerFunc(healthcheck.Handler)
 
-	router.StrictSlash(true).Path("/datasets/{datasetID}").Methods("GET").HandlerFunc(handlers.EditionsList(dc, rend))
-	router.StrictSlash(true).Path("/datasets/{datasetID}/editions").Methods("GET").HandlerFunc(handlers.EditionsList(dc, rend))
+	router.StrictSlash(true).Path("/datasets/{datasetID}").Methods("GET").HandlerFunc(handlers.EditionsList(dc, zc, rend))
+	router.StrictSlash(true).Path("/datasets/{datasetID}/editions").Methods("GET").HandlerFunc(handlers.EditionsList(dc, zc, rend))
 	router.StrictSlash(true).Path("/datasets/{datasetID}/editions/{editionID}").Methods("GET").HandlerFunc(handlers.FilterableLanding(dc, rend, zc))
 	router.StrictSlash(true).Path("/datasets/{datasetID}/editions/{edition}/versions").Methods("GET").HandlerFunc(handlers.VersionsList(dc, rend))
 	router.StrictSlash(true).Path("/datasets/{datasetID}/editions/{editionID}/versions/{versionID}").Methods("GET").HandlerFunc(handlers.FilterableLanding(dc, rend, zc))

--- a/mapper/mapper.go
+++ b/mapper/mapper.go
@@ -60,6 +60,28 @@ func CreateFilterableLandingPage(ctx context.Context, d dataset.Model, ver datas
 		})
 	}
 
+	// breadcrumbs won't contain this page or it's parent page in it's response
+	// from Zebedee, so add it to the slice
+	currentPageBreadcrumbTitle := ver.Links.Edition.ID
+	if currentPageBreadcrumbTitle == "time-series" {
+		currentPageBreadcrumbTitle = "Current"
+	}
+	datasetURL, err := url.Parse(d.Links.Self.URL)
+	if err != nil {
+		datasetURL.Path = ""
+		log.ErrorCtx(ctx, err, nil)
+	}
+	datasetBreadcrumbs := []model.TaxonomyNode{
+		{
+			Title: d.Title,
+			URI:   datasetURL.Path,
+		},
+		{
+			Title: currentPageBreadcrumbTitle,
+		},
+	}
+	p.Breadcrumb = append(p.Breadcrumb, datasetBreadcrumbs...)
+
 	if len(d.Contacts) > 0 {
 		p.ContactDetails.Name = d.Contacts[0].Name
 		p.ContactDetails.Telephone = d.Contacts[0].Telephone
@@ -295,7 +317,7 @@ func CreateVersionsList(ctx context.Context, d dataset.Model, edition dataset.Ed
 }
 
 // CreateEditionsList creates a editions list page based on api model responses
-func CreateEditionsList(ctx context.Context, d dataset.Model, editions []dataset.Edition, datasetID string) datasetEditionsList.Page {
+func CreateEditionsList(ctx context.Context, d dataset.Model, editions []dataset.Edition, datasetID string, breadcrumbs []data.Breadcrumb) datasetEditionsList.Page {
 	p := datasetEditionsList.Page{}
 	SetTaxonomyDomain(&p.Page)
 	p.Type = "dataset_edition_list"
@@ -305,6 +327,18 @@ func CreateEditionsList(ctx context.Context, d dataset.Model, editions []dataset
 	p.ShowFeedbackForm = true
 	p.DatasetId = datasetID
 	p.BetaBannerEnabled = true
+
+	for _, bc := range breadcrumbs {
+		p.Breadcrumb = append(p.Breadcrumb, model.TaxonomyNode{
+			Title: bc.Description.Title,
+			URI:   bc.URI,
+		})
+	}
+
+	// breadcrumbs won't contain this page in it's response from Zebedee, so add it to the slice
+	p.Breadcrumb = append(p.Breadcrumb, model.TaxonomyNode{
+		Title: d.Title,
+	})
 
 	if len(d.Contacts) > 0 {
 		p.ContactDetails.Name = d.Contacts[0].Name

--- a/vendor/github.com/ONSdigital/go-ns/clients/dataset/data.go
+++ b/vendor/github.com/ONSdigital/go-ns/clients/dataset/data.go
@@ -6,7 +6,7 @@ import (
 	"unicode"
 )
 
-// Model represents a response dataset model from the dataset	 api
+// Model represents a response dataset model from the dataset api
 type Model struct {
 	ID                string           `json:"id"`
 	CollectionID      string           `json:"collection_id"`
@@ -113,6 +113,7 @@ type Links struct {
 	Options       Link `json:"options,omitempty"`
 	Version       Link `json:"version,omitempty"`
 	Code          Link `json:"code,omitempty"`
+	Taxonomy      Link `json:"taxonomy,omitempty"`
 }
 
 // Link represents a single link within a dataset model

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -45,10 +45,10 @@
 			"revisionTime": "2018-06-07T13:26:14Z"
 		},
 		{
-			"checksumSHA1": "7sRxS0TMfUOf8rWfqrozenQZYRQ=",
+			"checksumSHA1": "U6qK/6OGFrgkPpqY6z3q4dph+pk=",
 			"path": "github.com/ONSdigital/go-ns/clients/dataset",
-			"revision": "6f82e6a20b01b654f578a2ece969813a4f825157",
-			"revisionTime": "2019-06-19T14:58:47Z"
+			"revision": "473b0c699f27bbe3dcc56ac68fc6311738d8f076",
+			"revisionTime": "2019-07-11T13:31:14Z"
 		},
 		{
 			"checksumSHA1": "30cvT+T3lSVX9d021VnyqjxylbU=",


### PR DESCRIPTION
### What

- Use Zebedee client to get breadcrumb of taxonomy
- Map taxonomy breadcrumbs and dataset pages to page model

### How to review

Checkout renderer branch: https://github.com/ONSdigital/dp-frontend-renderer/pull/305

Test that editions list page (e.g. `/datasets/cpih01`) and dataset landing page (e.g. `datasets/cpih01/editions/time-series/versions/1`) have working breadcrumbs

### Who can review

Anyone