### PR TITLE
Fix superseeded versions link

### DIFF
--- a/mapper/mapper.go
+++ b/mapper/mapper.go
@@ -282,7 +282,7 @@ func CreateVersionsList(ctx context.Context, d dataset.Model, edition dataset.Ed
 	p.DatasetId = d.ID
 
 	latestVersionNumber := 1
-	for i, ver := range versions {
+	for _, ver := range versions {
 		var version datasetVersionsList.Version
 		version.IsLatest = false
 		version.VersionNumber = ver.Version
@@ -291,8 +291,10 @@ func CreateVersionsList(ctx context.Context, d dataset.Model, edition dataset.Ed
 		version.VersionURL = fmt.Sprintf("/datasets/%s/editions/%s/versions/%d", ver.Links.Dataset.ID, ver.Edition, ver.Version)
 		version.FilterURL = fmt.Sprintf("/datasets/%s/editions/%s/versions/%d/filter", ver.Links.Dataset.ID, ver.Edition, ver.Version)
 
-		if ver.Version > 1 {
-			version.Superseded = fmt.Sprintf("/datasets/%s/editions/%s/versions/%d", ver.Links.Dataset.ID, ver.Edition, i)
+		// Not the 'created' first version and more than one stored version
+		if ver.Version > 1 && len(p.Data.Versions) >= 1 {
+			previousVersion := p.Data.Versions[len(p.Data.Versions)-1].VersionNumber
+			version.Superseded = fmt.Sprintf("/datasets/%s/editions/%s/versions/%d", ver.Links.Dataset.ID, ver.Edition, previousVersion)
 		}
 
 		if ver.Version > latestVersionNumber {


### PR DESCRIPTION
### What

Issue: 
If a version was deleted then all superseded version numbers would be incorrect and could link to 404 pages
Fix:
- If only 1 version exists then no superseded version is made
- If it is the first version then no superseded version is made
- If a version is deleted then next versions superseded version will now point to prior versions

<img width="1003" alt="Screenshot 2020-01-10 at 13 48 11" src="https://user-images.githubusercontent.com/47502916/72164410-8ddb0c80-33bd-11ea-8449-4ada2876e1f4.png">
<img width="1236" alt="Screenshot 2020-01-10 at 14 22 53" src="https://user-images.githubusercontent.com/47502916/72164411-8ddb0c80-33bd-11ea-88d6-209d53521fc5.png">

### How to review

Create some versions, delete some and check the versions list page

### Who can review

Anyone except me
