### PR TITLE
Feature/remove taxonomy domain

### DIFF
--- a/handlers/feedback.go
+++ b/handlers/feedback.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/ONSdigital/dp-api-clients-go/renderer"
 	"github.com/ONSdigital/dp-frontend-dataset-controller/config"
-	"github.com/ONSdigital/dp-frontend-dataset-controller/mapper"
 	"github.com/ONSdigital/dp-frontend-models/model"
 	"github.com/ONSdigital/dp-frontend-models/model/feedback"
 	"github.com/ONSdigital/go-ns/log"
@@ -34,7 +33,6 @@ type Feedback struct {
 // FeedbackThanks loads the Feedback Thank you page
 func FeedbackThanks(w http.ResponseWriter, req *http.Request) {
 	var p model.Page
-	mapper.SetTaxonomyDomain(&p)
 
 	p.Metadata.Title = "Thank you"
 	returnTo := req.URL.Query().Get("returnTo")
@@ -72,7 +70,6 @@ func GetFeedback(w http.ResponseWriter, req *http.Request) {
 
 func getFeedback(w http.ResponseWriter, req *http.Request, url, errorType, purpose, description, name, email string) {
 	var p feedback.Page
-	mapper.SetTaxonomyDomain(&p.Page)
 
 	var services = make(map[string]string)
 	services["cmd"] = "Customising data by applying filters"

--- a/mapper/mapper.go
+++ b/mapper/mapper.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"net/url"
-	"os"
 	"sort"
 	"strconv"
 	"strings"
@@ -18,11 +17,6 @@ import (
 	"github.com/ONSdigital/go-ns/log"
 	"github.com/ONSdigital/go-ns/zebedee/data"
 )
-
-// SetTaxonomyDomain will set the taxonomy domain for a given pages
-func SetTaxonomyDomain(p *model.Page) {
-	p.TaxonomyDomain = os.Getenv("TAXONOMY_DOMAIN")
-}
 
 // TimeSlice allows sorting of a list of time.Time
 type TimeSlice []time.Time
@@ -42,7 +36,6 @@ func (p TimeSlice) Swap(i, j int) {
 // CreateFilterableLandingPage creates a filterable dataset landing page based on api model responses
 func CreateFilterableLandingPage(ctx context.Context, d dataset.Model, ver dataset.Version, datasetID string, opts []dataset.Options, dims dataset.Dimensions, displayOtherVersionsLink bool, breadcrumbs []data.Breadcrumb, latestVersionNumber int, latestVersionURL string) datasetLandingPageFilterable.Page {
 	p := datasetLandingPageFilterable.Page{}
-	SetTaxonomyDomain(&p.Page)
 	p.Type = "dataset_landing_page"
 	p.Metadata.Title = d.Title
 	p.URI = d.Links.Self.URL
@@ -272,7 +265,6 @@ func CreateFilterableLandingPage(ctx context.Context, d dataset.Model, ver datas
 // CreateVersionsList creates a versions list page based on api model responses
 func CreateVersionsList(ctx context.Context, d dataset.Model, edition dataset.Edition, versions []dataset.Version) datasetVersionsList.Page {
 	var p datasetVersionsList.Page
-	SetTaxonomyDomain(&p.Page)
 	// TODO refactor and make Welsh compatible.
 	p.Metadata.Title = "All versions of " + d.Title
 	if len(versions) > 0 {
@@ -342,7 +334,6 @@ func CreateVersionsList(ctx context.Context, d dataset.Model, edition dataset.Ed
 // CreateEditionsList creates a editions list page based on api model responses
 func CreateEditionsList(ctx context.Context, d dataset.Model, editions []dataset.Edition, datasetID string, breadcrumbs []data.Breadcrumb) datasetEditionsList.Page {
 	p := datasetEditionsList.Page{}
-	SetTaxonomyDomain(&p.Page)
 	p.Type = "dataset_edition_list"
 	p.Metadata.Title = d.Title
 	p.URI = d.Links.Self.URL

--- a/mapper/mapper_test.go
+++ b/mapper/mapper_test.go
@@ -2,25 +2,16 @@ package mapper
 
 import (
 	"context"
-	"os"
 	"strconv"
 	"testing"
 
 	"github.com/ONSdigital/dp-api-clients-go/dataset"
-	"github.com/ONSdigital/dp-frontend-models/model"
 	"github.com/ONSdigital/go-ns/zebedee/data"
 	. "github.com/smartystreets/goconvey/convey"
 )
 
 func TestUnitMapper(t *testing.T) {
 	ctx := context.Background()
-
-	Convey("test SetTaxonomyDomain adds the taxonomy domain to page model", t, func() {
-		os.Setenv("TAXONOMY_DOMAIN", "https://www.ons.gov.uk")
-		p := model.Page{}
-		SetTaxonomyDomain(&p)
-		So(p.TaxonomyDomain, ShouldEqual, "https://www.ons.gov.uk")
-	})
 
 	Convey("test CreateFilterableLandingPage", t, func() {
 		d := dataset.Model{
@@ -163,14 +154,6 @@ func TestUnitMapper(t *testing.T) {
 		So(v0.Downloads[0].URI, ShouldEqual, "my-url")
 	})
 
-	Convey("test taxonomy domain is set on page when environment variable is set", t, func() {
-		os.Setenv("TAXONOMY_DOMAIN", "my-domain")
-
-		p := CreateFilterableLandingPage(ctx, dataset.Model{}, dataset.Version{}, "", []dataset.Options{}, dataset.Dimensions{}, false, []data.Breadcrumb{}, 1, "/datasets/83jd98fkflg/editions/124/versions/1")
-
-		So(p.TaxonomyDomain, ShouldEqual, "my-domain")
-
-	})
 }
 
 // TestCreateVersionsList Tests the CreateVersionsList function in the mapper

--- a/vendor/github.com/ONSdigital/dp-frontend-models/model/page.go
+++ b/vendor/github.com/ONSdigital/dp-frontend-models/model/page.go
@@ -7,7 +7,6 @@ type Page struct {
 	DatasetTitle                     string         `json:"dataset_title"`
 	URI                              string         `json:"uri"`
 	Taxonomy                         []TaxonomyNode `json:"taxonomy"`
-	TaxonomyDomain                   string         `json:"taxonomy_domain"`
 	Breadcrumb                       []TaxonomyNode `json:"breadcrumb"`
 	IsInFilterBreadcrumb             bool           `json:"is_in_filter_breadcrumb"`
 	ServiceMessage                   string         `json:"service_message"`

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -45,10 +45,10 @@
 			"revisionTime": "2019-10-24T09:54:33Z"
 		},
 		{
-			"checksumSHA1": "qsWQHvSsn4XThaZ6DJWbdugsos0=",
+			"checksumSHA1": "fJkBbYwFJnWgmIhmYaf5Pnt8CNk=",
 			"path": "github.com/ONSdigital/dp-frontend-models/model",
-			"revision": "6eee1d972c81a8224e8bcef28cd398ed370854cc",
-			"revisionTime": "2019-09-05T13:10:15Z"
+			"revision": "61a4fc32d261a3e49e950290423ec0b8050612a2",
+			"revisionTime": "2019-10-25T12:16:22Z"
 		},
 		{
 			"checksumSHA1": "F5fUTKbRADGQSQLT73z6XxeSd2w=",


### PR DESCRIPTION
### What

- Remove `SetTaxonomyDomain()` mapper func
- Remove tests `SetTaxonomyDomain()` mapper func
- Vendor updated page model

### How to review

- Sanity check. Check for any missed TaxonomyDomain values
- Run app with `TAXONOMY_DOMAIN` flag set e.g. `make debug TAXONOMY_DOMAIN="http://www.test.com"` global links (navbar, footer, etc.) should be rendered relative, and **not** include `http://www.test.com`.

### Who can review

Anyone
