### PR TITLE
tweaks to margin, typography and spacing as per comments

### DIFF
--- a/assets/templates/census-landing.tmpl
+++ b/assets/templates/census-landing.tmpl
@@ -2,11 +2,13 @@
     <div class="grid u-ml-m u-mr-m">
         {{ template "partials/breadcrumb" . }}
         <section class="u-mb-s">
-            <h1 class="u-fs-xxl u-mt-l u-mb-s">{{ .Metadata.Title }}</h1>
+            <h1 class="u-fs-xxxl u-mt-l u-mb-s u-pb-no u-pt-no">{{ .Metadata.Title }}</h1>
         </section>
         <div class="grid__col col-4@m u-pl-no"></div>
         <div class="grid__col col-8@m u-pl-no">
+            <section class="u-mt-l u-mb-l" aria-label="{{ localise "Summary" .Language 1 }}">
             {{ template "partials/census/section" .DatasetLandingPage.Sections.summary }}
+            </section>
             {{ if .ContactDetails }}{{ template "partials/census/contact-details" . }}{{ end }}
             {{ template "partials/census/stats-disclosure" . }}
             {{ if .DatasetLandingPage.Methodologies }}{{ template "partials/census/methodologies" . }}{{ end }}

--- a/assets/templates/partials/census/collapsible.tmpl
+++ b/assets/templates/partials/census/collapsible.tmpl
@@ -1,4 +1,4 @@
-<div id="collapsible" class="collapsible js-collapsible collapsible--initialised u-pb-s" data-btn-close="{{ localise "HideThis" .Language 1 }}">
+<div id="collapsible" class="collapsible js-collapsible collapsible--initialised u-pb-no" data-btn-close="{{ localise "HideThis" .Language 1 }}">
     <div class="collapsible__heading js-collapsible-heading">
         <div class="collapsible__controls">
             <h2 class="collapsible__title u-mt-no">{{ .Title }}</h2>

--- a/assets/templates/partials/census/collapsible.tmpl
+++ b/assets/templates/partials/census/collapsible.tmpl
@@ -11,7 +11,7 @@
     </div>
     <div id="collapsible-content" class="collapsible__content js-collapsible-content">
         {{ range $i, $v := .Content }}
-            <p class="u-fs-r">{{ $v }}</p>
+            <p class="u-fs-r u-mb-s u-p-no">{{ $v }}</p>
         {{ end }}
         <button type="button" class="btn btn--small u-fs-r js-collapsible-button btn--secondary u-d-no u-p-no" aria-controls="collapsible">
             <span class="btn__inner js-collapsible-button-inner u-fs-r">{{ localise "HideThis" .Language 1 }}</span>

--- a/assets/templates/partials/census/contact-details.tmpl
+++ b/assets/templates/partials/census/contact-details.tmpl
@@ -1,16 +1,16 @@
-<section class="u-mt-m u-mb-s" aria-label="{{ localise "RelatedLinksForCensus" .Language 1 }}">
-    <h2 class="u-fw-b" id="contact-details">{{ localise "ContactDetails" .Language 1 }}</h2>
+<section class="u-mt-l u-mb-l" aria-label="{{ localise "RelatedLinksForCensus" .Language 1 }}">
+    <h2 class="u-fw-b u-mt-l u-pb-no u-pt-no" id="contact-details">{{ localise "ContactDetails" .Language 1 }}</h2>
     <nav class="related-content__navigation" aria-labelledby="contact-details">
         <ul class="list list--bare u-fs-r">
             {{ if .ContactDetails.Email }}
-                <li class="list__item u-mt-no u-mb-no u-pl-no u-fs-r">
-                    <p class="u-mt-no u-mt-no u-mb-no u-fs-r u-pb-no">{{ localise "Email" .Language 1 }}</p>
+                <li class="list__item u-mt-s u-mb-s u-pl-no u-pb-no u-pt-no u-fs-r">
+                    <p class="u-mt-no u-mt-no u-mb-no u-fs-r u-pt-no u-pb-no">{{ localise "Email" .Language 1 }}</p>
                     <a href="mailto:{{.ContactDetails.Email}}" class="list__link underline-link">{{ .ContactDetails.Email }}</a>
                 </li>
             {{ end }}
             {{ if .ContactDetails.Telephone }}
-                <li class="list__item u-mt-no u-pl-no u-fs-r">
-                    <p class="u-mt-no u-mb-no u-fs-r u-pb-no">{{ localise "Phone" .Language 1 }}</p>
+                <li class="list__item u-mt-s u-mb-s u-pl-no u-pb-no u-pt-no u-fs-r">
+                    <p class="u-mt-no u-mb-no u-fs-r u-pt-no u-pb-no">{{ localise "Phone" .Language 1 }}</p>
                     <a href="tel:{{ .ContactDetails.Telephone | safeHTML }}" class="list__link underline-link">{{ .ContactDetails.Telephone }}</a>
                 </li>
             {{ end }}

