### PR TITLE
Update legacy dataset page release date to ISO8601 format for JSON-LD tags

### DIFF
--- a/mapper/legacy.go
+++ b/mapper/legacy.go
@@ -70,7 +70,7 @@ func CreateLegacyDatasetLanding(ctx context.Context, req *http.Request, dlp zebe
 			log.Event(ctx, "failed to parse release date", log.Error(err), log.Data{"release_date": dlp.Description.ReleaseDate})
 			sdlp.DatasetLandingPage.ReleaseDate = dlp.Description.ReleaseDate
 		}
-		sdlp.DatasetLandingPage.ReleaseDate = releaseDateInTimeFormat.Add(1 * time.Hour).Format("02 January 2006")
+		sdlp.DatasetLandingPage.ReleaseDate = releaseDateInTimeFormat.Add(1 * time.Hour).Format(time.RFC3339)
 	} else {
 		sdlp.DatasetLandingPage.ReleaseDate = dlp.Description.ReleaseDate
 	}


### PR DESCRIPTION
### What

A fix for a publishing support issue was implemented where if Legacy publications had a release time of `23:00`, an additional hour would be added on so that the publication would have the correct release date. I believe this was an issue of saving the date based on GMT/BST rather than UTC

Currently that date was being updated and saved in the format, `DD Month YYYY`. This PR updates the format saved to be `RFC3339`, which is a profile of the ISO8601 date/time format.

The reason for this change is so the JSON-LD tags can have the `releaseDate` property stored in the correct format. In `dp-frontend-renderer`, we have a `dateFormat` helper function which will parse `RFC3339` into the `DD Month YYYY` format anyway, so any place on the Legacy page where we mention the Release Date will still be displayed as it should be

### How to review

- Check that the code change makes sense
- Go to a legacy dataset landing page (e.g. http://localhost:8081/economy/economicoutputandproductivity/output/datasets/indexofproduction) and ensure the release date is correctly formatted and that it is the right date
- You can check to see if the release date is correct by commenting out the hack fix in `legacy.go` (lines 66 - 77) and replacing it with `sdlp.DatasetLandingPage.ReleaseDate = dlp.Description.ReleaseDate`
- This should then show the release date to be a day before what it actually is, assuming that the legacy dataset page in question had a release time of `23:00`

### Who can review

Anyone but me
