### PR TITLE
Fix for latest version prompt on versions page not appearing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 build/*
+\.idea/

--- a/mapper/mapper.go
+++ b/mapper/mapper.go
@@ -334,11 +334,7 @@ func CreateVersionsList(ctx context.Context, d dataset.Model, edition dataset.Ed
 		}
 	}
 
-	// Reverse splice, so it is ordered by latest
-	for i := len(p.Data.Versions)/2 - 1; i >= 0; i-- {
-		versionsInReverse := len(p.Data.Versions) - 1 - i
-		p.Data.Versions[i], p.Data.Versions[versionsInReverse] = p.Data.Versions[versionsInReverse], p.Data.Versions[i]
-	}
+	sort.Slice(p.Data.Versions, func(i, j int) bool { return p.Data.Versions[i].VersionNumber > p.Data.Versions[j].VersionNumber })
 	return p
 }
 

--- a/mapper/mapper.go
+++ b/mapper/mapper.go
@@ -273,7 +273,7 @@ func CreateFilterableLandingPage(ctx context.Context, d dataset.Model, ver datas
 func CreateVersionsList(ctx context.Context, d dataset.Model, edition dataset.Edition, versions []dataset.Version) datasetVersionsList.Page {
 	var p datasetVersionsList.Page
 	SetTaxonomyDomain(&p.Page)
-	// TODO refactor and make Welsh compatable.
+	// TODO refactor and make Welsh compatible.
 	p.Metadata.Title = "All versions of " + d.Title
 	if len(versions) > 0 {
 		p.Metadata.Title += " " + versions[0].Edition
@@ -287,9 +287,10 @@ func CreateVersionsList(ctx context.Context, d dataset.Model, edition dataset.Ed
 	p.Data.LatestVersionURL = uri.Path
 	p.DatasetId = d.ID
 
+	latestVersionNumber := 1
 	for i, ver := range versions {
 		var version datasetVersionsList.Version
-
+		version.IsLatest = false
 		version.VersionNumber = ver.Version
 		version.Title = d.Title
 		version.Date = ver.ReleaseDate
@@ -297,12 +298,11 @@ func CreateVersionsList(ctx context.Context, d dataset.Model, edition dataset.Ed
 		version.FilterURL = fmt.Sprintf("/datasets/%s/editions/%s/versions/%d/filter", ver.Links.Dataset.ID, ver.Edition, ver.Version)
 
 		if ver.Version > 1 {
-			version.Superseded = fmt.Sprintf("/datasets/%s/editions/%s/versions/%d", ver.Links.Dataset.ID, ver.Edition, (i))
+			version.Superseded = fmt.Sprintf("/datasets/%s/editions/%s/versions/%d", ver.Links.Dataset.ID, ver.Edition, i)
 		}
-		if ver.Version == len(versions) {
-			version.IsLatest = true
-		} else {
-			version.IsLatest = false
+
+		if ver.Version > latestVersionNumber{
+			latestVersionNumber = ver.Version
 		}
 
 		for ext, download := range ver.Downloads {
@@ -327,6 +327,13 @@ func CreateVersionsList(ctx context.Context, d dataset.Model, edition dataset.Ed
 
 		p.Data.Versions = append(p.Data.Versions, version)
 	}
+
+	for i, ver := range p.Data.Versions{
+		if ver.VersionNumber == latestVersionNumber {
+			p.Data.Versions[i].IsLatest = true
+		}
+	}
+
 	// Reverse splice, so it is ordered by latest
 	for i := len(p.Data.Versions)/2 - 1; i >= 0; i-- {
 		versionsInReverse := len(p.Data.Versions) - 1 - i

--- a/mapper/mapper.go
+++ b/mapper/mapper.go
@@ -331,6 +331,7 @@ func CreateVersionsList(ctx context.Context, d dataset.Model, edition dataset.Ed
 	for i, ver := range p.Data.Versions{
 		if ver.VersionNumber == latestVersionNumber {
 			p.Data.Versions[i].IsLatest = true
+			break;
 		}
 	}
 

--- a/vendor/github.com/ONSdigital/go-ns/common/locale.go
+++ b/vendor/github.com/ONSdigital/go-ns/common/locale.go
@@ -9,41 +9,44 @@ const (
 	LangEN = "en"
 	LangCY = "cy"
 
+	DefaultLang = LangEN
+
 	LocaleCookieKey = "lang"
 	LocaleHeaderKey = "LocaleCode"
 )
+var SupportedLanguages = [2]string{LangEN, LangCY}
+
 
 // SetLocaleCode sets the Locale code used to set the language
 func SetLocaleCode(req *http.Request) *http.Request {
-	localeCode := ExtractLangFromSubDomain(req)
+	localeCode := GetLangFromSubDomain(req)
 
 	// Language is overridden by cookie 'lang' here if present.
 	if c, err := req.Cookie(LocaleCookieKey); err == nil && len(c.Value) > 0 {
-		localeCode = ExtractLangFromCookie(c)
+		localeCode = GetLangFromCookieOrDefault(c)
 	}
 	req.Header.Set(LocaleHeaderKey, localeCode)
 
 	return req
 }
 
-// ExtractLangFromSubDomain returns a language based on subdomain
-func ExtractLangFromSubDomain(req *http.Request) string {
+// GetLangFromSubDomain returns a language based on subdomain
+func GetLangFromSubDomain(req *http.Request) string {
 	args := strings.Split(req.Host, ".")
 	if len(args) == 0 {
 		// Defaulting to "en" (LangEN) if no arguments
 		return LangEN
 	}
-	if strings.Split(req.Host, ".")[0] == LangCY {
+	if args[0] == LangCY {
 		return LangCY
 	}
 	return LangEN
 }
 
-// ExtractLangFromCookie returns a language based on the lang cookie
-func ExtractLangFromCookie(c *http.Cookie) string {
+// GetLangFromCookieOrDefault returns a language based on the lang cookie or if not valid defaults it
+func GetLangFromCookieOrDefault(c *http.Cookie) string {
 	if c.Value == LangCY || c.Value == LangEN {
 		return c.Value
 	}
-	return LangEN
-
+	return DefaultLang
 }

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -63,10 +63,10 @@
 			"revisionTime": "2018-06-07T13:26:14Z"
 		},
 		{
-			"checksumSHA1": "F+kAREbYcIceRimr1oz321889C8=",
+			"checksumSHA1": "a1j+FiKx0eqh3hz8knUfoiEh2dQ=",
 			"path": "github.com/ONSdigital/go-ns/common",
-			"revision": "d5019fd87b49b1027b8d3956c82bb295e69f9e03",
-			"revisionTime": "2019-07-23T10:01:44Z"
+			"revision": "f143613c2ec1af6d6b57ccf01d4193c75863f4d5",
+			"revisionTime": "2019-08-15T07:52:23Z"
 		},
 		{
 			"checksumSHA1": "hnWK78otqTZwDU2D16X5GHzvIhk=",


### PR DESCRIPTION

### What

* Fix for latest version prompt on versions page not appearing
  *  Note this only happened when a version was deleted 
<img width="892" alt="Screenshot 2019-08-07 at 11 24 19" src="https://user-images.githubusercontent.com/47502916/62615846-05d07280-b906-11e9-9e53-33ef2393f254.png">

- Small typo fixes
- Ignore IDE files (Typically used by JetBrains IDEs


### How to review

Create a couple of versions of a collection, delete one. Check that the latest version text: '(latest version)' is still present on the correct version.

### Who can review

Anyone except me.