### PR TITLE
Feature/map dataset metadata to census landing page

### DIFF
--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -9,6 +9,7 @@ import (
 	"net/url"
 	"regexp"
 	"strconv"
+	"strings"
 	"sync"
 
 	"github.com/ONSdigital/dp-net/handlers"
@@ -138,13 +139,6 @@ func FilterableLanding(dc DatasetClient, rend RenderClient, zc ZebedeeClient, cf
 	})
 }
 
-// CensusDatasetLanding will load a census dataset landing page
-func CensusDatasetLanding(rend RenderClient, apiRouterVersion string) http.HandlerFunc {
-	return handlers.ControllerHandler(func(w http.ResponseWriter, req *http.Request, lang, collectionID, userAccessToken string) {
-		censusLanding(w, req, rend, collectionID, lang, apiRouterVersion, userAccessToken)
-	})
-}
-
 // EditionsList will load a list of editions for a filterable dataset
 func EditionsList(dc DatasetClient, zc ZebedeeClient, rend RenderClient, cfg config.Config, apiRouterVersion string) http.HandlerFunc {
 	return handlers.ControllerHandler(func(w http.ResponseWriter, req *http.Request, lang, collectionID, userAccessToken string) {
@@ -159,9 +153,9 @@ func VersionsList(dc DatasetClient, rend RenderClient, cfg config.Config) http.H
 	})
 }
 
