### PR TITLE
Replaced GetOptionsInBatches with GetOptionsBatchProcess for metadata file generation

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -24,7 +24,6 @@ type Config struct {
 	HealthCheckInterval        time.Duration `envconfig:"HEALTHCHECK_INTERVAL"`
 	HealthCheckCriticalTimeout time.Duration `envconfig:"HEALTHCHECK_CRITICAL_TIMEOUT"`
 	BatchSizeLimit             int           `envconfig:"BATCH_SIZE_LIMIT"`
-	BatchMaxWorkers            int           `envconfig:"BATCH_MAX_WORKERS"`
 	EnableProfiler             bool          `envconfig:"ENABLE_PROFILER"`
 	PprofToken                 string        `envconfig:"PPROF_TOKEN" json:"-"`
 }
@@ -47,7 +46,6 @@ func Get() (cfg *Config, err error) {
 		HealthCheckInterval:        30 * time.Second,
 		HealthCheckCriticalTimeout: 90 * time.Second,
 		BatchSizeLimit:             1000, // maximum limit value to get items from APIs in a single call
-		BatchMaxWorkers:            100,  // maximum number of concurrent go-routines requesting items from APIs with pagination
 		EnableProfiler:             false,
 	}
 

--- a/handlers/handlers_test.go
+++ b/handlers/handlers_test.go
@@ -267,8 +267,7 @@ func TestUnitHandlers(t *testing.T) {
 			mockZebedeeClient := NewMockZebedeeClient(mockCtrl)
 			mockClient := NewMockDatasetClient(mockCtrl)
 			mockConfig := config.Config{
-				BatchSizeLimit:  1000,
-				BatchMaxWorkers: 100,
+				BatchSizeLimit: 1000,
 			}
 			mockClient.EXPECT().Get(ctx, userAuthToken, serviceAuthToken, collectionID, "12345").Return(dataset.DatasetDetails{Contacts: &[]dataset.Contact{{Name: "Matt"}}, URI: "/economy/grossdomesticproduct/datasets/gdpjanuary2018", Links: dataset.Links{LatestVersion: dataset.Link{URL: "/datasets/1234/editions/5678/versions/2017"}}}, nil)
 			versions := []dataset.Version{{ReleaseDate: "02-01-2005", Links: dataset.Links{Self: dataset.Link{URL: "/datasets/12345/editions/2016/versions/1"}}}}
@@ -285,8 +284,8 @@ func TestUnitHandlers(t *testing.T) {
 			mockClient.EXPECT().GetOptions(ctx, userAuthToken, serviceAuthToken, collectionID, "12345", "5678", "2017", "aggregate",
 				&dataset.QueryParams{Offset: 0, Limit: numOptsSummary}).Return(datasetOptions(0, numOptsSummary), nil)
 			mockClient.EXPECT().GetVersionMetadata(ctx, userAuthToken, serviceAuthToken, collectionID, "12345", "5678", "2017")
-			mockClient.EXPECT().GetOptionsInBatches(ctx, userAuthToken, serviceAuthToken, collectionID, "12345", "5678", "2017", "aggregate",
-				mockConfig.BatchSizeLimit, mockConfig.BatchMaxWorkers).Return(datasetOptions(0, 1000), nil)
+			mockClient.EXPECT().GetOptionsBatchProcess(ctx, userAuthToken, serviceAuthToken, collectionID, "12345", "5678", "2017", "aggregate",
+				nil, gomock.Any(), mockConfig.BatchSizeLimit, 1).Return(nil)
 			mockZebedeeClient.EXPECT().GetBreadcrumb(ctx, userAuthToken, collectionID, locale, "")
 
 			mockRend := NewMockRenderClient(mockCtrl)

--- a/handlers/mock_handlers.go
+++ b/handlers/mock_handlers.go
@@ -208,19 +208,18 @@ func (mr *MockDatasetClientMockRecorder) GetOptions(ctx, userAuthToken, serviceA
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetOptions", reflect.TypeOf((*MockDatasetClient)(nil).GetOptions), ctx, userAuthToken, serviceAuthToken, collectionID, id, edition, version, dimension, q)
 }
 
-// GetOptionsInBatches mocks base method
-func (m *MockDatasetClient) GetOptionsInBatches(ctx context.Context, userAuthToken, serviceAuthToken, collectionID, id, edition, version, dimension string, batchSize, maxWorkers int) (dataset.Options, error) {
+// GetOptionsBatchProcess mocks base method
+func (m *MockDatasetClient) GetOptionsBatchProcess(ctx context.Context, userAuthToken, serviceAuthToken, collectionID, id, edition, version, dimension string, optionIDs *[]string, processBatch dataset.OptionsBatchProcessor, batchSize, maxWorkers int) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetOptionsInBatches", ctx, userAuthToken, serviceAuthToken, collectionID, id, edition, version, dimension, batchSize, maxWorkers)
-	ret0, _ := ret[0].(dataset.Options)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+	ret := m.ctrl.Call(m, "GetOptionsBatchProcess", ctx, userAuthToken, serviceAuthToken, collectionID, id, edition, version, dimension, optionIDs, processBatch, batchSize, maxWorkers)
+	ret0, _ := ret[0].(error)
+	return ret0
 }
 
-// GetOptionsInBatches indicates an expected call of GetOptionsInBatches
-func (mr *MockDatasetClientMockRecorder) GetOptionsInBatches(ctx, userAuthToken, serviceAuthToken, collectionID, id, edition, version, dimension, batchSize, maxWorkers interface{}) *gomock.Call {
+// GetOptionsBatchProcess indicates an expected call of GetOptionsBatchProcess
+func (mr *MockDatasetClientMockRecorder) GetOptionsBatchProcess(ctx, userAuthToken, serviceAuthToken, collectionID, id, edition, version, dimension, optionIDs, processBatch, batchSize, maxWorkers interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetOptionsInBatches", reflect.TypeOf((*MockDatasetClient)(nil).GetOptionsInBatches), ctx, userAuthToken, serviceAuthToken, collectionID, id, edition, version, dimension, batchSize, maxWorkers)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetOptionsBatchProcess", reflect.TypeOf((*MockDatasetClient)(nil).GetOptionsBatchProcess), ctx, userAuthToken, serviceAuthToken, collectionID, id, edition, version, dimension, optionIDs, processBatch, batchSize, maxWorkers)
 }
 
 // MockRenderClient is a mock of RenderClient interface


### PR DESCRIPTION
### What

- Use GetOptionsBatchProcess to reduce the memory usage of the metadata file generation:
Instead of accumulating all the options and then writing the file bytes, we now write the file bytes for each batch.
- Use sequential batch processing, so that the expected dimension order is kept in the metadata file.

This should fix the OOM kill observed in develop when trying to generate the metadata file for 

### How to review

- Make sure code changes make sense
- Make sure unit tests pass
- (info): tested locally: reduced memory usage to 1/3 of previous value

### Who can review

Anyone