### PR TITLE
Feature/json ld implementation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.13
 require (
 	github.com/ONSdigital/dp-api-clients-go v1.4.0
 	github.com/ONSdigital/dp-cookies v0.0.0-20200218165833-32f13bf75fbb
-	github.com/ONSdigital/dp-frontend-models v1.4.2
+	github.com/ONSdigital/dp-frontend-models v1.5.0
 	github.com/ONSdigital/dp-healthcheck v1.0.0
 	github.com/ONSdigital/go-ns v0.0.0-20200205115900-a11716f93bad
 	github.com/ONSdigital/log.go v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -10,6 +10,8 @@ github.com/ONSdigital/dp-frontend-models v1.4.1 h1:zaBwBe1Z15iRnPCrYd7FNWfJb7Vq0
 github.com/ONSdigital/dp-frontend-models v1.4.1/go.mod h1:TT96P7Mi69N3Tc/jFNdbjiwG4GAaMjP26HLotFQ6BPw=
 github.com/ONSdigital/dp-frontend-models v1.4.2 h1:GL5ykEYnMRzM7qutSnQuKUXI8LLi3d+iH2MUfTLz9OQ=
 github.com/ONSdigital/dp-frontend-models v1.4.2/go.mod h1:TT96P7Mi69N3Tc/jFNdbjiwG4GAaMjP26HLotFQ6BPw=
+github.com/ONSdigital/dp-frontend-models v1.5.0 h1:FZngursXY984WuCW5x4+VzyDOkoEUQleh3OT4/w1NNU=
+github.com/ONSdigital/dp-frontend-models v1.5.0/go.mod h1:K4n0EwATkzbuWzSajBHja+uc9zvqnKiq6WtUwLav4Kg=
 github.com/ONSdigital/dp-healthcheck v0.0.0-20200131122546-9db6d3f0494e/go.mod h1:zighxZ/0m5u7zo0eAr8XFlA+Dz2ic7A1vna6YXvhCjQ=
 github.com/ONSdigital/dp-healthcheck v0.0.0-20200219161048-205cb782aff1/go.mod h1:zighxZ/0m5u7zo0eAr8XFlA+Dz2ic7A1vna6YXvhCjQ=
 github.com/ONSdigital/dp-healthcheck v1.0.0 h1:bySQU8kQRs4n3WbgH8QtVwCJLqG9ri722saATjvNNfc=
@@ -25,6 +27,7 @@ github.com/ONSdigital/log.go v0.0.0-20191127134126-2a610b254f20/go.mod h1:BD7D8F
 github.com/ONSdigital/log.go v1.0.0 h1:hZQTuitFv4nSrpzMhpGvafUC5/8xMVnLI0CWe1rAJNc=
 github.com/ONSdigital/log.go v1.0.0/go.mod h1:UnGu9Q14gNC+kz0DOkdnLYGoqugCvnokHBRBxFRpVoQ=
 github.com/eknkc/amber v0.0.0-20171010120322-cdade1c07385/go.mod h1:0vRUJqYpeSZifjYj7uP3BG/gKcuzL9xWVV/Y+cK33KM=
+github.com/facebookgo/freeport v0.0.0-20150612182905-d4adf43b75b9 h1:wWke/RUCl7VRjQhwPlR/v0glZXNYzBHdNUzf/Am2Nmg=
 github.com/facebookgo/freeport v0.0.0-20150612182905-d4adf43b75b9/go.mod h1:uPmAp6Sws4L7+Q/OokbWDAK1ibXYhB3PXFP1kol5hPg=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fatih/color v1.9.0 h1:8xPHl4/q1VyqGIPif1F+1V3Y3lSmrq01EabUW3CoW5s=
@@ -33,6 +36,7 @@ github.com/go-avro/avro v0.0.0-20171219232920-444163702c11/go.mod h1:kxj6THYP0dm
 github.com/golang/mock v1.3.1/go.mod h1:sBzyDLLjw3U8JLTeZvSv8jJB+tU5PVekmnlKIyFUx0Y=
 github.com/golang/mock v1.4.0 h1:Rd1kQnQu0Hq3qvJppYSG0HtP+f5LPPUiDswTLiEegLg=
 github.com/golang/mock v1.4.0/go.mod h1:UOMv5ysSaYNkG+OFQykRIcU/QvvxJf3p21QfJ2Bt3cw=
+github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1 h1:EGx4pi6eqNxGaHF6qqu48+N2wcFQ5qg5FXgOdqsJ5d8=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
 github.com/gorilla/mux v1.7.3/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
 github.com/gorilla/mux v1.7.4 h1:VuZ8uybHlWmqV03+zRzdwKL4tUnIp1MAQtp1mIFE1bc=
@@ -67,6 +71,7 @@ golang.org/x/net v0.0.0-20191209160850-c0dbc17a3553/go.mod h1:z5CRVTTTmAJ677TzLL
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190222072716-a9d3bda3a223/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/sys v0.0.0-20191026070338-33540a1f6037 h1:YyJpGZS1sBuBCzLAR1VEpK193GlqGZbnPFnPV/5Rsb4=
 golang.org/x/sys v0.0.0-20191026070338-33540a1f6037/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/mapper/legacy.go
+++ b/mapper/legacy.go
@@ -23,11 +23,18 @@ func CreateLegacyDatasetLanding(ctx context.Context, req *http.Request, dlp zebe
 
 	MapCookiePreferences(req, &sdlp.CookiesPreferencesSet, &sdlp.CookiesPolicy)
 
-	sdlp.Type = dlp.Type
+	// Prepend 'legacy_' to type value to make it easier to differentiate between
+	// filterable and legacy dataset pages - their models are different
+	var pageType strings.Builder
+	pageType.WriteString("legacy_")
+	pageType.WriteString(dlp.Type)
+
+	sdlp.Type = pageType.String()
 	sdlp.URI = dlp.URI
 	sdlp.Metadata.Title = dlp.Description.Title
 	sdlp.Metadata.Description = dlp.Description.Summary
 	sdlp.Language = localeCode
+	sdlp.HasJSONLD = true
 
 	for _, d := range dlp.RelatedDatasets {
 		sdlp.DatasetLandingPage.Related.Datasets = append(sdlp.DatasetLandingPage.Related.Datasets, model.Related(d))

--- a/mapper/legacy_test.go
+++ b/mapper/legacy_test.go
@@ -21,7 +21,7 @@ func TestUnitMapperLegacy(t *testing.T) {
 		sdlp := CreateLegacyDatasetLanding(ctx, req, dlp, bcs, ds, lang)
 		So(sdlp, ShouldNotBeEmpty)
 
-		So(sdlp.Type, ShouldEqual, dlp.Type)
+		So(sdlp.Type, ShouldEqual, "legacy_dataset")
 		So(sdlp.URI, ShouldEqual, dlp.URI)
 		So(sdlp.Metadata.Title, ShouldEqual, dlp.Description.Title)
 		So(sdlp.Metadata.Description, ShouldEqual, dlp.Description.Summary)

--- a/mapper/mapper.go
+++ b/mapper/mapper.go
@@ -17,6 +17,7 @@ import (
 	"github.com/ONSdigital/dp-frontend-models/model/datasetEditionsList"
 	"github.com/ONSdigital/dp-frontend-models/model/datasetLandingPageFilterable"
 	"github.com/ONSdigital/dp-frontend-models/model/datasetVersionsList"
+
 	"github.com/ONSdigital/log.go/log"
 )
 
@@ -48,6 +49,7 @@ func CreateFilterableLandingPage(ctx context.Context, req *http.Request, d datas
 	p.DatasetId = datasetID
 	p.ReleaseDate = ver.ReleaseDate
 	p.BetaBannerEnabled = true
+	p.HasJSONLD = true
 
 	for _, breadcrumb := range breadcrumbs {
 		p.Page.Breadcrumb = append(p.Page.Breadcrumb, model.TaxonomyNode{


### PR DESCRIPTION
### What

- Updated `dp-frontend-models` version to `v1.5.0`
- Appended `legacy_` to Legacy Dataset Landing Page type in order to differentiate it from the filterable landing page. This is because the data in each of their models is different, and so the JSONLD builder needed to know the distinction in order to render the correct data.
- Added `HasJSONLD` to relevant mappers

### How to review

- Ensure that `dp-frontend-dataset-controller` is running on branch `feature/json-ld-implementation`
- Ensure that `dp-frontend-models` has been pulled and both renderer and the dataset controller are using `v1.5.0` of the models
- run the renderer with `make debug ENABLE_JSONLD_CONTROL=true`
- run `dp-frontend-router` with `make debug DATASET_ROUTES_ENABLED=true`

- Once all running, visit the relevant pages - legacy dataset landing page, filterable dataset landing page and dataset timeseries page. On each page you should see within the `<head>` a script with `type="application/ld+json"` - review the contents of that script
- Ensure that the json is valid
- Ensure that the fields broadly align with that which are in GTM

- Check that code changes make sense

### Who can review

Anyone but me