### PR TITLE
Bump go version to 1.13.8 and fix ci yml file

### DIFF
--- a/ci/build.yml
+++ b/ci/build.yml
@@ -6,7 +6,7 @@ image_resource:
   type: docker-image
   source:
     repository: golang
-    tags: 1.13.7
+    tag: 1.13.8
 
 inputs:
   - name: dp-frontend-dataset-controller

--- a/ci/unit.yml
+++ b/ci/unit.yml
@@ -6,7 +6,7 @@ image_resource:
   type: docker-image
   source:
     repository: golang
-    tag: 1.13.7
+    tag: 1.13.8
 
 inputs:
   - name: dp-frontend-dataset-controller


### PR DESCRIPTION
### What

Bump go version to 1.13.8 and fix ci yml files

Use field tag to set ci go version instead of non-functioning `tags` field

### How to review

N/A

### Who can review

Anyone
