### PR TITLE
used batch processing for metadata file generation

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -23,6 +23,8 @@ type Config struct {
 	GracefulShutdownTimeout    time.Duration `envconfig:"GRACEFUL_SHUTDOWN_TIMEOUT"`
 	HealthCheckInterval        time.Duration `envconfig:"HEALTHCHECK_INTERVAL"`
 	HealthCheckCriticalTimeout time.Duration `envconfig:"HEALTHCHECK_CRITICAL_TIMEOUT"`
+	BatchSizeLimit             int           `envconfig:"BATCH_SIZE_LIMIT"`
+	BatchMaxWorkers            int           `envconfig:"BATCH_MAX_WORKERS"`
 	EnableProfiler             bool          `envconfig:"ENABLE_PROFILER"`
 	PprofToken                 string        `envconfig:"PPROF_TOKEN" json:"-"`
 }
@@ -44,6 +46,8 @@ func Get() (cfg *Config, err error) {
 		GracefulShutdownTimeout:    5 * time.Second,
 		HealthCheckInterval:        30 * time.Second,
 		HealthCheckCriticalTimeout: 90 * time.Second,
+		BatchSizeLimit:             1000, // maximum limit value to get items from APIs in a single call
+		BatchMaxWorkers:            100,  // maximum number of concurrent go-routines requesting items from APIs with pagination
 		EnableProfiler:             false,
 	}
 

