### PR TITLE
updated access token vendor to pull in latest fix

### DIFF
--- a/vendor/github.com/ONSdigital/go-ns/handlers/accessToken/handler.go
+++ b/vendor/github.com/ONSdigital/go-ns/handlers/accessToken/handler.go
@@ -11,13 +11,10 @@ import (
 
 // CheckHeaderValueAndForwardWithRequestContext is a wrapper which adds a accessToken from the request header to context if one does not yet exist
 func CheckHeaderValueAndForwardWithRequestContext(h http.Handler) http.Handler {
-
 	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-
 		accessToken := req.Header.Get(common.AccessTokenHeaderKey)
-
 		if accessToken != "" {
-			req = req.WithContext(context.WithValue(req.Context(), common.AccessTokenHeaderKey, accessToken))
+			req = addUserAccessTokenToRequestContext(accessToken, req)
 		}
 
 		h.ServeHTTP(w, req)
@@ -26,19 +23,25 @@ func CheckHeaderValueAndForwardWithRequestContext(h http.Handler) http.Handler {
 
 // CheckCookieValueAndForwardWithRequestContext is a wrapper which adds a accessToken from the cookie to context if one does not yet exist
 func CheckCookieValueAndForwardWithRequestContext(h http.Handler) http.Handler {
-
 	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-
 		accessTokenCookie, err := req.Cookie(common.AccessTokenCookieKey)
-		if err == nil {
-			accessToken := accessTokenCookie.Value
-			req = req.WithContext(context.WithValue(req.Context(), common.AccessTokenHeaderKey, accessToken))
-		} else {
+		if err != nil {
 			if err != http.ErrNoCookie {
-				log.ErrorCtx(req.Context(), errors.New("unexpected error while extracting collection ID from cookie"), nil)
+				log.ErrorCtx(req.Context(), errors.New("unexpected error while extracting user Florence access token from cookie"), nil)
 			}
+		} else {
+			req = addUserAccessTokenToRequestContext(accessTokenCookie.Value, req)
 		}
 
 		h.ServeHTTP(w, req)
 	})
+}
+
+// addUserAccessTokenToRequestContext add the user florence access token to the request context. TODO TECHNICAL DEBT:
+//
+// There is inconsistency around which content key is used to store/retrieve the token. As a temp fix we are adding the
+// same value with both keys. To fix this properly we need to pick 1 context key and update all uses to use the same one.
+func addUserAccessTokenToRequestContext(userAccessToken string, req *http.Request) *http.Request {
+	req = req.WithContext(context.WithValue(req.Context(), common.AccessTokenHeaderKey, userAccessToken))
+	return req.WithContext(context.WithValue(req.Context(), common.FlorenceIdentityKey, userAccessToken))
 }

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -69,10 +69,10 @@
 			"revisionTime": "2019-06-26T11:14:30Z"
 		},
 		{
-			"checksumSHA1": "y24uVuOQBiUWkawZVwdWRZ5TxHk=",
+			"checksumSHA1": "gPmeo8SaEG731UM3ejs32yd9SB8=",
 			"path": "github.com/ONSdigital/go-ns/handlers/accessToken",
-			"revision": "a71825ee63804c27756ac8444c56a843285b09d6",
-			"revisionTime": "2019-07-08T12:45:24Z"
+			"revision": "9dedeaa7b91f2187ebae8cf6b63a268016fa50b3",
+			"revisionTime": "2019-07-19T07:31:34Z"
 		},
 		{
 			"checksumSHA1": "P5NQRDEiQJNSdTZqgcfR/o5T43Q=",


### PR DESCRIPTION

Updated vendor for `go-ns/handlers/accessToken/handler.go` to bring in fix for missing florence user access token.

