### PR TITLE
Fix broken language links on dataset pages

### DIFF
--- a/main.go
+++ b/main.go
@@ -71,6 +71,7 @@ func run(ctx context.Context) error {
 		log.Event(ctx, "unable to retrieve service configuration", log.ERROR, log.Error(err))
 		return err
 	}
+
 	log.Event(ctx, "got service configuration", log.INFO, log.Data{"config": cfg})
 
 	// Get API version from its URL
@@ -194,7 +195,6 @@ func run(ctx context.Context) error {
 }
 
 func registerCheckers(ctx context.Context, h *health.HealthCheck, r *renderer.Renderer, apiRouterCli *healthcheck.Client) (err error) {
-
 	hasErrors := false
 
 	if err = h.AddCheck("frontend renderer", r.Checker); err != nil {

--- a/mapper/mapper.go
+++ b/mapper/mapper.go
@@ -63,12 +63,13 @@ func CreateFilterableLandingPage(ctx context.Context, req *http.Request, d datas
 	p.Type = "dataset_landing_page"
 	p.Metadata.Title = d.Title
 	p.Language = lang
-	p.URI = d.Links.Self.URL
+	p.URI = req.URL.Path
 	p.DatasetLandingPage.UnitOfMeasurement = d.UnitOfMeasure
 	p.Metadata.Description = d.Description
 	p.DatasetId = datasetID
 	p.ReleaseDate = ver.ReleaseDate
 	p.BetaBannerEnabled = true
+	
 	if d.Type == "nomis" {
 		p.DatasetLandingPage.NomisReferenceURL = d.NomisReferenceURL
 		homeBreadcrumb := model.TaxonomyNode{
@@ -349,6 +350,7 @@ func CreateVersionsList(ctx context.Context, req *http.Request, d dataset.Datase
 
 	p.Data.LatestVersionURL = helpers.DatasetVersionUrl(d.ID, edition.Edition, edition.Links.LatestVersion.ID)
 	p.DatasetId = d.ID
+	p.URI = req.URL.Path
 
 	latestVersionNumber := 1
 	for _, ver := range versions {
@@ -412,7 +414,7 @@ func CreateEditionsList(ctx context.Context, req *http.Request, d dataset.Datase
 	p.Type = "dataset_edition_list"
 	p.Language = lang
 	p.Metadata.Title = d.Title
-	p.URI = d.Links.Self.URL
+	p.URI = req.URL.Path
 	p.Metadata.Description = d.Description
 	p.DatasetId = datasetID
 	p.BetaBannerEnabled = true

--- a/mapper/mapper_test.go
+++ b/mapper/mapper_test.go
@@ -173,7 +173,7 @@ func TestUnitMapper(t *testing.T) {
 
 		So(p.Type, ShouldEqual, "dataset_landing_page")
 		So(p.Metadata.Title, ShouldEqual, d.Title)
-		So(p.URI, ShouldEqual, d.Links.Self.URL)
+		So(p.URI, ShouldEqual, req.URL.Path)
 		So(p.ContactDetails.Name, ShouldEqual, contact.Name)
 		So(p.ContactDetails.Telephone, ShouldEqual, contact.Telephone)
 		So(p.ContactDetails.Email, ShouldEqual, contact.Email)
@@ -285,7 +285,7 @@ func TestUnitMapper(t *testing.T) {
 
 		So(p.Type, ShouldEqual, "dataset_landing_page")
 		So(p.Metadata.Title, ShouldEqual, d.Title)
-		So(p.URI, ShouldEqual, d.Links.Self.URL)
+		So(p.URI, ShouldEqual, req.URL.Path)
 		So(p.ContactDetails.Name, ShouldEqual, contact.Name)
 		So(p.ContactDetails.Telephone, ShouldEqual, contact.Telephone)
 		So(p.ContactDetails.Email, ShouldEqual, contact.Email)


### PR DESCRIPTION
### What

The language toggle links on the landing page, editions list and versions list were pointing to a static URL returned from the stored page model which didn't take into account the actual URI being visited when the page was being viewed. 
As it turns out, the link was broken because the actual normal version of the link was in fact broken itself (a ticket has now been raised) so upon that being fixed it should automatically redirect to the appropriate page.
However, if relying on the redirect we would end up on the latest edition/version page no matter which we were viewing so it is probably better to set the URI based on reflection of the actual request object so an accurate path can be generated.

### How to review

Test the filterable dataset landing page and editions and versions list pages, check the language toggle redirects to the same page but translated (or English version if translation fails).

### Who can review

Anyone