-func censusLanding(w http.ResponseWriter, req *http.Request, rend RenderClient, collectionID, lang, apiRouterVersion, userAccessToken string) {
+func censusLanding(w http.ResponseWriter, req *http.Request, datasetModel dataset.DatasetDetails, rend RenderClient, collectionID, lang, apiRouterVersion, userAccessToken string) {
 	basePage := rend.NewBasePageModel()
-	m := mapper.CreateCensusDatasetLandingPage(req, basePage, lang)
+	m := mapper.CreateCensusDatasetLandingPage(req, basePage, datasetModel, lang)
 	rend.BuildPage(w, m, "census-landing")
 }
 
@@ -237,6 +231,11 @@ func filterableLanding(w http.ResponseWriter, req *http.Request, dc DatasetClien
 	datasetModel, err := dc.Get(ctx, userAccessToken, "", collectionID, datasetID)
 	if err != nil {
 		setStatusCode(req, w, err)
+		return
+	}
+
+	if cfg.EnableCensusPages && strings.Contains(datasetModel.Type, "cantabular") {
+		censusLanding(w, req, datasetModel, rend, collectionID, lang, apiRouterVersion, userAccessToken)
 		return
 	}
 

--- a/handlers/handlers_test.go
+++ b/handlers/handlers_test.go
@@ -334,6 +334,66 @@ func TestUnitHandlers(t *testing.T) {
 
 			So(w.Code, ShouldEqual, http.StatusInternalServerError)
 		})
+
+	})
+
+	Convey("test census landing page", t, func() {
+		mockClient := NewMockDatasetClient(mockCtrl)
+		mockZebedeeClient := NewMockZebedeeClient(mockCtrl)
+		mockRend := NewMockRenderClient(mockCtrl)
+
+		Convey("filterable landing handler returns census landing template for cantabular types", func() {
+			mockConfig := config.Config{EnableCensusPages: true}
+			mockClient.EXPECT().Get(ctx, userAuthToken, serviceAuthToken, collectionID, "12345").Return(dataset.DatasetDetails{Contacts: &[]dataset.Contact{{Name: "Nick"}}, Type: "cantabular-table", URI: "/economy/grossdomesticproduct/datasets/gdpjanuary2018", Links: dataset.Links{LatestVersion: dataset.Link{URL: "/datasets/1234/editions/5678/versions/2017"}}}, nil)
+
+			mockRend.EXPECT().NewBasePageModel().Return(coreModel.NewPage(cfg.PatternLibraryAssetsPath, cfg.SiteDomain))
+			mockRend.EXPECT().BuildPage(gomock.Any(), gomock.Any(), "census-landing")
+
+			w := httptest.NewRecorder()
+			req := httptest.NewRequest("GET", "/datasets/12345", nil)
+
+			router := mux.NewRouter()
+			router.HandleFunc("/datasets/{datasetID}", FilterableLanding(mockClient, mockRend, mockZebedeeClient, mockConfig, "/v1"))
+
+			router.ServeHTTP(w, req)
+
+			So(w.Code, ShouldEqual, http.StatusOK)
+		})
+
+		Convey("filterable landing page returned if census config is false", func() {
+			mockConfig := config.Config{EnableCensusPages: false}
+			mockClient.EXPECT().Get(ctx, userAuthToken, serviceAuthToken, collectionID, "12345").Return(dataset.DatasetDetails{Contacts: &[]dataset.Contact{{Name: "Nick"}}, Type: "cantabular-table", URI: "/economy/grossdomesticproduct/datasets/gdpjanuary2018", Links: dataset.Links{LatestVersion: dataset.Link{URL: "/datasets/1234/editions/5678/versions/2017"}}}, nil)
+			versions := []dataset.Version{{ReleaseDate: "02-01-2005", Links: dataset.Links{Self: dataset.Link{URL: "/datasets/12345/editions/2016/versions/1"}}}}
+			mockClient.EXPECT().GetVersions(ctx, userAuthToken, serviceAuthToken, collectionID, "", "12345", "5678").Return(versions, nil)
+			mockClient.EXPECT().GetVersion(ctx, userAuthToken, serviceAuthToken, collectionID, "", "12345", "5678", "2017").Return(versions[0], nil)
+			dims := dataset.VersionDimensions{
+				Items: []dataset.VersionDimension{
+					{
+						Name: "aggregate",
+					},
+				},
+			}
+			mockClient.EXPECT().GetVersionDimensions(ctx, userAuthToken, serviceAuthToken, collectionID, "12345", "5678", "2017").Return(dims, nil)
+			mockClient.EXPECT().GetOptions(ctx, userAuthToken, serviceAuthToken, collectionID, "12345", "5678", "2017", "aggregate",
+				&dataset.QueryParams{Offset: 0, Limit: numOptsSummary}).Return(datasetOptions(0, numOptsSummary), nil)
+			mockClient.EXPECT().GetVersionMetadata(ctx, userAuthToken, serviceAuthToken, collectionID, "12345", "5678", "2017")
+			mockClient.EXPECT().GetOptions(ctx, userAuthToken, serviceAuthToken, collectionID, "12345", "5678", "2017", "aggregate",
+				&dataset.QueryParams{Offset: 0, Limit: maxMetadataOptions}).Return(datasetOptions(0, maxMetadataOptions), nil)
+			mockZebedeeClient.EXPECT().GetBreadcrumb(ctx, userAuthToken, collectionID, locale, "")
+
+			mockRend.EXPECT().NewBasePageModel().Return(coreModel.NewPage(cfg.PatternLibraryAssetsPath, cfg.SiteDomain))
+			mockRend.EXPECT().BuildPage(gomock.Any(), gomock.Any(), "filterable")
+
+			w := httptest.NewRecorder()
+			req := httptest.NewRequest("GET", "/datasets/12345", nil)
+
+			router := mux.NewRouter()
+			router.HandleFunc("/datasets/{datasetID}", FilterableLanding(mockClient, mockRend, mockZebedeeClient, mockConfig, "/v1"))
+
+			router.ServeHTTP(w, req)
+
+			So(w.Code, ShouldEqual, http.StatusOK)
+		})
 	})
 
 	Convey("test versions list", t, func() {

--- a/main.go
+++ b/main.go
@@ -107,7 +107,6 @@ func run(ctx context.Context) error {
 	}
 
 	// Initialise render client, routes and initialise localisations bundles
-	//rend := render.NewWithDefaultClient(assets.Asset, assets.AssetNames, cfg.PatternLibraryAssetsPath, cfg.SiteDomain)
 	rend := render.NewWithDefaultClient(assets.Asset, assets.AssetNames, cfg.PatternLibraryAssetsPath, cfg.SiteDomain)
 
 	// Enable profiling endpoint for authorised users
@@ -117,10 +116,6 @@ func run(ctx context.Context) error {
 	}
 
 	router.StrictSlash(true).Path("/health").HandlerFunc(healthcheck.Handler)
-
-	if cfg.EnableCensusPages {
-		router.StrictSlash(true).Path("/datasets/census").Methods("GET").HandlerFunc(handlers.CensusDatasetLanding(rend, apiRouterVersion))
-	}
 
 	router.StrictSlash(true).Path("/datasets/{datasetID}").Methods("GET").HandlerFunc(handlers.EditionsList(dc, zc, rend, *cfg, apiRouterVersion))
 	router.StrictSlash(true).Path("/datasets/{datasetID}/editions").Methods("GET").HandlerFunc(handlers.EditionsList(dc, zc, rend, *cfg, apiRouterVersion))

--- a/mapper/mapper_test.go
+++ b/mapper/mapper_test.go
@@ -486,3 +486,42 @@ func TestUnitMapCookiesPreferences(t *testing.T) {
 		So(pageModel.CookiesPolicy.Usage, ShouldEqual, true)
 	})
 }
