### PR TITLE
Feature/add loop11 flag

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -22,6 +22,7 @@ type Config struct {
 	FeedbackFrom       string `env:"FEEDBACK_FROM"`
 	DownloadServiceURL string `env:"DOWNLOAD_SERVICE_URL"`
 	ServiceToken       string `env:"SERVICE_TOKEN"`
+	EnableLoop11	   bool   `env:"ENABLE_LOOP11"`
 }
 
 func init() {
@@ -39,6 +40,7 @@ func init() {
 		FeedbackTo:         "",
 		FeedbackFrom:       "",
 		ServiceToken:       "",
+		EnableLoop11:		false,
 	}
 	err := gofigure.Gofigure(&cfg)
 	if err != nil {

--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -179,7 +179,7 @@ func versionsList(w http.ResponseWriter, req *http.Request, dc DatasetClient, re
 		return
 	}
 
-	p := mapper.CreateVersionsList(ctx, d, e, versions)
+	p := mapper.CreateVersionsList(ctx, d, e, versions, cfg.EnableLoop11)
 	b, err := json.Marshal(p)
 	if err != nil {
 		setStatusCode(req, w, err)
@@ -288,7 +288,7 @@ func filterableLanding(w http.ResponseWriter, req *http.Request, dc DatasetClien
 		ver.Downloads = make(map[string]dataset.Download)
 	}
 
-	m := mapper.CreateFilterableLandingPage(ctx, datasetModel, ver, datasetID, opts, dims, displayOtherVersionsLink, bc, latestVersionNumber, latestVersionOfEditionURL)
+	m := mapper.CreateFilterableLandingPage(ctx, datasetModel, ver, datasetID, opts, dims, displayOtherVersionsLink, bc, latestVersionNumber, latestVersionOfEditionURL, cfg.EnableLoop11)
 
 	for i, d := range m.DatasetLandingPage.Version.Downloads {
 		if len(cfg.DownloadServiceURL) > 0 {

--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -368,7 +368,7 @@ func editionsList(w http.ResponseWriter, req *http.Request, dc DatasetClient, zc
 		}
 	}
 
-	m := mapper.CreateEditionsList(ctx, datasetModel, datasetEditions, datasetID, bc)
+	m := mapper.CreateEditionsList(ctx, datasetModel, datasetEditions, datasetID, bc, cfg.EnableLoop11)
 
 	b, err := json.Marshal(m)
 	if err != nil {

--- a/mapper/mapper.go
+++ b/mapper/mapper.go
@@ -334,7 +334,7 @@ func CreateVersionsList(ctx context.Context, d dataset.Model, edition dataset.Ed
 }
 
 // CreateEditionsList creates a editions list page based on api model responses
-func CreateEditionsList(ctx context.Context, d dataset.Model, editions []dataset.Edition, datasetID string, breadcrumbs []data.Breadcrumb) datasetEditionsList.Page {
+func CreateEditionsList(ctx context.Context, d dataset.Model, editions []dataset.Edition, datasetID string, breadcrumbs []data.Breadcrumb, enableLoop11 bool) datasetEditionsList.Page {
 	p := datasetEditionsList.Page{}
 	p.Type = "dataset_edition_list"
 	p.Metadata.Title = d.Title
@@ -343,6 +343,7 @@ func CreateEditionsList(ctx context.Context, d dataset.Model, editions []dataset
 	p.ShowFeedbackForm = true
 	p.DatasetId = datasetID
 	p.BetaBannerEnabled = true
+	p.EnableLoop11 = enableLoop11
 
 	for _, bc := range breadcrumbs {
 		p.Breadcrumb = append(p.Breadcrumb, model.TaxonomyNode{

--- a/mapper/mapper.go
+++ b/mapper/mapper.go
@@ -34,7 +34,7 @@ func (p TimeSlice) Swap(i, j int) {
 }
 
 // CreateFilterableLandingPage creates a filterable dataset landing page based on api model responses
-func CreateFilterableLandingPage(ctx context.Context, d dataset.Model, ver dataset.Version, datasetID string, opts []dataset.Options, dims dataset.Dimensions, displayOtherVersionsLink bool, breadcrumbs []data.Breadcrumb, latestVersionNumber int, latestVersionURL string) datasetLandingPageFilterable.Page {
+func CreateFilterableLandingPage(ctx context.Context, d dataset.Model, ver dataset.Version, datasetID string, opts []dataset.Options, dims dataset.Dimensions, displayOtherVersionsLink bool, breadcrumbs []data.Breadcrumb, latestVersionNumber int, latestVersionURL string, enableLoop11 bool) datasetLandingPageFilterable.Page {
 	p := datasetLandingPageFilterable.Page{}
 	p.Type = "dataset_landing_page"
 	p.Metadata.Title = d.Title
@@ -45,6 +45,7 @@ func CreateFilterableLandingPage(ctx context.Context, d dataset.Model, ver datas
 	p.DatasetId = datasetID
 	p.ReleaseDate = ver.ReleaseDate
 	p.BetaBannerEnabled = true
+	p.EnableLoop11 = enableLoop11
 
 	for _, breadcrumb := range breadcrumbs {
 		p.Page.Breadcrumb = append(p.Page.Breadcrumb, model.TaxonomyNode{
@@ -263,7 +264,7 @@ func CreateFilterableLandingPage(ctx context.Context, d dataset.Model, ver datas
 }
 
 // CreateVersionsList creates a versions list page based on api model responses
-func CreateVersionsList(ctx context.Context, d dataset.Model, edition dataset.Edition, versions []dataset.Version) datasetVersionsList.Page {
+func CreateVersionsList(ctx context.Context, d dataset.Model, edition dataset.Edition, versions []dataset.Version, enableLoop11 bool) datasetVersionsList.Page {
 	var p datasetVersionsList.Page
 	// TODO refactor and make Welsh compatible.
 	p.Metadata.Title = "All versions of " + d.Title
@@ -272,6 +273,7 @@ func CreateVersionsList(ctx context.Context, d dataset.Model, edition dataset.Ed
 	}
 	p.Metadata.Title += " dataset"
 	p.BetaBannerEnabled = true
+	p.EnableLoop11 = enableLoop11
 	uri, err := url.Parse(edition.Links.LatestVersion.URL)
 	if err != nil {
 		log.ErrorCtx(ctx, err, nil)

--- a/mapper/mapper_test.go
+++ b/mapper/mapper_test.go
@@ -115,7 +115,7 @@ func TestUnitMapper(t *testing.T) {
 					},
 				},
 			},
-		}, dataset.Dimensions{}, false, []data.Breadcrumb{breadcrumbItem}, 1, "/datasets/83jd98fkflg/editions/124/versions/1")
+		}, dataset.Dimensions{}, false, []data.Breadcrumb{breadcrumbItem}, 1, "/datasets/83jd98fkflg/editions/124/versions/1", false)
 
 		So(p.Type, ShouldEqual, "dataset_landing_page")
 		So(p.Metadata.Title, ShouldEqual, d.Title)
@@ -206,7 +206,7 @@ func TestCreateVersionsList(t *testing.T) {
 	Convey("test latest version page", t, func() {
 		dummySingleVersionList := []dataset.Version{dummyVersion3}
 
-		page := CreateVersionsList(ctx, dummyModelData, dummyEditionData, dummySingleVersionList)
+		page := CreateVersionsList(ctx, dummyModelData, dummyEditionData, dummySingleVersionList, false)
 		Convey("title", func() {
 			So(page.Metadata.Title, ShouldEqual, "All versions of Consumer Prices Index including owner occupiers? housing costs (CPIH) time-series dataset")
 		})
@@ -215,7 +215,7 @@ func TestCreateVersionsList(t *testing.T) {
 		})
 
 		dummyMultipleVersionList := []dataset.Version{dummyVersion1, dummyVersion2, dummyVersion3}
-		page = CreateVersionsList(ctx, dummyModelData, dummyEditionData, dummyMultipleVersionList)
+		page = CreateVersionsList(ctx, dummyModelData, dummyEditionData, dummyMultipleVersionList, false)
 
 		Convey("has correct number of versions when multiple should be present", func() {
 			So(len(page.Data.Versions), ShouldEqual, 3)

--- a/mapper/mapper_test.go
+++ b/mapper/mapper_test.go
@@ -115,7 +115,7 @@ func TestUnitMapper(t *testing.T) {
 					},
 				},
 			},
-		}, dataset.Dimensions{}, false, []data.Breadcrumb{breadcrumbItem}, 1, "/datasets/83jd98fkflg/editions/124/versions/1", false)
+		}, dataset.Dimensions{}, false, []data.Breadcrumb{breadcrumbItem}, 1, "/datasets/83jd98fkflg/editions/124/versions/1", true)
 
 		So(p.Type, ShouldEqual, "dataset_landing_page")
 		So(p.Metadata.Title, ShouldEqual, d.Title)
@@ -130,6 +130,7 @@ func TestUnitMapper(t *testing.T) {
 		So(p.ShowFeedbackForm, ShouldEqual, true)
 		So(p.Breadcrumb[0].Title, ShouldEqual, breadcrumbItem.Description.Title)
 		So(p.Breadcrumb[0].URI, ShouldEqual, breadcrumbItem.URI)
+		So(p.EnableLoop11, ShouldEqual, true)
 
 		So(len(p.DatasetLandingPage.Dimensions), ShouldEqual, 2)
 		So(p.DatasetLandingPage.Dimensions[0].Title, ShouldEqual, "Age")

--- a/vendor/github.com/ONSdigital/dp-frontend-models/model/page.go
+++ b/vendor/github.com/ONSdigital/dp-frontend-models/model/page.go
@@ -19,4 +19,5 @@ type Page struct {
 	ShowFeedbackForm                 bool           `json:"show_feedback_form"`
 	ReleaseDate                      string         `json:"release_date"`
 	BetaBannerEnabled                bool           `json:"beta_banner_enabled"`
+	EnableLoop11                     bool           `json:"enable_loop11"`
 }

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -45,10 +45,10 @@
 			"revisionTime": "2019-10-25T10:16:01Z"
 		},
 		{
-			"checksumSHA1": "fJkBbYwFJnWgmIhmYaf5Pnt8CNk=",
+			"checksumSHA1": "5PuwTxKjJHFNFEaERgwzM7s6H9s=",
 			"path": "github.com/ONSdigital/dp-frontend-models/model",
-			"revision": "61a4fc32d261a3e49e950290423ec0b8050612a2",
-			"revisionTime": "2019-10-25T12:16:22Z"
+			"revision": "44856264a7b325671330a28436476436e374f098",
+			"revisionTime": "2019-12-04T16:06:58Z"
 		},
 		{
 			"checksumSHA1": "F5fUTKbRADGQSQLT73z6XxeSd2w=",


### PR DESCRIPTION
### What

Implemented a new flag, `ENABLE_LOOP11`, that will toggle the loading of the loop11 script for filter-dataset controller routes. This is set to false by default.

### How to review

1. Pull `feature/add-loop11-flag` branch for `dp-frontend-renderer`, `dp-frontend-models`, `dp-frontend-dataset-controller`, `dp-frontend-filter-dataset-controller` and `dp-geography-controller`.
2. Enable loop11 for each controller by including the flag, `ENABLE_LOOP11=true`
3. Check in network tab that loop11.js is present when visiting the specific pages for that controller.
4. Sense check that the loop11 script isn't loaded when the controller is run without the flag.

### Who can review

Anyone
