### PR TITLE
Release/1.6.6

### DIFF
--- a/handlers/handlers_test.go
+++ b/handlers/handlers_test.go
@@ -101,8 +101,7 @@ func TestUnitHandlers(t *testing.T) {
 		Convey("test successful json response", func() {
 			mockZebedeeClient := NewMockZebedeeClient(mockCtrl)
 			mockDatasetClient := NewMockDatasetClient(mockCtrl)
-			mockZebedeeClient.EXPECT().Get("/data?uri=/data").Return([]byte(`{"some_json":true}`), nil)
-			mockZebedeeClient.EXPECT().SetAccessToken("12345")
+			mockZebedeeClient.EXPECT().Get(ctx, "/data?uri=/data").Return([]byte(`{"some_json":true}`), nil)
 
 			w := httptest.NewRecorder()
 			req, err := http.NewRequest("GET", "/data", nil)
@@ -120,7 +119,7 @@ func TestUnitHandlers(t *testing.T) {
 		Convey("test status 500 returned if zedbedee get returns error", func() {
 			mockZebedeeClient := NewMockZebedeeClient(mockCtrl)
 			mockDatasetClient := NewMockDatasetClient(mockCtrl)
-			mockZebedeeClient.EXPECT().Get("/data?uri=/data").Return(nil, errors.New("something went wrong with zebedee"))
+			mockZebedeeClient.EXPECT().Get(ctx, "/data?uri=/data").Return(nil, errors.New("something went wrong with zebedee"))
 
 			w := httptest.NewRecorder()
 			req, err := http.NewRequest("GET", "/data", nil)
@@ -142,9 +141,9 @@ func TestUnitHandlers(t *testing.T) {
 			dlp := data.DatasetLandingPage{URI: "http://helloworld.com"}
 			dlp.Datasets = append(dlp.Datasets, data.Related{Title: "A dataset!", URI: "dataset.com"})
 
-			mockZebedeeClient.EXPECT().GetDatasetLandingPage("/data?uri=/somelegacypage").Return(dlp, nil)
-			mockZebedeeClient.EXPECT().GetBreadcrumb(dlp.URI)
-			mockZebedeeClient.EXPECT().GetDataset("dataset.com")
+			mockZebedeeClient.EXPECT().GetDatasetLandingPage(ctx, "/somelegacypage").Return(dlp, nil)
+			mockZebedeeClient.EXPECT().GetBreadcrumb(ctx, dlp.URI)
+			mockZebedeeClient.EXPECT().GetDataset(ctx, "dataset.com")
 
 			mockRend := NewMockRenderClient(mockCtrl)
 			mockRend.EXPECT().Do("dataset-landing-page-static", gomock.Any()).Return([]byte(`<html><body><h1>Some HTML from renderer!</h1></body></html>`), nil)
@@ -166,7 +165,7 @@ func TestUnitHandlers(t *testing.T) {
 			mockZebedeeClient := NewMockZebedeeClient(mockCtrl)
 			mockDatasetClient := NewMockDatasetClient(mockCtrl)
 			dlp := data.DatasetLandingPage{}
-			mockZebedeeClient.EXPECT().GetDatasetLandingPage("/data?uri=/somelegacypage").Return(dlp, errors.New("something went wrong :("))
+			mockZebedeeClient.EXPECT().GetDatasetLandingPage(ctx, "/somelegacypage").Return(dlp, errors.New("something went wrong :("))
 
 			w := httptest.NewRecorder()
 			req, err := http.NewRequest("GET", "/somelegacypage", nil)
@@ -183,8 +182,8 @@ func TestUnitHandlers(t *testing.T) {
 			mockZebedeeClient := NewMockZebedeeClient(mockCtrl)
 			mockDatasetClient := NewMockDatasetClient(mockCtrl)
 			dlp := data.DatasetLandingPage{URI: "http://helloworld.com"}
-			mockZebedeeClient.EXPECT().GetDatasetLandingPage("/data?uri=/somelegacypage").Return(dlp, nil)
-			mockZebedeeClient.EXPECT().GetBreadcrumb(dlp.URI).Return(nil, errors.New("something went wrong"))
+			mockZebedeeClient.EXPECT().GetDatasetLandingPage(ctx, "/somelegacypage").Return(dlp, nil)
+			mockZebedeeClient.EXPECT().GetBreadcrumb(ctx, dlp.URI).Return(nil, errors.New("something went wrong"))
 
 			w := httptest.NewRecorder()
 			req, err := http.NewRequest("GET", "/somelegacypage", nil)
@@ -203,9 +202,9 @@ func TestUnitHandlers(t *testing.T) {
 			dlp := data.DatasetLandingPage{URI: "http://helloworld.com"}
 			dlp.Datasets = append(dlp.Datasets, data.Related{Title: "A dataset!", URI: "dataset.com"})
 
-			mockZebedeeClient.EXPECT().GetDatasetLandingPage("/data?uri=/somelegacypage").Return(dlp, nil)
-			mockZebedeeClient.EXPECT().GetBreadcrumb(dlp.URI)
-			mockZebedeeClient.EXPECT().GetDataset("dataset.com")
+			mockZebedeeClient.EXPECT().GetDatasetLandingPage(ctx, "/somelegacypage").Return(dlp, nil)
+			mockZebedeeClient.EXPECT().GetBreadcrumb(ctx, dlp.URI)
+			mockZebedeeClient.EXPECT().GetDataset(ctx, "dataset.com")
 
 			mockRend := NewMockRenderClient(mockCtrl)
 			mockRend.EXPECT().Do("dataset-landing-page-static", gomock.Any()).Return(nil, errors.New("error from renderer"))
@@ -254,7 +253,7 @@ func TestUnitHandlers(t *testing.T) {
 			mockClient.EXPECT().GetOptions(ctx, "12345", "5678", "2017", "aggregate").Return(opts, nil)
 			mockClient.EXPECT().GetVersionMetadata(ctx, "12345", "5678", "2017")
 			mockClient.EXPECT().GetOptions(ctx, "12345", "5678", "2017", "aggregate").Return(opts, nil)
-			mockZebedeeClient.EXPECT().GetBreadcrumb("/economy/grossdomesticproduct/datasets/gdpjanuary2018")
+			mockZebedeeClient.EXPECT().GetBreadcrumb(ctx, "")
 
 			mockRend := NewMockRenderClient(mockCtrl)
 			mockRend.EXPECT().Do("dataset-landing-page-filterable", gomock.Any()).Return([]byte(`<html><body><h1>Some HTML from renderer!</h1></body></html>`), nil)
@@ -293,7 +292,7 @@ func TestUnitHandlers(t *testing.T) {
 			mockClient.EXPECT().Get(ctx, "12345").Return(dataset.Model{}, nil)
 			versions := []dataset.Version{dataset.Version{ReleaseDate: "02-01-2005", Links: dataset.Links{Self: dataset.Link{URL: "/datasets/12345/editions/2016/versions/1"}}}}
 			mockClient.EXPECT().GetVersions(ctx, "12345", "5678").Return(versions, errors.New("sorry"))
-			mockZebedeeClient.EXPECT().GetBreadcrumb("")
+			mockZebedeeClient.EXPECT().GetBreadcrumb(ctx, "")
 
 			w := httptest.NewRecorder()
 			req := httptest.NewRequest("GET", "/datasets/12345/editions/5678", nil)
@@ -315,7 +314,7 @@ func TestUnitHandlers(t *testing.T) {
 			mockClient.EXPECT().GetVersion(ctx, "12345", "5678", "1").Return(versions[0], nil)
 			mockClient.EXPECT().GetDimensions(ctx, "12345", "5678", "1")
 			mockClient.EXPECT().GetVersionMetadata(ctx, "12345", "5678", "1")
-			mockZebedeeClient.EXPECT().GetBreadcrumb("")
+			mockZebedeeClient.EXPECT().GetBreadcrumb(ctx, "")
 
 			mockRend := NewMockRenderClient(mockCtrl)
 			mockRend.EXPECT().Do("dataset-landing-page-filterable", gomock.Any()).Return(nil, errors.New("error from renderer"))

--- a/handlers/mock_zebedee.go
+++ b/handlers/mock_zebedee.go
@@ -5,6 +5,7 @@
 package handlers
 
 import (
+	context "context"
 	data "github.com/ONSdigital/go-ns/zebedee/data"
 	gomock "github.com/golang/mock/gomock"
 	reflect "reflect"
@@ -33,76 +34,64 @@ func (m *MockZebedeeClient) EXPECT() *MockZebedeeClientMockRecorder {
 	return m.recorder
 }
 
-// SetAccessToken mocks base method
-func (m *MockZebedeeClient) SetAccessToken(arg0 string) {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "SetAccessToken", arg0)
-}
-
-// SetAccessToken indicates an expected call of SetAccessToken
-func (mr *MockZebedeeClientMockRecorder) SetAccessToken(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetAccessToken", reflect.TypeOf((*MockZebedeeClient)(nil).SetAccessToken), arg0)
-}
-
 // GetBreadcrumb mocks base method
-func (m *MockZebedeeClient) GetBreadcrumb(arg0 string) ([]data.Breadcrumb, error) {
+func (m *MockZebedeeClient) GetBreadcrumb(arg0 context.Context, arg1 string) ([]data.Breadcrumb, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetBreadcrumb", arg0)
+	ret := m.ctrl.Call(m, "GetBreadcrumb", arg0, arg1)
 	ret0, _ := ret[0].([]data.Breadcrumb)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetBreadcrumb indicates an expected call of GetBreadcrumb
-func (mr *MockZebedeeClientMockRecorder) GetBreadcrumb(arg0 interface{}) *gomock.Call {
+func (mr *MockZebedeeClientMockRecorder) GetBreadcrumb(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBreadcrumb", reflect.TypeOf((*MockZebedeeClient)(nil).GetBreadcrumb), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBreadcrumb", reflect.TypeOf((*MockZebedeeClient)(nil).GetBreadcrumb), arg0, arg1)
 }
 
 // Get mocks base method
-func (m *MockZebedeeClient) Get(arg0 string) ([]byte, error) {
+func (m *MockZebedeeClient) Get(arg0 context.Context, arg1 string) ([]byte, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Get", arg0)
+	ret := m.ctrl.Call(m, "Get", arg0, arg1)
 	ret0, _ := ret[0].([]byte)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Get indicates an expected call of Get
-func (mr *MockZebedeeClientMockRecorder) Get(arg0 interface{}) *gomock.Call {
+func (mr *MockZebedeeClientMockRecorder) Get(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockZebedeeClient)(nil).Get), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockZebedeeClient)(nil).Get), arg0, arg1)
 }
 
 // GetDatasetLandingPage mocks base method
-func (m *MockZebedeeClient) GetDatasetLandingPage(arg0 string) (data.DatasetLandingPage, error) {
+func (m *MockZebedeeClient) GetDatasetLandingPage(arg0 context.Context, arg1 string) (data.DatasetLandingPage, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetDatasetLandingPage", arg0)
+	ret := m.ctrl.Call(m, "GetDatasetLandingPage", arg0, arg1)
 	ret0, _ := ret[0].(data.DatasetLandingPage)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetDatasetLandingPage indicates an expected call of GetDatasetLandingPage
-func (mr *MockZebedeeClientMockRecorder) GetDatasetLandingPage(arg0 interface{}) *gomock.Call {
+func (mr *MockZebedeeClientMockRecorder) GetDatasetLandingPage(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDatasetLandingPage", reflect.TypeOf((*MockZebedeeClient)(nil).GetDatasetLandingPage), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDatasetLandingPage", reflect.TypeOf((*MockZebedeeClient)(nil).GetDatasetLandingPage), arg0, arg1)
 }
 
 // GetDataset mocks base method
-func (m *MockZebedeeClient) GetDataset(arg0 string) (data.Dataset, error) {
+func (m *MockZebedeeClient) GetDataset(arg0 context.Context, arg1 string) (data.Dataset, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetDataset", arg0)
+	ret := m.ctrl.Call(m, "GetDataset", arg0, arg1)
 	ret0, _ := ret[0].(data.Dataset)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetDataset indicates an expected call of GetDataset
-func (mr *MockZebedeeClientMockRecorder) GetDataset(arg0 interface{}) *gomock.Call {
+func (mr *MockZebedeeClientMockRecorder) GetDataset(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDataset", reflect.TypeOf((*MockZebedeeClient)(nil).GetDataset), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDataset", reflect.TypeOf((*MockZebedeeClient)(nil).GetDataset), arg0, arg1)
 }
 
 // Healthcheck mocks base method

--- a/handlers/zebedee.go
+++ b/handlers/zebedee.go
@@ -1,6 +1,8 @@
 package handlers
 
 import (
+	"context"
+
 	"github.com/ONSdigital/go-ns/healthcheck"
 	"github.com/ONSdigital/go-ns/zebedee/data"
 )
@@ -10,10 +12,9 @@ import (
 
 // ZebedeeClient is an interface for zebedee client
 type ZebedeeClient interface {
-	SetAccessToken(string)
-	GetBreadcrumb(string) ([]data.Breadcrumb, error)
-	Get(string) ([]byte, error)
-	GetDatasetLandingPage(string) (data.DatasetLandingPage, error)
-	GetDataset(string) (data.Dataset, error)
+	GetBreadcrumb(context.Context, string) ([]data.Breadcrumb, error)
+	Get(context.Context, string) ([]byte, error)
+	GetDatasetLandingPage(context.Context, string) (data.DatasetLandingPage, error)
+	GetDataset(context.Context, string) (data.Dataset, error)
 	healthcheck.Client
 }

--- a/main.go
+++ b/main.go
@@ -13,6 +13,7 @@ import (
 	"github.com/ONSdigital/go-ns/clients/dataset"
 	"github.com/ONSdigital/go-ns/clients/filter"
 	"github.com/ONSdigital/go-ns/clients/renderer"
+	"github.com/ONSdigital/go-ns/handlers/accessToken"
 	"github.com/ONSdigital/go-ns/handlers/collectionID"
 	"github.com/ONSdigital/go-ns/handlers/healthcheck"
 	"github.com/ONSdigital/go-ns/log"
@@ -45,8 +46,8 @@ func main() {
 
 	router.StrictSlash(true).Path("/healthcheck").HandlerFunc(healthcheck.Handler)
 
-	router.StrictSlash(true).Path("/datasets/{datasetID}").Methods("GET").HandlerFunc(handlers.EditionsList(dc, rend))
-	router.StrictSlash(true).Path("/datasets/{datasetID}/editions").Methods("GET").HandlerFunc(handlers.EditionsList(dc, rend))
+	router.StrictSlash(true).Path("/datasets/{datasetID}").Methods("GET").HandlerFunc(handlers.EditionsList(dc, zc, rend))
+	router.StrictSlash(true).Path("/datasets/{datasetID}/editions").Methods("GET").HandlerFunc(handlers.EditionsList(dc, zc, rend))
 	router.StrictSlash(true).Path("/datasets/{datasetID}/editions/{editionID}").Methods("GET").HandlerFunc(handlers.FilterableLanding(dc, rend, zc))
 	router.StrictSlash(true).Path("/datasets/{datasetID}/editions/{edition}/versions").Methods("GET").HandlerFunc(handlers.VersionsList(dc, rend))
 	router.StrictSlash(true).Path("/datasets/{datasetID}/editions/{editionID}/versions/{versionID}").Methods("GET").HandlerFunc(handlers.FilterableLanding(dc, rend, zc))
@@ -85,6 +86,9 @@ func main() {
 
 	s.Middleware["CollectionID"] = collectionID.CheckCookie
 	s.MiddlewareOrder = append(s.MiddlewareOrder, "CollectionID")
+
+	s.Middleware["AccessToken"] = accessToken.CheckCookieValueAndForwardWithRequestContext
+	s.MiddlewareOrder = append(s.MiddlewareOrder, "AccessToken")
 
 	go func() {
 		if err := s.ListenAndServe(); err != nil {

--- a/vendor/github.com/ONSdigital/dp-frontend-models/model/datasetVersionsList/model.go
+++ b/vendor/github.com/ONSdigital/dp-frontend-models/model/datasetVersionsList/model.go
@@ -16,10 +16,22 @@ type VersionsList struct {
 
 // Version represents an edition version on the version list page
 type Version struct {
-	Date      string     `json:"date"`
-	Reasons   []string   `json:"reasons"`
-	Downloads []Download `json:"downloads"`
-	FilterURL string     `json:"filter_url"`
+	Date          string       `json:"date"`
+	Corrections   []Correction `json:"correction"`
+	Downloads     []Download   `json:"downloads"`
+	FilterURL     string       `json:"filter_url"`
+	VersionURL    string       `json:"version_url"`
+	VersionNumber int          `json:"version_number"`
+	Superseded    string       `json:"superseded"`
+	IsLatest      bool         `json:"is_latest"`
+	Title         string       `json:"title"`
+	Edition       string       `json:"edition"`
+}
+
+// Correction represents a single correction on the versions list page
+type Correction struct {
+	Reason string `json:"reason"`
+	Date   string `json:"date"`
 }
 
 //Download has the details for the an individual dataset's downloadable files

--- a/vendor/github.com/ONSdigital/go-ns/clients/dataset/data.go
+++ b/vendor/github.com/ONSdigital/go-ns/clients/dataset/data.go
@@ -6,7 +6,7 @@ import (
 	"unicode"
 )
 
-// Model represents a response dataset model from the dataset	 api
+// Model represents a response dataset model from the dataset api
 type Model struct {
 	ID                string           `json:"id"`
 	CollectionID      string           `json:"collection_id"`
@@ -113,6 +113,7 @@ type Links struct {
 	Options       Link `json:"options,omitempty"`
 	Version       Link `json:"version,omitempty"`
 	Code          Link `json:"code,omitempty"`
+	Taxonomy      Link `json:"taxonomy,omitempty"`
 }
 
 // Link represents a single link within a dataset model

--- a/vendor/github.com/ONSdigital/go-ns/common/access_token.go
+++ b/vendor/github.com/ONSdigital/go-ns/common/access_token.go
@@ -1,0 +1,6 @@
+package common
+
+const (
+	AccessTokenHeaderKey = "X-Florence-Token"
+	AccessTokenCookieKey = "access_token"
+)

--- a/vendor/github.com/ONSdigital/go-ns/handlers/accessToken/handler.go
+++ b/vendor/github.com/ONSdigital/go-ns/handlers/accessToken/handler.go
@@ -1,0 +1,47 @@
+package accessToken
+
+import (
+	"context"
+	"errors"
+	"net/http"
+
+	"github.com/ONSdigital/go-ns/common"
+	"github.com/ONSdigital/go-ns/log"
+)
+
+// CheckHeaderValueAndForwardWithRequestContext is a wrapper which adds a accessToken from the request header to context if one does not yet exist
+func CheckHeaderValueAndForwardWithRequestContext(h http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		accessToken := req.Header.Get(common.AccessTokenHeaderKey)
+		if accessToken != "" {
+			req = addUserAccessTokenToRequestContext(accessToken, req)
+		}
+
+		h.ServeHTTP(w, req)
+	})
+}
+
+// CheckCookieValueAndForwardWithRequestContext is a wrapper which adds a accessToken from the cookie to context if one does not yet exist
+func CheckCookieValueAndForwardWithRequestContext(h http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		accessTokenCookie, err := req.Cookie(common.AccessTokenCookieKey)
+		if err != nil {
+			if err != http.ErrNoCookie {
+				log.ErrorCtx(req.Context(), errors.New("unexpected error while extracting user Florence access token from cookie"), nil)
+			}
+		} else {
+			req = addUserAccessTokenToRequestContext(accessTokenCookie.Value, req)
+		}
+
+		h.ServeHTTP(w, req)
+	})
+}
+
+// addUserAccessTokenToRequestContext add the user florence access token to the request context. TODO TECHNICAL DEBT:
+//
+// There is inconsistency around which content key is used to store/retrieve the token. As a temp fix we are adding the
+// same value with both keys. To fix this properly we need to pick 1 context key and update all uses to use the same one.
+func addUserAccessTokenToRequestContext(userAccessToken string, req *http.Request) *http.Request {
+	req = req.WithContext(context.WithValue(req.Context(), common.AccessTokenHeaderKey, userAccessToken))
+	return req.WithContext(context.WithValue(req.Context(), common.FlorenceIdentityKey, userAccessToken))
+}

--- a/vendor/github.com/ONSdigital/go-ns/zebedee/client/client.go
+++ b/vendor/github.com/ONSdigital/go-ns/zebedee/client/client.go
@@ -1,7 +1,9 @@
 package client
 
 import (
+	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -12,15 +14,15 @@ import (
 	"time"
 
 	"github.com/ONSdigital/go-ns/common"
+	"github.com/ONSdigital/go-ns/log"
 	"github.com/ONSdigital/go-ns/rhttp"
 	"github.com/ONSdigital/go-ns/zebedee/data"
 )
 
 // ZebedeeClient represents a zebedee client
 type ZebedeeClient struct {
-	zebedeeURL  string
-	client      *rhttp.Client
-	accessToken string
+	zebedeeURL string
+	client     *rhttp.Client
 }
 
 // ErrInvalidZebedeeResponse is returned when zebedee does not respond
@@ -58,8 +60,8 @@ func NewZebedeeClient(url string) *ZebedeeClient {
 }
 
 // Get returns a response for the requested uri in zebedee
-func (c *ZebedeeClient) Get(path string) ([]byte, error) {
-	return c.get(path)
+func (c *ZebedeeClient) Get(ctx context.Context, path string) ([]byte, error) {
+	return c.get(ctx, path)
 }
 
 // Healthcheck calls the healthcheck endpoint on the api and alerts the caller of any errors
@@ -78,8 +80,9 @@ func (c *ZebedeeClient) Healthcheck() (string, error) {
 
 // GetDatasetLandingPage returns a DatasetLandingPage populated with data from a zebedee response. If an error
 // is returned there is a chance that a partly completed DatasetLandingPage is returned
-func (c *ZebedeeClient) GetDatasetLandingPage(path string) (data.DatasetLandingPage, error) {
-	b, err := c.get(path)
+func (c *ZebedeeClient) GetDatasetLandingPage(ctx context.Context, path string) (data.DatasetLandingPage, error) {
+	reqURL := c.createRequestURL(ctx, "/data?uri="+path)
+	b, err := c.get(ctx, reqURL)
 	if err != nil {
 		return data.DatasetLandingPage{}, err
 	}
@@ -109,7 +112,7 @@ func (c *ZebedeeClient) GetDatasetLandingPage(path string) (data.DatasetLandingP
 					<-sem
 					wg.Done()
 				}()
-				t, _ := c.GetPageTitle(e.URI)
+				t, _ := c.GetPageTitle(ctx, e.URI)
 				element[i].Title = t.Title
 			}(i, e, element)
 		}
@@ -119,19 +122,18 @@ func (c *ZebedeeClient) GetDatasetLandingPage(path string) (data.DatasetLandingP
 	return dlp, nil
 }
 
-// SetAccessToken adds an access token to the client to authenticate with zebedee
-func (c *ZebedeeClient) SetAccessToken(token string) {
-	c.accessToken = token
-}
-
-func (c *ZebedeeClient) get(path string) ([]byte, error) {
+func (c *ZebedeeClient) get(ctx context.Context, path string) ([]byte, error) {
 	req, err := http.NewRequest("GET", c.zebedeeURL+path, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	if len(c.accessToken) > 0 {
-		req.Header.Set(common.FlorenceHeaderKey, c.accessToken)
+	if ctx.Value(common.AccessTokenHeaderKey) != nil {
+		accessToken, ok := ctx.Value(common.AccessTokenHeaderKey).(string)
+		if !ok {
+			log.ErrorCtx(ctx, errors.New("error casting access token cookie to string"), nil)
+		}
+		req.Header.Set(common.FlorenceHeaderKey, accessToken)
 	}
 
 	resp, err := c.client.Do(req)
@@ -149,8 +151,8 @@ func (c *ZebedeeClient) get(path string) ([]byte, error) {
 }
 
 // GetBreadcrumb returns a Breadcrumb
-func (c *ZebedeeClient) GetBreadcrumb(uri string) ([]data.Breadcrumb, error) {
-	b, err := c.get("/parents?uri=" + uri)
+func (c *ZebedeeClient) GetBreadcrumb(ctx context.Context, uri string) ([]data.Breadcrumb, error) {
+	b, err := c.get(ctx, "/parents?uri="+uri)
 	if err != nil {
 		return nil, err
 	}
@@ -164,8 +166,8 @@ func (c *ZebedeeClient) GetBreadcrumb(uri string) ([]data.Breadcrumb, error) {
 }
 
 // GetDataset returns details about a dataset from zebedee
-func (c *ZebedeeClient) GetDataset(uri string) (data.Dataset, error) {
-	b, err := c.get("/data?uri=" + uri)
+func (c *ZebedeeClient) GetDataset(ctx context.Context, uri string) (data.Dataset, error) {
+	b, err := c.get(ctx, "/data?uri="+uri)
 	if err != nil {
 		return data.Dataset{}, err
 	}
@@ -178,7 +180,7 @@ func (c *ZebedeeClient) GetDataset(uri string) (data.Dataset, error) {
 	downloads := make([]data.Download, 0)
 
 	for _, v := range d.Downloads {
-		fs, err := c.GetFileSize(uri + "/" + v.File)
+		fs, err := c.GetFileSize(ctx, uri+"/"+v.File)
 		if err != nil {
 			return d, err
 		}
@@ -193,7 +195,7 @@ func (c *ZebedeeClient) GetDataset(uri string) (data.Dataset, error) {
 
 	supplementaryFiles := make([]data.SupplementaryFile, 0)
 	for _, v := range d.SupplementaryFiles {
-		fs, err := c.GetFileSize(uri + "/" + v.File)
+		fs, err := c.GetFileSize(ctx, uri+"/"+v.File)
 		if err != nil {
 			return d, err
 		}
@@ -211,8 +213,8 @@ func (c *ZebedeeClient) GetDataset(uri string) (data.Dataset, error) {
 }
 
 // GetFileSize retrieves a given filesize from zebedee
-func (c *ZebedeeClient) GetFileSize(uri string) (data.FileSize, error) {
-	b, err := c.get("/filesize?uri=" + uri)
+func (c *ZebedeeClient) GetFileSize(ctx context.Context, uri string) (data.FileSize, error) {
+	b, err := c.get(ctx, "/filesize?uri="+uri)
 	if err != nil {
 		return data.FileSize{}, err
 	}
@@ -226,8 +228,8 @@ func (c *ZebedeeClient) GetFileSize(uri string) (data.FileSize, error) {
 }
 
 // GetPageTitle retrieves a page title from zebedee
-func (c *ZebedeeClient) GetPageTitle(uri string) (data.PageTitle, error) {
-	b, err := c.get("/data?uri=" + uri + "&title")
+func (c *ZebedeeClient) GetPageTitle(ctx context.Context, uri string) (data.PageTitle, error) {
+	b, err := c.get(ctx, "/data?uri="+uri+"&title")
 	if err != nil {
 		return data.PageTitle{}, err
 	}
@@ -238,4 +240,17 @@ func (c *ZebedeeClient) GetPageTitle(uri string) (data.PageTitle, error) {
 	}
 
 	return pt, nil
+}
+
+func (c *ZebedeeClient) createRequestURL(ctx context.Context, path string) string {
+	var url string
+	if ctx.Value(common.CollectionIDHeaderKey) != nil {
+		collectionID, ok := ctx.Value(common.CollectionIDHeaderKey).(string)
+		if !ok {
+			log.ErrorCtx(ctx, errors.New("error casting collection ID cookie to string"), nil)
+		}
+		url = "/data/" + collectionID
+	}
+	url = url + path
+	return url
 }

--- a/vendor/github.com/ONSdigital/go-ns/zebedee/zebedeeMapper/mapper.go
+++ b/vendor/github.com/ONSdigital/go-ns/zebedee/zebedeeMapper/mapper.go
@@ -51,6 +51,7 @@ func MapZebedeeDatasetLandingPageToFrontendModel(dlp data.DatasetLandingPage, bc
 	sdlp.ContactDetails = model.ContactDetails(dlp.Description.Contact)
 	sdlp.DatasetLandingPage.ReleaseDate = dlp.Description.ReleaseDate
 	sdlp.DatasetLandingPage.NextRelease = dlp.Description.NextRelease
+	sdlp.DatasetLandingPage.DatasetID = dlp.Description.DatasetID
 	sdlp.DatasetLandingPage.Notes = dlp.Section.Markdown
 
 	for _, bc := range bcs {

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -27,10 +27,10 @@
 			"revisionTime": "2019-06-12T09:32:01Z"
 		},
 		{
-			"checksumSHA1": "75LiXlJQRBdZq0U0dblxsumlseM=",
+			"checksumSHA1": "BNvcNTiuBS69r49n0J1gmP5X5m8=",
 			"path": "github.com/ONSdigital/dp-frontend-models/model/datasetVersionsList",
-			"revision": "d0c62d9ef084b61601727ffc57c5159d9003f374",
-			"revisionTime": "2019-06-05T11:13:56Z"
+			"revision": "a241555e39f608df7b7599b8da12078c007b3f53",
+			"revisionTime": "2019-07-11T13:08:03Z"
 		},
 		{
 			"checksumSHA1": "HqVWBwIqPXqBB0OnBJLFhAq8YDo=",
@@ -45,10 +45,10 @@
 			"revisionTime": "2018-06-07T13:26:14Z"
 		},
 		{
-			"checksumSHA1": "7sRxS0TMfUOf8rWfqrozenQZYRQ=",
+			"checksumSHA1": "U6qK/6OGFrgkPpqY6z3q4dph+pk=",
 			"path": "github.com/ONSdigital/go-ns/clients/dataset",
-			"revision": "6f82e6a20b01b654f578a2ece969813a4f825157",
-			"revisionTime": "2019-06-19T14:58:47Z"
+			"revision": "473b0c699f27bbe3dcc56ac68fc6311738d8f076",
+			"revisionTime": "2019-07-11T13:31:14Z"
 		},
 		{
 			"checksumSHA1": "30cvT+T3lSVX9d021VnyqjxylbU=",
@@ -63,10 +63,16 @@
 			"revisionTime": "2018-06-07T13:26:14Z"
 		},
 		{
-			"checksumSHA1": "hlr8fdPLJMYY6YkPuiBkI8Jm9Mc=",
+			"checksumSHA1": "EKyi1XnDHY92J3MomOqsSp/erRw=",
 			"path": "github.com/ONSdigital/go-ns/common",
-			"revision": "caee21dda39f1143056a5ec0b3031036e14c7c42",
-			"revisionTime": "2019-05-20T09:08:57Z"
+			"revision": "9d7a9b194abd25973e015478e6e6514ba398d231",
+			"revisionTime": "2019-06-26T11:14:30Z"
+		},
+		{
+			"checksumSHA1": "gPmeo8SaEG731UM3ejs32yd9SB8=",
+			"path": "github.com/ONSdigital/go-ns/handlers/accessToken",
+			"revision": "9dedeaa7b91f2187ebae8cf6b63a268016fa50b3",
+			"revisionTime": "2019-07-19T07:31:34Z"
 		},
 		{
 			"checksumSHA1": "P5NQRDEiQJNSdTZqgcfR/o5T43Q=",
@@ -117,10 +123,10 @@
 			"revisionTime": "2018-06-07T13:26:14Z"
 		},
 		{
-			"checksumSHA1": "cJWJF357pxg9moFdCiwYjbP7FCs=",
+			"checksumSHA1": "JVYcgiLYn00vESzMyaQqC6pF0pw=",
 			"path": "github.com/ONSdigital/go-ns/zebedee/client",
-			"revision": "8f16ab9f96817f89e7a2e2791f6ff72346f15711",
-			"revisionTime": "2018-11-27T09:28:38Z"
+			"revision": "ba92cde67e201ffba6f382610deabc4c3e86e6af",
+			"revisionTime": "2019-07-09T08:27:28Z"
 		},
 		{
 			"checksumSHA1": "UzD4bpGuvgLkXixqcUKF3YZ9tOs=",
@@ -129,10 +135,10 @@
 			"revisionTime": "2019-05-20T09:08:57Z"
 		},
 		{
-			"checksumSHA1": "jTYGIg3hCVtfo3Lkm6BvEUqhXhA=",
+			"checksumSHA1": "lEppDOAYlgUrEeLuCv+ER3qd3GA=",
 			"path": "github.com/ONSdigital/go-ns/zebedee/zebedeeMapper",
-			"revision": "b855e422a973c7e4b527fdb02f6ec0ae3a756677",
-			"revisionTime": "2019-06-12T09:52:30Z"
+			"revision": "473b0c699f27bbe3dcc56ac68fc6311738d8f076",
+			"revisionTime": "2019-07-11T13:31:14Z"
 		},
 		{
 			"checksumSHA1": "MAeBR949WamCkKZdQjI21gfK/U0=",


### PR DESCRIPTION
### What

Release 1.6.6

#### In this release
* Fix fail on breadcrumb error 
* Add breadcrumbs to dataset pages 
* go-ns updated to enable datasetid mapping 
* New model data populated for revamped versions page