+
+func TestCreateCensusDatasetLandingPage(t *testing.T) {
+	req := httptest.NewRequest("", "/", nil)
+	pageModel := model.Page{}
+	contact := dataset.Contact{
+		Name:      "Test contact",
+		Telephone: "01232 123 123",
+		Email:     "hello@testing.com",
+	}
+	methodology := dataset.Methodology{
+		Description: "An interesting methodology description",
+		URL:         "http://www.google.com",
+		Title:       "The methodology title",
+	}
+	datasetModel := dataset.DatasetDetails{
+		Contacts: &[]dataset.Contact{
+			contact,
+		},
+		Description: "An interesting test description",
+		Methodologies: &[]dataset.Methodology{
+			methodology,
+		},
+		Title: "Test title",
+		Type:  "cantabular",
+	}
+
+	Convey("Census dataset landing page maps correctly", t, func() {
+		page := CreateCensusDatasetLandingPage(req, pageModel, datasetModel, "")
+		So(page.Type, ShouldEqual, datasetModel.Type)
+		So(page.Metadata.Title, ShouldEqual, datasetModel.Title)
+		So(page.Metadata.Description, ShouldEqual, datasetModel.Description)
+		So(page.ContactDetails.Name, ShouldEqual, contact.Name)
+		So(page.ContactDetails.Email, ShouldEqual, contact.Email)
+		So(page.ContactDetails.Telephone, ShouldEqual, contact.Telephone)
+		So(page.DatasetLandingPage.Methodologies[0].Description, ShouldEqual, methodology.Description)
+		So(page.DatasetLandingPage.Methodologies[0].Title, ShouldEqual, methodology.Title)
+		So(page.DatasetLandingPage.Methodologies[0].URL, ShouldEqual, methodology.URL)
+	})
+}


### PR DESCRIPTION
### What

- Removed rendundant code
- Created unit tests
- Updated mapper function to map known API responses (WIP)

### How to review
**N.B.** This is still a work in progress, so some hardcoded values remain

#### Easy way
- Check unit tests pass
- Sanity check

#### End to end (the hard way)
Run these services:
- (pull this branch of) dp-frontend-dataset-controller `make debug ENABLE_CENSUS_PAGES=true`
- florence - use the `feature/add-cantabular-type` branch 
- sixteens
- dp-frontend-router
- dp-publishing-dataset-controller
- dp-api-router
- dp-compose/cantabular-import
  - **N.B.** There are a number of services that are run via this subfolder of dp-compose

Step:
1. POST a cantabular recipe using Postman 
You'll need to update the headers to include your `X-Florence-Token` and send this example recipe (feel free to change to experiment)
```json
{
    "alias": "Some Cantabular",
    "cantabular_blob": "Example",
    "format": "cantabular_table",
    "id": "d773db66-b101-43ac-991d-cb2c99f6d5d1",
    "output_instances": [
        {
            
                "code_lists": [
                    {
                        "href": "http://localhost:22400/code-lists/city-regions",
                        "id": "city",
                        "is_hierarchy": false,
                        "name": "City"
                    },
                    {
                        "href": "http://localhost:22400/code-lists/siblings_3",
                        "id": "siblings_3",
                        "is_hierarchy": false,
                        "name": "Number Of Siblings (3 mappings)"
                    },
                    {
                        "href": "http://localhost:22400/code-lists/sex",
                        "id": "sex",
                        "is_hierarchy": false,
                        "name": "Sex"
                    }
            ],
            "dataset_id": "cantabular-1",
            "editions": [
                "2021"
            ],
            "title": "Another cantabular"
        }
    ]
}
```
2. Upload the dataset in Florence (follow on screen instructions)
3. Go back to your Collection and click `Create/edit content`
4. Click `Filterable dataset`
5. Create new dataset
6. Choose your dataset
7. Create the dataset
8. Click on your new dataset (if you used the above recipe, it will be `cantabular-1`)
9. Choose the latest edition (if you used the above recipe, it will be `2021`)
10. Click on Version: 1
11. Complete some metadata fields 
i. Title
ii. Release date
iii. Summary
iv. Contact (name, email and telephone)
v. Add a methodology
vi. Click `Save` and then `Preview` and the new census dataset landing page should be displayed
or `Save and submit for review` and go through the normal publishing steps (you'll need `The train`)

If you followed the above recipe and steps (even if you didn't publish; the joys of working locally 😄 ) the page will be available at:
[http://localhost:8081/datasets/cantabular-1](http://localhost:8081/datasets/cantabular-1) 😌 

### Who can review

Anyone but me
