### PR TITLE
Release 1.6.9

### DIFF
--- a/vendor/github.com/ONSdigital/go-ns/zebedee/zebedeeMapper/mapper.go
+++ b/vendor/github.com/ONSdigital/go-ns/zebedee/zebedeeMapper/mapper.go
@@ -3,6 +3,7 @@ package zebedeeMapper
 import (
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/ONSdigital/dp-frontend-models/model"
 	"github.com/ONSdigital/dp-frontend-models/model/datasetLandingPageStatic"
@@ -50,8 +51,20 @@ func MapZebedeeDatasetLandingPageToFrontendModel(dlp data.DatasetLandingPage, bc
 	sdlp.DatasetLandingPage.IsNationalStatistic = dlp.Description.NationalStatistic
 	sdlp.DatasetLandingPage.IsTimeseries = dlp.Timeseries
 	sdlp.ContactDetails = model.ContactDetails(dlp.Description.Contact)
-	sdlp.DatasetLandingPage.ReleaseDate = dlp.Description.ReleaseDate
-	sdlp.DatasetLandingPage.NextRelease = dlp.Description.NextRelease
+
+	// HACK FIX TODO REMOVE WHEN TIME IS SAVED CORRECTLY (GMT/UTC Issue)
+	if strings.Contains(dlp.Description.ReleaseDate, "T23:00:00"){
+		releaseDateInTimeFormat, err := time.Parse(time.RFC3339, dlp.Description.ReleaseDate)
+		if err != nil{
+			log.Error(err, nil)
+			sdlp.DatasetLandingPage.ReleaseDate = dlp.Description.ReleaseDate
+		}
+		sdlp.DatasetLandingPage.ReleaseDate = releaseDateInTimeFormat.Add(1 * time.Hour).Format("02 January 2006")
+	} else {
+		sdlp.DatasetLandingPage.ReleaseDate = dlp.Description.ReleaseDate
+	}
+	// END of hack fix
+    sdlp.DatasetLandingPage.NextRelease = dlp.Description.NextRelease
 	sdlp.DatasetLandingPage.DatasetID = dlp.Description.DatasetID
 	sdlp.DatasetLandingPage.Notes = dlp.Section.Markdown
 

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -147,10 +147,10 @@
 			"revisionTime": "2019-09-19T16:09:22Z"
 		},
 		{
-			"checksumSHA1": "fO7lMA4hJvLdEmLJWveQv0xPuhs=",
+			"checksumSHA1": "jYnnbRVYyWAcbAhTfY0lJzS0ikk=",
 			"path": "github.com/ONSdigital/go-ns/zebedee/zebedeeMapper",
-			"revision": "30bf55ba5a05f1d425fba4607f1af7d0e8a89cae",
-			"revisionTime": "2019-09-19T16:09:22Z"
+			"revision": "b53b51e1adea80d413c7ebb6aad848ea732258a8",
+			"revisionTime": "2019-10-23T10:37:30Z"
 		},
 		{
 			"checksumSHA1": "MAeBR949WamCkKZdQjI21gfK/U0=",


### PR DESCRIPTION
### What

Release 1.6.9 containing a zebedeeMapper vendored in with an update to time.
This is a hacky fix release and initial issue should be resolved of time in BST saving an hour earlier than it should, resulting in release date appearing as the day before.

### How to review

With CMD endpoints enabled, check that the release date is accurate to that in the JSON

### Who can review

Anyone except me