--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -30,7 +30,6 @@ import (
 
 const dataEndpoint = `\/data$`
 const numOptsSummary = 50
-const maxMetadataOptions = 1000
 
 // To mock interfaces in this file
 //go:generate mockgen -source=handlers.go -destination=mock_handlers.go -package=handlers github.com/ONSdigital/dp-frontend-dataset-controller/handlers FilterClient,DatasetClient,RenderClient
@@ -51,6 +50,7 @@ type DatasetClient interface {
 	GetVersionMetadata(ctx context.Context, userAuthToken, serviceAuthToken, collectionID, id, edition, version string) (m dataset.Metadata, err error)
 	GetVersionDimensions(ctx context.Context, userAuthToken, serviceAuthToken, collectionID, id, edition, version string) (m dataset.VersionDimensions, err error)
 	GetOptions(ctx context.Context, userAuthToken, serviceAuthToken, collectionID, id, edition, version, dimension string, q dataset.QueryParams) (m dataset.Options, err error)
+	GetOptionsInBatches(ctx context.Context, userAuthToken, serviceAuthToken, collectionID, id, edition, version, dimension string, batchSize, maxWorkers int) (opts dataset.Options, err error)
 }
 
 // RenderClient is an interface with methods for require for rendering a template
@@ -64,14 +64,8 @@ type ClientError interface {
 	Code() int
 }
 
-// errTooManyOptions is an error returned when a request can't complete because the dimension has too many options
-var errTooManyOptions = errors.New("too many options in dimension")
-
 func setStatusCode(req *http.Request, w http.ResponseWriter, err error) {
 	status := http.StatusInternalServerError
-	if err == errTooManyOptions {
-		status = http.StatusRequestEntityTooLarge
-	}
 	if err, ok := err.(ClientError); ok {
 		if err.Code() == http.StatusNotFound {
 			status = err.Code()
@@ -290,13 +284,11 @@ func filterableLanding(w http.ResponseWriter, req *http.Request, dc DatasetClien
 		return
 	}
 
-	// get metadata file content. If a dimension has too many options, ignore the error and a size 0 will be shown to the user
+	// get metadata file content
 	textBytes, err := getText(dc, userAccessToken, collectionID, datasetID, edition, version, metadata, dims, req, cfg)
 	if err != nil {
-		if err != errTooManyOptions {
-			setStatusCode(req, w, err)
-			return
-		}
+		setStatusCode(req, w, err)
+		return
 	}
 
 	if ver.Downloads == nil {
@@ -513,10 +505,12 @@ func metadataText(w http.ResponseWriter, req *http.Request, dc DatasetClient, cf
 		return
 	}
 
+	metadataFileSize := strconv.Itoa(len(b))
+
 	w.Header().Set("Content-Type", "plain/text")
+	w.Header().Set("Content-Length", metadataFileSize)
 
 	w.Write(b)
-
 }
 
 // getText gets a byte array containing the metadata content, based on options returned by dataset API.
@@ -528,13 +522,9 @@ func getText(dc DatasetClient, userAccessToken, collectionID, datasetID, edition
 	b.WriteString("Dimensions:\n")
 
 	for _, dimension := range dimensions.Items {
-		q := dataset.QueryParams{Offset: 0, Limit: maxMetadataOptions}
-		options, err := dc.GetOptions(req.Context(), userAccessToken, "", collectionID, datasetID, edition, version, dimension.Name, q)
+		options, err := dc.GetOptionsInBatches(req.Context(), userAccessToken, "", collectionID, datasetID, edition, version, dimension.Name, cfg.BatchSizeLimit, cfg.BatchMaxWorkers)
 		if err != nil {
 			return nil, err
-		}
-		if options.TotalCount > maxMetadataOptions {
-			return []byte{}, errTooManyOptions
 		}
 
 		b.WriteString(options.String())

--- a/handlers/handlers_test.go
+++ b/handlers/handlers_test.go
@@ -266,7 +266,10 @@ func TestUnitHandlers(t *testing.T) {
 		Convey("test filterable landing page is successful, when it receives good dataset api responses", func() {
 			mockZebedeeClient := NewMockZebedeeClient(mockCtrl)
 			mockClient := NewMockDatasetClient(mockCtrl)
-			mockConfig := config.Config{}
+			mockConfig := config.Config{
+				BatchSizeLimit:  1000,
+				BatchMaxWorkers: 100,
+			}
 			mockClient.EXPECT().Get(ctx, userAuthToken, serviceAuthToken, collectionID, "12345").Return(dataset.DatasetDetails{Contacts: &[]dataset.Contact{{Name: "Matt"}}, URI: "/economy/grossdomesticproduct/datasets/gdpjanuary2018", Links: dataset.Links{LatestVersion: dataset.Link{URL: "/datasets/1234/editions/5678/versions/2017"}}}, nil)
 			versions := []dataset.Version{{ReleaseDate: "02-01-2005", Links: dataset.Links{Self: dataset.Link{URL: "/datasets/12345/editions/2016/versions/1"}}}}
 			mockClient.EXPECT().GetVersions(ctx, userAuthToken, serviceAuthToken, collectionID, "", "12345", "5678").Return(versions, nil)
@@ -282,8 +285,8 @@ func TestUnitHandlers(t *testing.T) {
 			mockClient.EXPECT().GetOptions(ctx, userAuthToken, serviceAuthToken, collectionID, "12345", "5678", "2017", "aggregate",
 				dataset.QueryParams{Offset: 0, Limit: numOptsSummary}).Return(datasetOptions(0, numOptsSummary), nil)
 			mockClient.EXPECT().GetVersionMetadata(ctx, userAuthToken, serviceAuthToken, collectionID, "12345", "5678", "2017")
-			mockClient.EXPECT().GetOptions(ctx, userAuthToken, serviceAuthToken, collectionID, "12345", "5678", "2017", "aggregate",
-				dataset.QueryParams{Offset: 0, Limit: maxMetadataOptions}).Return(datasetOptions(0, maxMetadataOptions), nil)
+			mockClient.EXPECT().GetOptionsInBatches(ctx, userAuthToken, serviceAuthToken, collectionID, "12345", "5678", "2017", "aggregate",
+				mockConfig.BatchSizeLimit, mockConfig.BatchMaxWorkers).Return(datasetOptions(0, 1000), nil)
 			mockZebedeeClient.EXPECT().GetBreadcrumb(ctx, userAuthToken, collectionID, locale, "")
 
 			mockRend := NewMockRenderClient(mockCtrl)

--- a/handlers/mock_handlers.go
+++ b/handlers/mock_handlers.go
@@ -208,6 +208,21 @@ func (mr *MockDatasetClientMockRecorder) GetOptions(ctx, userAuthToken, serviceA
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetOptions", reflect.TypeOf((*MockDatasetClient)(nil).GetOptions), ctx, userAuthToken, serviceAuthToken, collectionID, id, edition, version, dimension, q)
 }
 
+// GetOptionsInBatches mocks base method
+func (m *MockDatasetClient) GetOptionsInBatches(ctx context.Context, userAuthToken, serviceAuthToken, collectionID, id, edition, version, dimension string, batchSize, maxWorkers int) (dataset.Options, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetOptionsInBatches", ctx, userAuthToken, serviceAuthToken, collectionID, id, edition, version, dimension, batchSize, maxWorkers)
+	ret0, _ := ret[0].(dataset.Options)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetOptionsInBatches indicates an expected call of GetOptionsInBatches
+func (mr *MockDatasetClientMockRecorder) GetOptionsInBatches(ctx, userAuthToken, serviceAuthToken, collectionID, id, edition, version, dimension, batchSize, maxWorkers interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetOptionsInBatches", reflect.TypeOf((*MockDatasetClient)(nil).GetOptionsInBatches), ctx, userAuthToken, serviceAuthToken, collectionID, id, edition, version, dimension, batchSize, maxWorkers)
+}
+
 // MockRenderClient is a mock of RenderClient interface
 type MockRenderClient struct {
 	ctrl     *gomock.Controller


### PR DESCRIPTION
### What

After testing the metadata file generation 'on-the-fly' with >200,000 options per dimension, I didn't see a huge performance impact. In this task, the metadata file generation is reintroduced using get options in batches
- Get options from dataset API in batches
- Introduced config for batch size and number of concurrent workers.
- Removed errTooManyOptions error

### How to review

- Make sure code changes make sense
- Make sure unit tests pass
- Information: I tested it locally by artificially returning 200,000 options per dimension for CPIH datasets. The file was around 16MB and could be handled without any issue.

### Who can review

anyone