### PR TITLE
Versions page was missing latest version, now no longer

### DIFF
--- a/mapper/mapper.go
+++ b/mapper/mapper.go
@@ -288,10 +288,6 @@ func CreateVersionsList(ctx context.Context, d dataset.Model, edition dataset.Ed
 	p.DatasetId = d.ID
 
 	for i, ver := range versions {
-		if edition.Links.LatestVersion.URL == ver.Links.Self.URL {
-			continue
-		}
-
 		var version datasetVersionsList.Version
 
 		version.VersionNumber = ver.Version


### PR DESCRIPTION
### What

This should now show all versions
When appending versions list, it would skip the latest in the edition

### How to review

Check out the version page, publish to edition then repeat, go to versions page, do you see version: x (latest)? 
<img width="736" alt="Screenshot 2019-08-06 at 12 00 25" src="https://user-images.githubusercontent.com/47502916/62534826-da844f80-b841-11e9-9392-38eb8c5d4e0a.png">

Note this worked locally before and still does without this fix, the issue was discovered on develop, fix assumed from looking through code. Worked on develop as edition.Links.LatestVersion.URL wasn't set.

### Who can review

Anyone except me