### PR TITLE
update dp-renderer to 1.3.0 (updates beta banner on Census DLP)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/ONSdigital/dp-cookies v0.2.0
 	github.com/ONSdigital/dp-healthcheck v1.0.5
 	github.com/ONSdigital/dp-net v1.0.12
-	github.com/ONSdigital/dp-renderer v1.2.0
+	github.com/ONSdigital/dp-renderer v1.3.0
 	github.com/ONSdigital/log.go/v2 v2.0.9
 	github.com/golang/mock v1.6.0
 	github.com/gorilla/mux v1.8.0

--- a/go.sum
+++ b/go.sum
@@ -20,6 +20,8 @@ github.com/ONSdigital/dp-renderer v1.0.1-0.20210817082012-d37f0f2c4fa7 h1:iutZKg
 github.com/ONSdigital/dp-renderer v1.0.1-0.20210817082012-d37f0f2c4fa7/go.mod h1:d2n2zLhU93qkvS1ArRyLBDZkqT8+UajrEJFkc+9uRJc=
 github.com/ONSdigital/dp-renderer v1.2.0 h1:aYwU4T+WxlS+jyXV9KoJNhDxhbUn+p3Vr8Ky+LevXAA=
 github.com/ONSdigital/dp-renderer v1.2.0/go.mod h1:Z5sbyS0ApY6D8ikGDt2KIl5bt2p5kk73PeeMxGs1pEM=
+github.com/ONSdigital/dp-renderer v1.3.0 h1:2DwmLcHIGHQAaZze7GByfHEnuwIg77bajQXB/hDjl7c=
+github.com/ONSdigital/dp-renderer v1.3.0/go.mod h1:Z5sbyS0ApY6D8ikGDt2KIl5bt2p5kk73PeeMxGs1pEM=
 github.com/ONSdigital/go-ns v0.0.0-20191104121206-f144c4ec2e58/go.mod h1:iWos35il+NjbvDEqwtB736pyHru0MPFE/LqcwkV1wDc=
 github.com/ONSdigital/log.go v1.0.0/go.mod h1:UnGu9Q14gNC+kz0DOkdnLYGoqugCvnokHBRBxFRpVoQ=
 github.com/ONSdigital/log.go v1.0.1-0.20200805084515-ee61165ea36a/go.mod h1:dDnQATFXCBOknvj6ZQuKfmDhbOWf3e8mtV+dPEfWJqs=


### PR DESCRIPTION
### What

Update `dp-renderer` to `1.3.0`. This change will mean that the beta banner on the Census DLP is now styled a la ONS Design System, rather than Sixteens

![image](https://user-images.githubusercontent.com/23668262/133969099-e1866943-381c-4e49-8140-ccd8d4999efe.png)


### How to review

Sense check. Consider checking the beta banner for the Census DLP if you have it running locally and ensure it matches that of the ONS Design System's

### Who can review

Frontend dev / someone with Cantabular set up locally