--- a/assets/templates/partials/census/methodologies.tmpl
+++ b/assets/templates/partials/census/methodologies.tmpl
@@ -1,6 +1,6 @@
-<section class="u-mt-s u-mb-s" aria-label="{{ localise "Methodology" .Language 1 }}">
-    <h2 class="u-fw-b">{{ localise "Methodology" .Language 1 }}</h2>
+<section class="u-mt-l u-mb-l" aria-label="{{ localise "Methodology" .Language 1 }}">
+    <h2 class="u-fw-b u-mt-l u-pb-no u-pt-no">{{ localise "Methodology" .Language 1 }}</h2>
     {{ range .DatasetLandingPage.Methodologies }}
-        <p class="u-fs-r">{{ .Description }}</p>
+        <p class="u-fs-r u-pt-no u-pb-no">{{ .Description }}</p>
     {{ end }}
 </section>

--- a/assets/templates/partials/census/methodologies.tmpl
+++ b/assets/templates/partials/census/methodologies.tmpl
@@ -1,6 +1,6 @@
 <section class="u-mt-l u-mb-l" aria-label="{{ localise "Methodology" .Language 1 }}">
     <h2 class="u-fw-b u-mt-l u-pb-no u-pt-no">{{ localise "Methodology" .Language 1 }}</h2>
     {{ range .DatasetLandingPage.Methodologies }}
-        <p class="u-fs-r u-pt-no u-pb-no">{{ .Description }}</p>
+        <p class="u-fs-r u-pt-no u-pb-no u-mt-s u-mb-s">{{ .Description }}</p>
     {{ end }}
 </section>

--- a/assets/templates/partials/census/section.tmpl
+++ b/assets/templates/partials/census/section.tmpl
@@ -1,6 +1,6 @@
-<h2 class="u-fw-b">{{ .Title }}</h2>
+<h2 class="u-fw-b u-mt-l u-pb-no u-pt-no">{{ .Title }}</h2>
 {{ range $i, $v := .Description }}
-<p class="u-fs-r">{{ $v }}</p>
+<p class="u-fs-r u-mt-s u-mb-s u-pt-no u-pb-no">{{ $v }}</p>
 {{ end }}
 {{ if .Collapsible.Title }}
     {{ template "partials/census/collapsible" .Collapsible }}

--- a/assets/templates/partials/census/stats-disclosure.tmpl
+++ b/assets/templates/partials/census/stats-disclosure.tmpl
@@ -1,5 +1,5 @@
-<section class="u-mt-s u-mb-s" aria-label="{{ localise "StatsDisclosureTitle" .Language 1 }}">
-    <h2 class="u-fw-b">{{ localise "StatsDisclosureTitle" .Language 1 }}</h2>
-    <p class="u-fs-r">{{ localise "StatsDisclosureReasoning" .Language 1 }}</p>
-    <p class="u-fs-r">{{ localise "StatsDisclosureEffect" .Language 1 }}</p>
+<section class="u-mt-l u-mb-l" aria-label="{{ localise "StatsDisclosureTitle" .Language 1 }}">
+    <h2 class="u-fw-b u-mt-l u-pb-no u-pt-no">{{ localise "StatsDisclosureTitle" .Language 1 }}</h2>
+    <p class="u-fs-r u-mt-s u-mb-s u-pt-no u-pb-no">{{ localise "StatsDisclosureReasoning" .Language 1 }}</p>
+    <p class="u-fs-r u-mt-s u-mb-s u-pt-no u-pb-no">{{ localise "StatsDisclosureEffect" .Language 1 }}</p>
 </section>

--- a/assets/templates/partials/share-dataset/share-this-dataset.tmpl
+++ b/assets/templates/partials/share-dataset/share-this-dataset.tmpl
@@ -4,7 +4,7 @@
 <ul class="list list--inline list--bare list--icons">
   {{ range .ShareLocations }}
   <li class="list__item u-pl-no u-pr-xs">
-    <span class="list__prefix" >
+    <span class="list__prefix">
     {{ template "partials/share-dataset/icon-handler" .Icon }}
     </span><a href="{{.Link}}" class="list__link u-fs-r u-pt-xxs underline-link" target="_blank" rel="noreferrer external">{{ .Title }}<span class="u-vh">{{ localise "ShareLinkA11yText" $shareDetails.Language 1 }}</span></a>
   </li>


### PR DESCRIPTION
### What

Spacing and typography tweaks as per comments. These include:

- Top level heading now `2.6rem`
- Margin between paragraphs now `1rem`
- Vertical rhythm between each section (e.g. between Statistical Disclosure and Methodology) is now `2rem`

### How to review

- Check that the changes align with what's detailed above

### Who can review

A frontend dev
