### PR TITLE
Trim version from path, if present in the breadcrumbs

### DIFF
--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -135,9 +135,9 @@ func FilterableLanding(dc DatasetClient, rend RenderClient, zc ZebedeeClient, cf
 }
 
 // EditionsList will load a list of editions for a filterable dataset
-func EditionsList(dc DatasetClient, zc ZebedeeClient, rend RenderClient, cfg config.Config) http.HandlerFunc {
+func EditionsList(dc DatasetClient, zc ZebedeeClient, rend RenderClient, cfg config.Config, apiRouterVersion string) http.HandlerFunc {
 	return handlers.ControllerHandler(func(w http.ResponseWriter, req *http.Request, lang, collectionID, userAccessToken string) {
-		editionsList(w, req, dc, zc, rend, cfg, collectionID, lang, userAccessToken)
+		editionsList(w, req, dc, zc, rend, cfg, collectionID, lang, apiRouterVersion, userAccessToken)
 	})
 }
 
@@ -320,7 +320,7 @@ func filterableLanding(w http.ResponseWriter, req *http.Request, dc DatasetClien
 
 }
 
-func editionsList(w http.ResponseWriter, req *http.Request, dc DatasetClient, zc ZebedeeClient, rend RenderClient, cfg config.Config, collectionID, lang, userAccessToken string) {
+func editionsList(w http.ResponseWriter, req *http.Request, dc DatasetClient, zc ZebedeeClient, rend RenderClient, cfg config.Config, collectionID, lang, apiRouterVersion, userAccessToken string) {
 	vars := mux.Vars(req)
 	datasetID := vars["datasetID"]
 	ctx := req.Context()
@@ -353,7 +353,7 @@ func editionsList(w http.ResponseWriter, req *http.Request, dc DatasetClient, zc
 		http.Redirect(w, req, latestVersionPath, 302)
 	}
 
-	m := mapper.CreateEditionsList(ctx, req, datasetModel, datasetEditions, datasetID, bc, lang)
+	m := mapper.CreateEditionsList(ctx, req, datasetModel, datasetEditions, datasetID, bc, lang, apiRouterVersion)
 
 	b, err := json.Marshal(m)
 	if err != nil {

--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -128,9 +128,9 @@ func LegacyLanding(zc ZebedeeClient, dc DatasetClient, rend RenderClient, cfg co
 }
 
 // FilterableLanding will load a filterable landing page
-func FilterableLanding(dc DatasetClient, rend RenderClient, zc ZebedeeClient, cfg config.Config) http.HandlerFunc {
+func FilterableLanding(dc DatasetClient, rend RenderClient, zc ZebedeeClient, cfg config.Config, apiRouterVersion string) http.HandlerFunc {
 	return handlers.ControllerHandler(func(w http.ResponseWriter, req *http.Request, lang, collectionID, userAccessToken string) {
-		filterableLanding(w, req, dc, rend, zc, cfg, collectionID, lang, userAccessToken)
+		filterableLanding(w, req, dc, rend, zc, cfg, collectionID, lang, apiRouterVersion, userAccessToken)
 	})
 }
 
@@ -188,7 +188,7 @@ func versionsList(w http.ResponseWriter, req *http.Request, dc DatasetClient, re
 	w.Write(templateHTML)
 }
 
-func filterableLanding(w http.ResponseWriter, req *http.Request, dc DatasetClient, rend RenderClient, zc ZebedeeClient, cfg config.Config, collectionID, lang, userAccessToken string) {
+func filterableLanding(w http.ResponseWriter, req *http.Request, dc DatasetClient, rend RenderClient, zc ZebedeeClient, cfg config.Config, collectionID, lang, apiRouterVersion, userAccessToken string) {
 	vars := mux.Vars(req)
 	datasetID := vars["datasetID"]
 	edition := vars["editionID"]
@@ -279,7 +279,7 @@ func filterableLanding(w http.ResponseWriter, req *http.Request, dc DatasetClien
 		ver.Downloads = make(map[string]dataset.Download)
 	}
 
-	m := mapper.CreateFilterableLandingPage(ctx, req, datasetModel, ver, datasetID, opts, dims, displayOtherVersionsLink, bc, latestVersionNumber, latestVersionOfEditionURL, lang)
+	m := mapper.CreateFilterableLandingPage(ctx, req, datasetModel, ver, datasetID, opts, dims, displayOtherVersionsLink, bc, latestVersionNumber, latestVersionOfEditionURL, lang, apiRouterVersion)
 
 	for i, d := range m.DatasetLandingPage.Version.Downloads {
 		if len(cfg.DownloadServiceURL) > 0 {

--- a/handlers/handlers_test.go
+++ b/handlers/handlers_test.go
@@ -276,7 +276,7 @@ func TestUnitHandlers(t *testing.T) {
 			req := httptest.NewRequest("GET", "/datasets/12345", nil)
 
 			router := mux.NewRouter()
-			router.HandleFunc("/datasets/{datasetID}", FilterableLanding(mockClient, mockRend, mockZebedeeClient, mockConfig))
+			router.HandleFunc("/datasets/{datasetID}", FilterableLanding(mockClient, mockRend, mockZebedeeClient, mockConfig, ""))
 
 			router.ServeHTTP(w, req)
 
@@ -294,7 +294,7 @@ func TestUnitHandlers(t *testing.T) {
 			req := httptest.NewRequest("GET", "/datasets/12345", nil)
 
 			router := mux.NewRouter()
-			router.HandleFunc("/datasets/{datasetID}", FilterableLanding(mockClient, nil, mockZebedeeClient, mockConfig))
+			router.HandleFunc("/datasets/{datasetID}", FilterableLanding(mockClient, nil, mockZebedeeClient, mockConfig, "/v1"))
 
 			router.ServeHTTP(w, req)
 
@@ -314,7 +314,7 @@ func TestUnitHandlers(t *testing.T) {
 			req := httptest.NewRequest("GET", "/datasets/12345/editions/5678", nil)
 
 			router := mux.NewRouter()
-			router.HandleFunc("/datasets/{datasetID}/editions/{editionID}", FilterableLanding(mockClient, nil, mockZebedeeClient, mockConfig))
+			router.HandleFunc("/datasets/{datasetID}/editions/{editionID}", FilterableLanding(mockClient, nil, mockZebedeeClient, mockConfig, "/v1"))
 
 			router.ServeHTTP(w, req)
 
@@ -340,7 +340,7 @@ func TestUnitHandlers(t *testing.T) {
 			req := httptest.NewRequest("GET", "/datasets/12345/editions/5678/versions/1", nil)
 
 			router := mux.NewRouter()
-			router.HandleFunc("/datasets/{datasetID}/editions/{editionID}/versions/{versionID}", FilterableLanding(mockClient, mockRend, mockZebedeeClient, mockConfig))
+			router.HandleFunc("/datasets/{datasetID}/editions/{editionID}/versions/{versionID}", FilterableLanding(mockClient, mockRend, mockZebedeeClient, mockConfig, "/v1"))
 
 			router.ServeHTTP(w, req)
 

--- a/helpers/helpers.go
+++ b/helpers/helpers.go
@@ -2,6 +2,7 @@ package helpers
 
 import (
 	"fmt"
+	"net/url"
 	"regexp"
 )
 
@@ -16,6 +17,16 @@ func ExtractDatasetInfoFromPath(path string) (datasetID, edition, version string
 	return subs[1], subs[2], subs[3], nil
 }
 
+// DatasetVersionUrl constructs a dataset version URL from the provided datasetID, edition and version values
 func DatasetVersionUrl(datasetID string, edition string, version string) string {
 	return fmt.Sprintf("/datasets/%s/editions/%s/versions/%s", datasetID, edition, version)
+}
+
+// GetAPIRouterVersion returns the path of the provided url, which corresponds to the api router version
+func GetAPIRouterVersion(rawurl string) (string, error) {
+	apiRouterURL, err := url.Parse(rawurl)
+	if err != nil {
+		return "", err
+	}
+	return apiRouterURL.Path, nil
 }

--- a/helpers/helpers_test.go
+++ b/helpers/helpers_test.go
@@ -1,6 +1,7 @@
 package helpers
 
 import (
+	"net/url"
 	"testing"
 
 	. "github.com/smartystreets/goconvey/convey"
@@ -23,5 +24,37 @@ func TestUnitHelpers(t *testing.T) {
 			So(edition, ShouldEqual, "")
 			So(version, ShouldEqual, "")
 		})
+	})
+}
+
+func TestDatasetVerionURL(t *testing.T) {
+	Convey("The dataset version URL is correctly constructed from the provided parameters", t, func() {
+		So(DatasetVersionUrl("myDataset", "myEdition", "myVersion"), ShouldResemble,
+			"/datasets/myDataset/editions/myEdition/versions/myVersion")
+	})
+}
+
+func TestGetAPIRouterVersion(t *testing.T) {
+
+	Convey("The api router version is correctly extracted from a valid API Router URL", t, func() {
+		version, err := GetAPIRouterVersion("http://localhost:23200/v1")
+		So(err, ShouldBeNil)
+		So(version, ShouldEqual, "/v1")
+	})
+
+	Convey("An empty string version is extracted from a valid unversioned API Router URL", t, func() {
+		version, err := GetAPIRouterVersion("http://localhost:23200")
+		So(err, ShouldBeNil)
+		So(version, ShouldEqual, "")
+	})
+
+	Convey("Extracting a version from an invalid API Router URL results in the parsing error being returned", t, func() {
+		version, err := GetAPIRouterVersion("hello%goodbye")
+		So(err, ShouldResemble, &url.Error{
+			Op:  "parse",
+			URL: "hello%goodbye",
+			Err: url.EscapeError("%go"),
+		})
+		So(version, ShouldEqual, "")
 	})
 }

--- a/main.go
+++ b/main.go
@@ -14,6 +14,7 @@ import (
 	"github.com/ONSdigital/dp-api-clients-go/zebedee"
 	"github.com/ONSdigital/dp-frontend-dataset-controller/config"
 	"github.com/ONSdigital/dp-frontend-dataset-controller/handlers"
+	"github.com/ONSdigital/dp-frontend-dataset-controller/helpers"
 	health "github.com/ONSdigital/dp-healthcheck/healthcheck"
 	"github.com/ONSdigital/log.go/log"
 	"github.com/gorilla/mux"
@@ -64,14 +65,21 @@ func run(ctx context.Context) error {
 	signals := make(chan os.Signal, 1)
 	signal.Notify(signals, os.Interrupt, os.Kill)
 
+	// Get config
 	cfg, err := config.Get()
 	if err != nil {
 		log.Event(ctx, "unable to retrieve service configuration", log.ERROR, log.Error(err))
 		return err
 	}
-
 	log.Event(ctx, "got service configuration", log.INFO, log.Data{"config": cfg})
 
+	// Get API version from its URL
+	apiRouterVersion, err := helpers.GetAPIRouterVersion(cfg.APIRouterURL)
+	if err != nil {
+		return err
+	}
+
+	// Healthcheck version Info
 	versionInfo, err := health.NewVersionInfo(
 		BuildTime,
 		GitCommit,
@@ -107,9 +115,9 @@ func run(ctx context.Context) error {
 
 	router.StrictSlash(true).Path("/datasets/{datasetID}").Methods("GET").HandlerFunc(handlers.EditionsList(dc, zc, rend, *cfg))
 	router.StrictSlash(true).Path("/datasets/{datasetID}/editions").Methods("GET").HandlerFunc(handlers.EditionsList(dc, zc, rend, *cfg))
-	router.StrictSlash(true).Path("/datasets/{datasetID}/editions/{editionID}").Methods("GET").HandlerFunc(handlers.FilterableLanding(dc, rend, zc, *cfg))
+	router.StrictSlash(true).Path("/datasets/{datasetID}/editions/{editionID}").Methods("GET").HandlerFunc(handlers.FilterableLanding(dc, rend, zc, *cfg, apiRouterVersion))
 	router.StrictSlash(true).Path("/datasets/{datasetID}/editions/{edition}/versions").Methods("GET").HandlerFunc(handlers.VersionsList(dc, rend, *cfg))
-	router.StrictSlash(true).Path("/datasets/{datasetID}/editions/{editionID}/versions/{versionID}").Methods("GET").HandlerFunc(handlers.FilterableLanding(dc, rend, zc, *cfg))
+	router.StrictSlash(true).Path("/datasets/{datasetID}/editions/{editionID}/versions/{versionID}").Methods("GET").HandlerFunc(handlers.FilterableLanding(dc, rend, zc, *cfg, apiRouterVersion))
 	router.StrictSlash(true).Path("/datasets/{datasetID}/editions/{edition}/versions/{version}/metadata.txt").Methods("GET").HandlerFunc(handlers.MetadataText(dc, *cfg))
 
 	router.StrictSlash(true).Path("/datasets/{datasetID}/editions/{editionID}/versions/{versionID}/filter").Methods("POST").HandlerFunc(handlers.CreateFilterID(f, dc, *cfg))

--- a/main.go
+++ b/main.go
@@ -113,8 +113,8 @@ func run(ctx context.Context) error {
 
 	router.StrictSlash(true).Path("/health").HandlerFunc(healthcheck.Handler)
 
-	router.StrictSlash(true).Path("/datasets/{datasetID}").Methods("GET").HandlerFunc(handlers.EditionsList(dc, zc, rend, *cfg))
-	router.StrictSlash(true).Path("/datasets/{datasetID}/editions").Methods("GET").HandlerFunc(handlers.EditionsList(dc, zc, rend, *cfg))
+	router.StrictSlash(true).Path("/datasets/{datasetID}").Methods("GET").HandlerFunc(handlers.EditionsList(dc, zc, rend, *cfg, apiRouterVersion))
+	router.StrictSlash(true).Path("/datasets/{datasetID}/editions").Methods("GET").HandlerFunc(handlers.EditionsList(dc, zc, rend, *cfg, apiRouterVersion))
 	router.StrictSlash(true).Path("/datasets/{datasetID}/editions/{editionID}").Methods("GET").HandlerFunc(handlers.FilterableLanding(dc, rend, zc, *cfg, apiRouterVersion))
 	router.StrictSlash(true).Path("/datasets/{datasetID}/editions/{edition}/versions").Methods("GET").HandlerFunc(handlers.VersionsList(dc, rend, *cfg))
 	router.StrictSlash(true).Path("/datasets/{datasetID}/editions/{editionID}/versions/{versionID}").Methods("GET").HandlerFunc(handlers.FilterableLanding(dc, rend, zc, *cfg, apiRouterVersion))

--- a/mapper/mapper_test.go
+++ b/mapper/mapper_test.go
@@ -74,13 +74,13 @@ func TestUnitMapper(t *testing.T) {
 
 		// breadcrumbItem returned by zebedee after being proxied through API router
 		breadcrumbItem0 := zebedee.Breadcrumb{
-			URI:         "/v1/economy/grossdomesticproduct/datasets/gdpjanuary2018",
+			URI:         "http://myHost:1234/v1/economy/grossdomesticproduct/datasets/gdpjanuary2018",
 			Description: zebedee.NodeDescription{Title: "GDP: January 2018"},
 		}
 
 		// breadcrumbItem as expected as a result of CreateFilterableLandingPage
 		expectedBreadcrumbItem0 := zebedee.Breadcrumb{
-			URI:         "/economy/grossdomesticproduct/datasets/gdpjanuary2018",
+			URI:         "http://myHost:1234/economy/grossdomesticproduct/datasets/gdpjanuary2018",
 			Description: zebedee.NodeDescription{Title: "GDP: January 2018"},
 		}
 


### PR DESCRIPTION
### What

- Added apiRouterVersion (obtained from parsing the config API Router URL value)
- Use apiRouterVersion to trim any path that contains it, as returned Zebedee calls that are proxied through the API router
(Observation: maybe we should reconsider the interceptor in the API router, but I don't know what else is using it)
- Modified existing unit tests, with breadcrumbs containing the version path prefix, to test the mapper.

### How to review

- Make sure code changes make sense
- Make sure unit tests pass and cover new functionality

### Who can review

Anyone