### PR TITLE
pass query paramters only when necessary

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/ONSdigital/dp-frontend-dataset-controller
 go 1.13
 
 require (
-	github.com/ONSdigital/dp-api-clients-go v1.33.1-0.20210209135727-f314fa537677
+	github.com/ONSdigital/dp-api-clients-go v1.33.3
 	github.com/ONSdigital/dp-cookies v0.1.0
 	github.com/ONSdigital/dp-frontend-models v1.9.1
 	github.com/ONSdigital/dp-healthcheck v1.0.5

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/ONSdigital/dp-frontend-dataset-controller
 go 1.13
 
 require (
-	github.com/ONSdigital/dp-api-clients-go v1.33.0
+	github.com/ONSdigital/dp-api-clients-go v1.33.1-0.20210209135727-f314fa537677
 	github.com/ONSdigital/dp-cookies v0.1.0
 	github.com/ONSdigital/dp-frontend-models v1.9.1
 	github.com/ONSdigital/dp-healthcheck v1.0.5

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,6 @@
 github.com/ONSdigital/dp-api-clients-go v1.28.0/go.mod h1:iyJy6uRL4B6OYOJA0XMr5UHt6+Q8XmN9uwmURO+9Oj4=
-github.com/ONSdigital/dp-api-clients-go v1.33.1-0.20210209135727-f314fa537677 h1:zVhCOibHtROSsp9M8+zHOzE7VH9/ugNSobk4NHGQwgo=
-github.com/ONSdigital/dp-api-clients-go v1.33.1-0.20210209135727-f314fa537677/go.mod h1:0pUK3MN1v7DTjq0JSAD+DqbsZ8AVTodrXSXgJecg9Pw=
+github.com/ONSdigital/dp-api-clients-go v1.33.3 h1:Qa38jlMWEdgKeSt7tLhcctHfAFtTMn70ARMpCIP5kUs=
+github.com/ONSdigital/dp-api-clients-go v1.33.3/go.mod h1:0pUK3MN1v7DTjq0JSAD+DqbsZ8AVTodrXSXgJecg9Pw=
 github.com/ONSdigital/dp-cookies v0.1.0 h1:dP9wN8slCCr3nkybFmGIMXPsEjKHNIKi2iRjMi9E2bY=
 github.com/ONSdigital/dp-cookies v0.1.0/go.mod h1:7HvRBm+mU0xz2pryTa+vwphKxe5HYpXtmPe/e6FEIJU=
 github.com/ONSdigital/dp-frontend-models v1.9.1 h1:FtoZAxoxjvCQpj8U23usBSv9MhDCsqj+TdpVndbEeXk=

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,6 @@
 github.com/ONSdigital/dp-api-clients-go v1.28.0/go.mod h1:iyJy6uRL4B6OYOJA0XMr5UHt6+Q8XmN9uwmURO+9Oj4=
-github.com/ONSdigital/dp-api-clients-go v1.33.0 h1:VVWJZSpmHOJvXUETwgAcFaizW6voxRU8RbsmPHma4GU=
-github.com/ONSdigital/dp-api-clients-go v1.33.0/go.mod h1:0pUK3MN1v7DTjq0JSAD+DqbsZ8AVTodrXSXgJecg9Pw=
+github.com/ONSdigital/dp-api-clients-go v1.33.1-0.20210209135727-f314fa537677 h1:zVhCOibHtROSsp9M8+zHOzE7VH9/ugNSobk4NHGQwgo=
+github.com/ONSdigital/dp-api-clients-go v1.33.1-0.20210209135727-f314fa537677/go.mod h1:0pUK3MN1v7DTjq0JSAD+DqbsZ8AVTodrXSXgJecg9Pw=
 github.com/ONSdigital/dp-cookies v0.1.0 h1:dP9wN8slCCr3nkybFmGIMXPsEjKHNIKi2iRjMi9E2bY=
 github.com/ONSdigital/dp-cookies v0.1.0/go.mod h1:7HvRBm+mU0xz2pryTa+vwphKxe5HYpXtmPe/e6FEIJU=
 github.com/ONSdigital/dp-frontend-models v1.9.1 h1:FtoZAxoxjvCQpj8U23usBSv9MhDCsqj+TdpVndbEeXk=

--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -49,7 +49,7 @@ type DatasetClient interface {
 	GetVersion(ctx context.Context, userAuthToken, serviceAuthToken, downloadServiceAuthToken, collectionID, datasetID, edition, version string) (m dataset.Version, err error)
 	GetVersionMetadata(ctx context.Context, userAuthToken, serviceAuthToken, collectionID, id, edition, version string) (m dataset.Metadata, err error)
 	GetVersionDimensions(ctx context.Context, userAuthToken, serviceAuthToken, collectionID, id, edition, version string) (m dataset.VersionDimensions, err error)
-	GetOptions(ctx context.Context, userAuthToken, serviceAuthToken, collectionID, id, edition, version, dimension string, q dataset.QueryParams) (m dataset.Options, err error)
+	GetOptions(ctx context.Context, userAuthToken, serviceAuthToken, collectionID, id, edition, version, dimension string, q *dataset.QueryParams) (m dataset.Options, err error)
 	GetOptionsInBatches(ctx context.Context, userAuthToken, serviceAuthToken, collectionID, id, edition, version, dimension string, batchSize, maxWorkers int) (opts dataset.Options, err error)
 }
 
@@ -101,9 +101,9 @@ func CreateFilterID(c FilterClient, dc DatasetClient, cfg config.Config) http.Ha
 
 		var names []string
 		for _, dim := range dimensions.Items {
-			// we are only interested in the totalCount, no need to request more items.
-			q := dataset.QueryParams{Offset: 0, Limit: 1}
-			opts, err := dc.GetOptions(ctx, userAccessToken, "", collectionID, datasetID, edition, version, dim.Name, q)
+			// we are only interested in the totalCount, limit=0 will always return an empty list of items and the total count
+			q := dataset.QueryParams{Offset: 0, Limit: 0}
+			opts, err := dc.GetOptions(ctx, userAccessToken, "", collectionID, datasetID, edition, version, dim.Name, &q)
 			if err != nil {
 				setStatusCode(req, w, err)
 				return
@@ -199,7 +199,7 @@ func getOptionsSummary(ctx context.Context, dc DatasetClient, userAccessToken, c
 			numOpts = 0
 		}
 		q := dataset.QueryParams{Offset: 0, Limit: numOpts}
-		opt, err := dc.GetOptions(ctx, userAccessToken, "", collectionID, datasetID, edition, version, dim.Name, q)
+		opt, err := dc.GetOptions(ctx, userAccessToken, "", collectionID, datasetID, edition, version, dim.Name, &q)
 		if err != nil {
 			return opts, err
 		}

--- a/handlers/handlers_test.go
+++ b/handlers/handlers_test.go
@@ -107,9 +107,9 @@ func TestUnitHandlers(t *testing.T) {
 			}
 			mockDatasetClient.EXPECT().GetVersionDimensions(ctx, userAuthToken, serviceAuthToken, collectionID, "1234", "5678", "2017").Return(dims, nil)
 			mockDatasetClient.EXPECT().GetOptions(ctx, userAuthToken, serviceAuthToken, collectionID, "1234", "5678", "2017", "aggregate",
-				dataset.QueryParams{Offset: 0, Limit: 1}).Return(datasetOptions(0, 1), nil)
+				&dataset.QueryParams{Offset: 0, Limit: 0}).Return(datasetOptions(0, 1), nil)
 			mockDatasetClient.EXPECT().GetOptions(ctx, userAuthToken, serviceAuthToken, collectionID, "1234", "5678", "2017", "time",
-				dataset.QueryParams{Offset: 0, Limit: 1}).Return(datasetOptions(0, 1), nil)
+				&dataset.QueryParams{Offset: 0, Limit: 0}).Return(datasetOptions(0, 1), nil)
 
 			w := testResponse(301, "", "/datasets/1234/editions/5678/versions/2017/filter", mockClient, mockDatasetClient, CreateFilterID(mockClient, mockDatasetClient, mockConfig))
 
@@ -283,7 +283,7 @@ func TestUnitHandlers(t *testing.T) {
 			}
 			mockClient.EXPECT().GetVersionDimensions(ctx, userAuthToken, serviceAuthToken, collectionID, "12345", "5678", "2017").Return(dims, nil)
 			mockClient.EXPECT().GetOptions(ctx, userAuthToken, serviceAuthToken, collectionID, "12345", "5678", "2017", "aggregate",
-				dataset.QueryParams{Offset: 0, Limit: numOptsSummary}).Return(datasetOptions(0, numOptsSummary), nil)
+				&dataset.QueryParams{Offset: 0, Limit: numOptsSummary}).Return(datasetOptions(0, numOptsSummary), nil)
 			mockClient.EXPECT().GetVersionMetadata(ctx, userAuthToken, serviceAuthToken, collectionID, "12345", "5678", "2017")
 			mockClient.EXPECT().GetOptionsInBatches(ctx, userAuthToken, serviceAuthToken, collectionID, "12345", "5678", "2017", "aggregate",
 				mockConfig.BatchSizeLimit, mockConfig.BatchMaxWorkers).Return(datasetOptions(0, 1000), nil)

--- a/handlers/mock_handlers.go
+++ b/handlers/mock_handlers.go
@@ -194,7 +194,7 @@ func (mr *MockDatasetClientMockRecorder) GetVersionDimensions(ctx, userAuthToken
 }
 
 // GetOptions mocks base method
-func (m *MockDatasetClient) GetOptions(ctx context.Context, userAuthToken, serviceAuthToken, collectionID, id, edition, version, dimension string, q dataset.QueryParams) (dataset.Options, error) {
+func (m *MockDatasetClient) GetOptions(ctx context.Context, userAuthToken, serviceAuthToken, collectionID, id, edition, version, dimension string, q *dataset.QueryParams) (dataset.Options, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetOptions", ctx, userAuthToken, serviceAuthToken, collectionID, id, edition, version, dimension, q)
 	ret0, _ := ret[0].(dataset.Options)


### PR DESCRIPTION
### What

Needed to upgrade dp-api-clients-go so that we don't assume limit=0 returns all items.
- Upgraded to latest `dp-api-clients-go`, with optional query parameters
- Use limit=0 when we just need the total_count value

### How to review

- Make sure code changes make sense
- Make sure unit tests pass

### Who can review

Anyone