### PR TITLE
rolled back large metadta file generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,4 +56,3 @@ Then you can us the profiler as follows:
 Copyright ©‎ 2017 2020, Office for National Statistics (https://www.ons.gov.uk)
 
 Released under MIT license, see [LICENSE](LICENSE.md) for details.
-

--- a/config/config.go
+++ b/config/config.go
@@ -23,8 +23,6 @@ type Config struct {
 	GracefulShutdownTimeout    time.Duration `envconfig:"GRACEFUL_SHUTDOWN_TIMEOUT"`
 	HealthCheckInterval        time.Duration `envconfig:"HEALTHCHECK_INTERVAL"`
 	HealthCheckCriticalTimeout time.Duration `envconfig:"HEALTHCHECK_CRITICAL_TIMEOUT"`
-	BatchSizeLimit             int           `envconfig:"BATCH_SIZE_LIMIT"`
-	BatchMaxWorkers            int           `envconfig:"BATCH_MAX_WORKERS"`
 	EnableProfiler             bool          `envconfig:"ENABLE_PROFILER"`
 	PprofToken                 string        `envconfig:"PPROF_TOKEN" json:"-"`
 }
@@ -46,8 +44,6 @@ func Get() (cfg *Config, err error) {
 		GracefulShutdownTimeout:    5 * time.Second,
 		HealthCheckInterval:        30 * time.Second,
 		HealthCheckCriticalTimeout: 90 * time.Second,
-		BatchSizeLimit:             1000, // maximum limit value to get items from APIs in a single call
-		BatchMaxWorkers:            100,  // maximum number of concurrent go-routines requesting items from APIs with pagination
 		EnableProfiler:             false,
 	}
 

--- a/handlers/handlers_test.go
+++ b/handlers/handlers_test.go
@@ -49,11 +49,11 @@ func datasetOptions(offset, limit int) dataset.Options {
 
 func slice(full []dataset.Option, offset, limit int) (sliced []dataset.Option) {
 	end := offset + limit
-	if limit == 0 || end > len(full) {
+	if end > len(full) {
 		end = len(full)
 	}
 
-	if offset > len(full) {
+	if offset > len(full) || limit == 0 {
 		return []dataset.Option{}
 	}
 
@@ -107,9 +107,9 @@ func TestUnitHandlers(t *testing.T) {
 			}
 			mockDatasetClient.EXPECT().GetVersionDimensions(ctx, userAuthToken, serviceAuthToken, collectionID, "1234", "5678", "2017").Return(dims, nil)
 			mockDatasetClient.EXPECT().GetOptions(ctx, userAuthToken, serviceAuthToken, collectionID, "1234", "5678", "2017", "aggregate",
-				&dataset.QueryParams{Offset: 0, Limit: 0}).Return(datasetOptions(0, 1), nil)
+				&dataset.QueryParams{Offset: 0, Limit: 0}).Return(datasetOptions(0, 0), nil)
 			mockDatasetClient.EXPECT().GetOptions(ctx, userAuthToken, serviceAuthToken, collectionID, "1234", "5678", "2017", "time",
-				&dataset.QueryParams{Offset: 0, Limit: 0}).Return(datasetOptions(0, 1), nil)
+				&dataset.QueryParams{Offset: 0, Limit: 0}).Return(datasetOptions(0, 0), nil)
 
 			w := testResponse(301, "", "/datasets/1234/editions/5678/versions/2017/filter", mockClient, mockDatasetClient, CreateFilterID(mockClient, mockDatasetClient, mockConfig))
 
@@ -266,9 +266,7 @@ func TestUnitHandlers(t *testing.T) {
 		Convey("test filterable landing page is successful, when it receives good dataset api responses", func() {
 			mockZebedeeClient := NewMockZebedeeClient(mockCtrl)
 			mockClient := NewMockDatasetClient(mockCtrl)
-			mockConfig := config.Config{
-				BatchSizeLimit: 1000,
-			}
+			mockConfig := config.Config{}
 			mockClient.EXPECT().Get(ctx, userAuthToken, serviceAuthToken, collectionID, "12345").Return(dataset.DatasetDetails{Contacts: &[]dataset.Contact{{Name: "Matt"}}, URI: "/economy/grossdomesticproduct/datasets/gdpjanuary2018", Links: dataset.Links{LatestVersion: dataset.Link{URL: "/datasets/1234/editions/5678/versions/2017"}}}, nil)
 			versions := []dataset.Version{{ReleaseDate: "02-01-2005", Links: dataset.Links{Self: dataset.Link{URL: "/datasets/12345/editions/2016/versions/1"}}}}
 			mockClient.EXPECT().GetVersions(ctx, userAuthToken, serviceAuthToken, collectionID, "", "12345", "5678").Return(versions, nil)
@@ -284,8 +282,8 @@ func TestUnitHandlers(t *testing.T) {
 			mockClient.EXPECT().GetOptions(ctx, userAuthToken, serviceAuthToken, collectionID, "12345", "5678", "2017", "aggregate",
 				&dataset.QueryParams{Offset: 0, Limit: numOptsSummary}).Return(datasetOptions(0, numOptsSummary), nil)
 			mockClient.EXPECT().GetVersionMetadata(ctx, userAuthToken, serviceAuthToken, collectionID, "12345", "5678", "2017")
-			mockClient.EXPECT().GetOptionsBatchProcess(ctx, userAuthToken, serviceAuthToken, collectionID, "12345", "5678", "2017", "aggregate",
-				nil, gomock.Any(), mockConfig.BatchSizeLimit, mockConfig.BatchMaxWorkers).Return(nil)
+			mockClient.EXPECT().GetOptions(ctx, userAuthToken, serviceAuthToken, collectionID, "12345", "5678", "2017", "aggregate",
+				&dataset.QueryParams{Offset: 0, Limit: maxMetadataOptions}).Return(datasetOptions(0, maxMetadataOptions), nil)
 			mockZebedeeClient.EXPECT().GetBreadcrumb(ctx, userAuthToken, collectionID, locale, "")
 
 			mockRend := NewMockRenderClient(mockCtrl)

--- a/handlers/mock_handlers.go
+++ b/handlers/mock_handlers.go
@@ -208,20 +208,6 @@ func (mr *MockDatasetClientMockRecorder) GetOptions(ctx, userAuthToken, serviceA
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetOptions", reflect.TypeOf((*MockDatasetClient)(nil).GetOptions), ctx, userAuthToken, serviceAuthToken, collectionID, id, edition, version, dimension, q)
 }
 
-// GetOptionsBatchProcess mocks base method
-func (m *MockDatasetClient) GetOptionsBatchProcess(ctx context.Context, userAuthToken, serviceAuthToken, collectionID, id, edition, version, dimension string, optionIDs *[]string, processBatch dataset.OptionsBatchProcessor, batchSize, maxWorkers int) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetOptionsBatchProcess", ctx, userAuthToken, serviceAuthToken, collectionID, id, edition, version, dimension, optionIDs, processBatch, batchSize, maxWorkers)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// GetOptionsBatchProcess indicates an expected call of GetOptionsBatchProcess
-func (mr *MockDatasetClientMockRecorder) GetOptionsBatchProcess(ctx, userAuthToken, serviceAuthToken, collectionID, id, edition, version, dimension, optionIDs, processBatch, batchSize, maxWorkers interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetOptionsBatchProcess", reflect.TypeOf((*MockDatasetClient)(nil).GetOptionsBatchProcess), ctx, userAuthToken, serviceAuthToken, collectionID, id, edition, version, dimension, optionIDs, processBatch, batchSize, maxWorkers)
-}
-
 // MockRenderClient is a mock of RenderClient interface
 type MockRenderClient struct {
 	ctrl     *gomock.Controller


### PR DESCRIPTION
### What

Rolled back the large metadata file generation implementation, as we think it is better to use download service instead.

### How to review

- Make sure code changes make sense
  - you can compare with the previous commit:
https://github.com/ONSdigital/dp-frontend-dataset-controller/compare/5ea0942eb0c6da4cb2b6729f7583a613dc94f9ab...fix/undo-large-metadata-file-generation
- Make sure unit tests pass

### Who can review

Anyone