### PR TITLE
Feature/dlp census

### DIFF
--- a/assets/locales/service.cy.toml
+++ b/assets/locales/service.cy.toml
@@ -190,3 +190,19 @@ one = "Get the data"
 [StatisticalDisclosureControl]
 description = "Statistical disclosure control"
 one = "Statistical disclosure control"
+
+[Released]
+description = "Released"
+one = "Released"
+
+[LastUpdated]
+description = "Last updated"
+one = "Last updated"
+
+[SeeVersionHistory]
+description = "See version history"
+one = "See version history"
+
+[CensusDatasetLandingPageMetadataLabel]
+description = "Census DLP metadata label - datestamp and dataset ID"
+one = "Dataset ID and release date information"

--- a/assets/locales/service.en.toml
+++ b/assets/locales/service.en.toml
@@ -171,3 +171,19 @@ one = "Get the data"
 [StatisticalDisclosureControl]
 description = "Statistical disclosure control"
 one = "Statistical disclosure control"
+
+[Released]
+description = "Released"
+one = "Released"
+
+[LastUpdated]
+description = "Last updated"
+one = "Last updated"
+
+[SeeVersionHistory]
+description = "See version history"
+one = "See version history"
+
+[CensusDatasetLandingPageMetadataLabel]
+description = "Census DLP metadata label - datestamp and dataset ID"
+one = "Dataset ID and release date information"

--- a/assets/templates/census-landing.tmpl
+++ b/assets/templates/census-landing.tmpl
@@ -1,15 +1,15 @@
 <div class="page__container container ">
     <div class="grid u-ml-m u-mr-m">
         {{ template "partials/breadcrumb" . }}
-        <section class="u-mb-s">
-            <h1 class="u-fs-xxxl u-mt-l u-mb-s u-pb-no u-pt-no">{{ .Metadata.Title }}</h1>
+        <section class="u-mb-xl">
+            <h1 class="u-fs-xxxl u-mt-l u-mb-m u-pb-no u-pt-no">{{ .Metadata.Title }}</h1>
             {{ template "partials/census/id-datestamp" . }}
         </section>
         <div class="grid__col col-4@m u-pl-no">
             {{ template "partials/table-of-contents" .DatasetLandingPage.GuideContents }}
         </div>
         <div class="grid__col col-8@m u-pl-no">
-            <section class="u-mt-l u-mb-l" aria-label="{{ localise "Summary" .Language 1 }}">
+            <section class="u-mt-no u-mb-l" aria-label="{{ localise "Summary" .Language 1 }}">
             {{ template "partials/census/section" .DatasetLandingPage.Sections.summary }}
             </section>
             {{ if .HasContactDetails }}

--- a/assets/templates/census-landing.tmpl
+++ b/assets/templates/census-landing.tmpl
@@ -3,6 +3,7 @@
         {{ template "partials/breadcrumb" . }}
         <section class="u-mb-s">
             <h1 class="u-fs-xxxl u-mt-l u-mb-s u-pb-no u-pt-no">{{ .Metadata.Title }}</h1>
+            {{ template "partials/census/id-datestamp" . }}
         </section>
         <div class="grid__col col-4@m u-pl-no">
             {{ template "partials/table-of-contents" .DatasetLandingPage.GuideContents }}

--- a/assets/templates/partials/census/id-datestamp.tmpl
+++ b/assets/templates/partials/census/id-datestamp.tmpl
@@ -1,21 +1,19 @@
-{{ $releaseDateColWidth := "col-12@m" }}
-{{ if .DatasetLandingPage.HasOtherVersions }}
-    {{ $releaseDateColWidth = "col-4@m" }}
-{{ end }}
-
 <dl class="metadata metadata__list grid grid--gutterless u-cf u-mb-l" title="{{ localise "CensusDatasetLandingPageMetadataLabel" .Language 1 }}" aria-label="{{ localise "CensusDatasetLandingPageMetadataLabel" .Language 1 }}">
     <div class="grid__col col-12@m">
         <dt class="metadata__term u-mr-xs">{{ localise "DatasetID" .Language 1 }}</dt>
         <dd class="metadata__value u-f-no">{{ .ID }}</dd>
     </div>
-    <div class="grid__col {{$releaseDateColWidth}}">
-        <dt class="metadata__term u-mr-xs">{{ localise "Released" .Language 1 }}:</dt>
-        <dd class="metadata__value u-f-no">{{ dateFormat .InitialReleaseDate }}</dd>
-    </div>
     {{ if .DatasetLandingPage.HasOtherVersions }}
-        <div class="grid__col col-8@m">
-            <dt class="metadata__term u-mr-xs">{{ localise "LastUpdated" .Language 1 }}:</dt>
-            <dd class="metadata__value u-f-no">{{ dateFormat .Version.ReleaseDate }} &mdash; <a href="#version-history">{{ localise "SeeVersionHistory" .Language 1 }}</a></dd>
+        <div class="grid__col col-12@m">
+            <dt class="metadata__term u-mr-xs u-dib u-f-no">{{ localise "Released" .Language 1 }}:</dt>
+            <dd class="metadata__value u-f-no u-dib">{{ dateFormat .InitialReleaseDate }}</dd>
+            <dt class="metadata__term u-mr-xs u-dib u-ml-xs u-f-no">{{ localise "LastUpdated" .Language 1 }}:</dt>
+            <dd class="metadata__value u-f-no u-dib">{{ dateFormat .Version.ReleaseDate }} &mdash; <a href="#version-history">{{ localise "SeeVersionHistory" .Language 1 }}</a></dd>
+        </div>
+    {{ else }}
+        <div class="grid__col col-12@m">
+            <dt class="metadata__term u-mr-xs">{{ localise "Released" .Language 1 }}:</dt>
+            <dd class="metadata__value u-f-no">{{ dateFormat .InitialReleaseDate }}</dd>
         </div>
     {{ end }}
 </dl>

--- a/assets/templates/partials/census/id-datestamp.tmpl
+++ b/assets/templates/partials/census/id-datestamp.tmpl
@@ -1,12 +1,12 @@
-<dl class="metadata metadata__list grid grid--gutterless u-cf u-mb-l" title="{{ localise "CensusDatasetLandingPageMetadataLabel" .Language 1 }}" aria-label="{{ localise "CensusDatasetLandingPageMetadataLabel" .Language 1 }}">
+<dl class="metadata metadata__list grid grid--gutterless u-cf" title="{{ localise "CensusDatasetLandingPageMetadataLabel" .Language 1 }}" aria-label="{{ localise "CensusDatasetLandingPageMetadataLabel" .Language 1 }}">
     <div class="grid__col col-12@m">
-        <dt class="metadata__term u-mr-xs">{{ localise "DatasetID" .Language 1 }}</dt>
-        <dd class="metadata__value u-f-no">{{ .ID }}</dd>
+        <dt class="metadata__term u-mr-xs u-dib u-f-no">{{ localise "DatasetID" .Language 1 }}</dt>
+        <dd class="metadata__value u-f-no u-dib">{{ .ID }}</dd>
     </div>
     {{ if .DatasetLandingPage.HasOtherVersions }}
         <div class="grid__col col-12@m">
             <dt class="metadata__term u-mr-xs u-dib u-f-no">{{ localise "Released" .Language 1 }}:</dt>
-            <dd class="metadata__value u-f-no u-dib">{{ dateFormat .InitialReleaseDate }}</dd>
+            <dd class="metadata__value u-f-no u-mr-xs u-dib">{{ dateFormat .InitialReleaseDate }}</dd>
             <dt class="metadata__term u-dib u-mt-no u-f-no">{{ localise "LastUpdated" .Language 1 }}:</dt>
             <dd class="metadata__value u-f-no u-dib">{{ dateFormat .Version.ReleaseDate }} &mdash; <a href="#version-history">{{ localise "SeeVersionHistory" .Language 1 }}</a></dd>
         </div>

--- a/assets/templates/partials/census/id-datestamp.tmpl
+++ b/assets/templates/partials/census/id-datestamp.tmpl
@@ -13,7 +13,7 @@
     {{ else }}
         <div class="grid__col col-12@m u-mt-xs">
             <dt class="metadata__term u-mr-xs">{{ localise "Released" .Language 1 }}:</dt>
-            <dd class="metadata__value u-f-no">{{ dateFormat .InitialReleaseDate }}</dd>
+            <dd class="metadata__value u-f-no u-dib">{{ dateFormat .InitialReleaseDate }}</dd>
         </div>
     {{ end }}
 </dl>

--- a/assets/templates/partials/census/id-datestamp.tmpl
+++ b/assets/templates/partials/census/id-datestamp.tmpl
@@ -1,21 +1,21 @@
-<dl class="metadata metadata__list grid grid--gutterless u-cf u-mb-l" title="Dataset ID and datestamp" aria-label="Dataset ID and datestamp">
+{{ $releaseDateColWidth := "col-12@m" }}
+{{ if .DatasetLandingPage.HasOtherVersions }}
+    {{ $releaseDateColWidth = "col-4@m" }}
+{{ end }}
+
+<dl class="metadata metadata__list grid grid--gutterless u-cf u-mb-l" title="{{ localise "CensusDatasetLandingPageMetadataLabel" .Language 1 }}" aria-label="{{ localise "CensusDatasetLandingPageMetadataLabel" .Language 1 }}">
     <div class="grid__col col-12@m">
-        <dt class="metadata__term u-mr-xs">Dataset ID:</dt>
+        <dt class="metadata__term u-mr-xs">{{ localise "DatasetID" .Language 1 }}</dt>
         <dd class="metadata__value u-f-no">{{ .ID }}</dd>
     </div>
+    <div class="grid__col {{$releaseDateColWidth}}">
+        <dt class="metadata__term u-mr-xs">{{ localise "Released" .Language 1 }}:</dt>
+        <dd class="metadata__value u-f-no">{{ dateFormat .InitialReleaseDate }}</dd>
+    </div>
     {{ if .DatasetLandingPage.HasOtherVersions }}
-        <div class="grid__col col-4@m">
-            <dt class="metadata__term u-mr-xs">Release Date:</dt>
-            <dd class="metadata__value u-f-no">{{ dateFormat .InitialReleaseDate }}</dd>
-        </div>
         <div class="grid__col col-8@m">
-            <dt class="metadata__term u-mr-xs">Last updated:</dt>
-            <dd class="metadata__value u-f-no">{{ dateFormat .Version.ReleaseDate }} &mdash; <a href="#version-history">See version history</a></dd>
-        </div>
-    {{ else }}
-        <div class="grid__col col-12@m">
-            <dt class="metadata__term u-mr-xs">Release Date:</dt>
-            <dd class="metadata__value u-f-no">{{ dateFormat .InitialReleaseDate }}</dd>
+            <dt class="metadata__term u-mr-xs">{{ localise "LastUpdated" .Language 1 }}:</dt>
+            <dd class="metadata__value u-f-no">{{ dateFormat .Version.ReleaseDate }} &mdash; <a href="#version-history">{{ localise "SeeVersionHistory" .Language 1 }}</a></dd>
         </div>
     {{ end }}
 </dl>

--- a/assets/templates/partials/census/id-datestamp.tmpl
+++ b/assets/templates/partials/census/id-datestamp.tmpl
@@ -7,7 +7,7 @@
         <div class="grid__col col-12@m">
             <dt class="metadata__term u-mr-xs u-dib u-f-no">{{ localise "Released" .Language 1 }}:</dt>
             <dd class="metadata__value u-f-no u-dib">{{ dateFormat .InitialReleaseDate }}</dd>
-            <dt class="metadata__term u-mr-xs u-dib u-ml-xs u-f-no">{{ localise "LastUpdated" .Language 1 }}:</dt>
+            <dt class="metadata__term u-dib u-mt-no u-f-no">{{ localise "LastUpdated" .Language 1 }}:</dt>
             <dd class="metadata__value u-f-no u-dib">{{ dateFormat .Version.ReleaseDate }} &mdash; <a href="#version-history">{{ localise "SeeVersionHistory" .Language 1 }}</a></dd>
         </div>
     {{ else }}

--- a/assets/templates/partials/census/id-datestamp.tmpl
+++ b/assets/templates/partials/census/id-datestamp.tmpl
@@ -12,7 +12,7 @@
         </div>
     {{ else }}
         <div class="grid__col col-12@m u-mt-xs">
-            <dt class="metadata__term u-mr-xs">{{ localise "Released" .Language 1 }}:</dt>
+            <dt class="metadata__term u-mr-xs u-dib u-f-no">{{ localise "Released" .Language 1 }}:</dt>
             <dd class="metadata__value u-f-no u-dib">{{ dateFormat .InitialReleaseDate }}</dd>
         </div>
     {{ end }}

--- a/assets/templates/partials/census/id-datestamp.tmpl
+++ b/assets/templates/partials/census/id-datestamp.tmpl
@@ -11,7 +11,7 @@
             <dd class="metadata__value u-f-no u-dib">{{ dateFormat .Version.ReleaseDate }} &mdash; <a href="#version-history">{{ localise "SeeVersionHistory" .Language 1 }}</a></dd>
         </div>
     {{ else }}
-        <div class="grid__col col-12@m">
+        <div class="grid__col col-12@m u-mt-xs">
             <dt class="metadata__term u-mr-xs">{{ localise "Released" .Language 1 }}:</dt>
             <dd class="metadata__value u-f-no">{{ dateFormat .InitialReleaseDate }}</dd>
         </div>

--- a/assets/templates/partials/census/id-datestamp.tmpl
+++ b/assets/templates/partials/census/id-datestamp.tmpl
@@ -1,0 +1,21 @@
+<dl class="metadata metadata__list grid grid--gutterless u-cf u-mb-l" title="Dataset ID and datestamp" aria-label="Dataset ID and datestamp">
+    <div class="grid__col col-12@m">
+        <dt class="metadata__term u-mr-xs">Dataset ID:</dt>
+        <dd class="metadata__value u-f-no">{{ .ID }}</dd>
+    </div>
+    {{ if .DatasetLandingPage.HasOtherVersions }}
+        <div class="grid__col col-4@m">
+            <dt class="metadata__term u-mr-xs">Release Date:</dt>
+            <dd class="metadata__value u-f-no">{{ dateFormat .InitialReleaseDate }}</dd>
+        </div>
+        <div class="grid__col col-8@m">
+            <dt class="metadata__term u-mr-xs">Last updated:</dt>
+            <dd class="metadata__value u-f-no">{{ dateFormat .Version.ReleaseDate }} &mdash; <a href="#version-history">See version history</a></dd>
+        </div>
+    {{ else }}
+        <div class="grid__col col-12@m">
+            <dt class="metadata__term u-mr-xs">Release Date:</dt>
+            <dd class="metadata__value u-f-no">{{ dateFormat .InitialReleaseDate }}</dd>
+        </div>
+    {{ end }}
+</dl>

--- a/assets/templates/partials/census/section.tmpl
+++ b/assets/templates/partials/census/section.tmpl
@@ -1,4 +1,4 @@
-<h2 id="{{ .ID }}" class="u-fw-b u-mt-l u-pb-no u-pt-no">{{ .Title }}</h2>
+<h2 id="{{ .ID }}" class="u-fw-b u-pb-no u-mt-no u-pt-no">{{ .Title }}</h2>
 {{ range $i, $v := .Description }}
 <p class="u-fs-r u-mt-s u-mb-s u-pt-no u-pb-no">{{ $v }}</p>
 {{ end }}

--- a/assets/templates/partials/table-of-contents.tmpl
+++ b/assets/templates/partials/table-of-contents.tmpl
@@ -1,5 +1,5 @@
 {{ $guideContents := . }}
-<aside class="u-mt-l">
+<aside>
     <a class="skiplink" href="#guide-content">{{ localise "ContentsSkipLink" .Language 1 }}</a>
     <nav class="toc" aria-label="Pages in this guide">
         <h2 class="toc__title u-fs-r--b u-mb-s u-pt-no u-mt-no">{{ localise "Contents" .Language 1 }}</h2>

--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -153,8 +153,7 @@ func VersionsList(dc DatasetClient, rend RenderClient, cfg config.Config) http.H
 	})
 }
 
-func censusLanding(ctx context.Context, w http.ResponseWriter, req *http.Request, dc DatasetClient, datasetModel dataset.DatasetDetails, rend RenderClient, edition string, version dataset.Version, hasOtherVersions bool, collectionID, lang, apiRouterVersion, userAccessToken string) {
-
+func censusLanding(ctx context.Context, w http.ResponseWriter, req *http.Request, dc DatasetClient, datasetModel dataset.DatasetDetails, rend RenderClient, edition string, version dataset.Version, hasOtherVersions bool, collectionID, lang, userAccessToken string) {
 	var initialVersion dataset.Version
 	var initialVersionReleaseDate string
 	var err error
@@ -296,7 +295,7 @@ func filterableLanding(w http.ResponseWriter, req *http.Request, dc DatasetClien
 	}
 
 	if cfg.EnableCensusPages && strings.Contains(datasetModel.Type, "cantabular") {
-		censusLanding(ctx, w, req, dc, datasetModel, rend, edition, ver, displayOtherVersionsLink, collectionID, lang, apiRouterVersion, userAccessToken)
+		censusLanding(ctx, w, req, dc, datasetModel, rend, edition, ver, displayOtherVersionsLink, collectionID, lang, userAccessToken)
 		return
 	}
 

--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -153,9 +153,24 @@ func VersionsList(dc DatasetClient, rend RenderClient, cfg config.Config) http.H
 	})
 }
 
-func censusLanding(w http.ResponseWriter, req *http.Request, datasetModel dataset.DatasetDetails, rend RenderClient, collectionID, lang, apiRouterVersion, userAccessToken string) {
+func censusLanding(ctx context.Context, w http.ResponseWriter, req *http.Request, dc DatasetClient, datasetModel dataset.DatasetDetails, rend RenderClient, edition string, version dataset.Version, hasOtherVersions bool, collectionID, lang, apiRouterVersion, userAccessToken string) {
+
+	var initialVersion dataset.Version
+	var initialVersionReleaseDate string
+	var err error
+
+	if version.Version != 1 {
+		initialVersion, err = dc.GetVersion(ctx, userAccessToken, "", "", collectionID, datasetModel.ID, edition, "1")
+		initialVersionReleaseDate = initialVersion.ReleaseDate
+	}
+
+	if err != nil {
+		setStatusCode(req, w, err)
+		return
+	}
+
 	basePage := rend.NewBasePageModel()
-	m := mapper.CreateCensusDatasetLandingPage(req, basePage, datasetModel, lang)
+	m := mapper.CreateCensusDatasetLandingPage(req, basePage, datasetModel, version, initialVersionReleaseDate, hasOtherVersions, lang)
 	rend.BuildPage(w, m, "census-landing")
 }
 
@@ -234,11 +249,6 @@ func filterableLanding(w http.ResponseWriter, req *http.Request, dc DatasetClien
 		return
 	}
 
-	if cfg.EnableCensusPages && strings.Contains(datasetModel.Type, "cantabular") {
-		censusLanding(w, req, datasetModel, rend, collectionID, lang, apiRouterVersion, userAccessToken)
-		return
-	}
-
 	if len(edition) == 0 {
 		latestVersionURL, err := url.Parse(datasetModel.Links.LatestVersion.URL)
 		if err != nil {
@@ -284,6 +294,12 @@ func filterableLanding(w http.ResponseWriter, req *http.Request, dc DatasetClien
 		setStatusCode(req, w, err)
 		return
 	}
+
+	if cfg.EnableCensusPages && strings.Contains(datasetModel.Type, "cantabular") {
+		censusLanding(ctx, w, req, dc, datasetModel, rend, edition, ver, displayOtherVersionsLink, collectionID, lang, apiRouterVersion, userAccessToken)
+		return
+	}
+
 	dims := dataset.VersionDimensions{Items: nil}
 	if datasetModel.Type != "nomis" {
 		dims, err = dc.GetVersionDimensions(ctx, userAccessToken, "", collectionID, datasetID, edition, version)

--- a/handlers/handlers_test.go
+++ b/handlers/handlers_test.go
@@ -364,6 +364,32 @@ func TestUnitHandlers(t *testing.T) {
 			So(w.Code, ShouldEqual, http.StatusOK)
 		})
 
+		Convey("census dataset landing page correctly fetches version 1 data for initial release date field, when loading a later version", func() {
+			mockConfig := config.Config{EnableCensusPages: true}
+			mockClient.EXPECT().Get(ctx, userAuthToken, serviceAuthToken, collectionID, "12345").Return(dataset.DatasetDetails{Contacts: &[]dataset.Contact{{Name: "Nick"}}, Type: "cantabular-table", URI: "/economy/grossdomesticproduct/datasets/gdpjanuary2018", Links: dataset.Links{LatestVersion: dataset.Link{URL: "/datasets/12345/editions/2021/versions/2"}}, ID: "12345"}, nil)
+
+			versions := []dataset.Version{
+				{ReleaseDate: "02-01-2005", Version: 1, Links: dataset.Links{Self: dataset.Link{URL: "/datasets/12345/editions/2021/versions/1"}}},
+				{ReleaseDate: "05-01-2005", Version: 2, Links: dataset.Links{Self: dataset.Link{URL: "/datasets/12345/editions/2021/versions/2"}}},
+			}
+			mockClient.EXPECT().GetVersions(ctx, userAuthToken, serviceAuthToken, collectionID, "", "12345", "2021").Return(versions, nil)
+			mockClient.EXPECT().GetVersion(ctx, userAuthToken, serviceAuthToken, collectionID, "", "12345", "2021", "2").Return(versions[1], nil)
+			mockClient.EXPECT().GetVersion(ctx, userAuthToken, serviceAuthToken, collectionID, "", "12345", "2021", "1").Return(versions[0], nil)
+
+			mockRend.EXPECT().NewBasePageModel().Return(coreModel.NewPage(cfg.PatternLibraryAssetsPath, cfg.SiteDomain))
+			mockRend.EXPECT().BuildPage(gomock.Any(), gomock.Any(), "census-landing")
+
+			w := httptest.NewRecorder()
+			req := httptest.NewRequest("GET", "/datasets/12345", nil)
+
+			router := mux.NewRouter()
+			router.HandleFunc("/datasets/{datasetID}", FilterableLanding(mockClient, mockRend, mockZebedeeClient, mockConfig, "/v1"))
+
+			router.ServeHTTP(w, req)
+
+			So(w.Code, ShouldEqual, http.StatusOK)
+		})
+
 		Convey("filterable landing page returned if census config is false", func() {
 			mockConfig := config.Config{EnableCensusPages: false}
 			mockClient.EXPECT().Get(ctx, userAuthToken, serviceAuthToken, collectionID, "12345").Return(dataset.DatasetDetails{Contacts: &[]dataset.Contact{{Name: "Nick"}}, Type: "cantabular-table", URI: "/economy/grossdomesticproduct/datasets/gdpjanuary2018", Links: dataset.Links{LatestVersion: dataset.Link{URL: "/datasets/1234/editions/5678/versions/2017"}}}, nil)

--- a/handlers/handlers_test.go
+++ b/handlers/handlers_test.go
@@ -344,7 +344,11 @@ func TestUnitHandlers(t *testing.T) {
 
 		Convey("filterable landing handler returns census landing template for cantabular types", func() {
 			mockConfig := config.Config{EnableCensusPages: true}
-			mockClient.EXPECT().Get(ctx, userAuthToken, serviceAuthToken, collectionID, "12345").Return(dataset.DatasetDetails{Contacts: &[]dataset.Contact{{Name: "Nick"}}, Type: "cantabular-table", URI: "/economy/grossdomesticproduct/datasets/gdpjanuary2018", Links: dataset.Links{LatestVersion: dataset.Link{URL: "/datasets/1234/editions/5678/versions/2017"}}}, nil)
+			mockClient.EXPECT().Get(ctx, userAuthToken, serviceAuthToken, collectionID, "12345").Return(dataset.DatasetDetails{Contacts: &[]dataset.Contact{{Name: "Nick"}}, Type: "cantabular-table", URI: "/economy/grossdomesticproduct/datasets/gdpjanuary2018", Links: dataset.Links{LatestVersion: dataset.Link{URL: "/datasets/12345/editions/2021/versions/1"}}, ID: "12345"}, nil)
+
+			versions := []dataset.Version{{ReleaseDate: "02-01-2005", Version: 1, Links: dataset.Links{Self: dataset.Link{URL: "/datasets/12345/editions/2021/versions/1"}}}}
+			mockClient.EXPECT().GetVersions(ctx, userAuthToken, serviceAuthToken, collectionID, "", "12345", "2021").Return(versions, nil)
+			mockClient.EXPECT().GetVersion(ctx, userAuthToken, serviceAuthToken, collectionID, "", "12345", "2021", "1").Return(versions[0], nil)
 
 			mockRend.EXPECT().NewBasePageModel().Return(coreModel.NewPage(cfg.PatternLibraryAssetsPath, cfg.SiteDomain))
 			mockRend.EXPECT().BuildPage(gomock.Any(), gomock.Any(), "census-landing")

--- a/mapper/mapper.go
+++ b/mapper/mapper.go
@@ -465,7 +465,7 @@ func CreateEditionsList(basePage coreModel.Page, ctx context.Context, req *http.
 }
 
 // CreateCensusDatasetLandingPage creates a census-landing page based on api model responses
-func CreateCensusDatasetLandingPage(req *http.Request, basePage coreModel.Page, d dataset.DatasetDetails, lang string) datasetLandingPageCensus.Page {
+func CreateCensusDatasetLandingPage(req *http.Request, basePage coreModel.Page, d dataset.DatasetDetails, version dataset.Version, initialVersionReleaseDate string, hasOtherVersions bool, lang string) datasetLandingPageCensus.Page {
 	p := datasetLandingPageCensus.Page{
 		Page: basePage,
 	}
@@ -475,6 +475,16 @@ func CreateCensusDatasetLandingPage(req *http.Request, basePage coreModel.Page, 
 	p.Type = d.Type
 	p.Language = lang
 	p.URI = req.URL.Path
+	p.ID = d.ID
+
+	p.Version.ReleaseDate = version.ReleaseDate
+	if initialVersionReleaseDate == "" {
+		p.InitialReleaseDate = p.Version.ReleaseDate
+	} else {
+		p.InitialReleaseDate = initialVersionReleaseDate
+	}
+
+	p.DatasetLandingPage.HasOtherVersions = hasOtherVersions
 
 	p.Metadata.Title = d.Title
 	p.Metadata.Description = d.Description

--- a/mapper/mapper_test.go
+++ b/mapper/mapper_test.go
@@ -504,6 +504,7 @@ func TestCreateCensusDatasetLandingPage(t *testing.T) {
 		Contacts: &[]dataset.Contact{
 			contact,
 		},
+		ID:          "12345",
 		Description: "An interesting test description",
 		Methodologies: &[]dataset.Methodology{
 			methodology,
@@ -512,9 +513,21 @@ func TestCreateCensusDatasetLandingPage(t *testing.T) {
 		Type:  "cantabular",
 	}
 
-	Convey("Census dataset landing page maps correctly", t, func() {
-		page := CreateCensusDatasetLandingPage(req, pageModel, datasetModel, "")
+	versionOneDetails := dataset.Version{
+		ReleaseDate: "01-01-2021",
+	}
+
+	versionTwoDetails := dataset.Version{
+		ReleaseDate: "15-02-2021",
+	}
+
+	Convey("Census dataset landing page maps correctly as version 1", t, func() {
+		page := CreateCensusDatasetLandingPage(req, pageModel, datasetModel, versionOneDetails, "", false, "")
 		So(page.Type, ShouldEqual, datasetModel.Type)
+		So(page.ID, ShouldEqual, datasetModel.ID)
+		So(page.Version.ReleaseDate, ShouldEqual, versionOneDetails.ReleaseDate)
+		So(page.InitialReleaseDate, ShouldEqual, page.Version.ReleaseDate)
+		So(page.DatasetLandingPage.HasOtherVersions, ShouldEqual, false)
 		So(page.Metadata.Title, ShouldEqual, datasetModel.Title)
 		So(page.Metadata.Description, ShouldEqual, datasetModel.Description)
 		So(page.ContactDetails.Name, ShouldEqual, contact.Name)
@@ -524,6 +537,13 @@ func TestCreateCensusDatasetLandingPage(t *testing.T) {
 		So(page.DatasetLandingPage.Methodologies[0].Description, ShouldEqual, methodology.Description)
 		So(page.DatasetLandingPage.Methodologies[0].Title, ShouldEqual, methodology.Title)
 		So(page.DatasetLandingPage.Methodologies[0].URL, ShouldEqual, methodology.URL)
+	})
+
+	Convey("Release date and hasOtherVersions is mapped correctly when v2 of Census DLP dataset is loaded", t, func() {
+		page := CreateCensusDatasetLandingPage(req, pageModel, datasetModel, versionTwoDetails, versionOneDetails.ReleaseDate, true, "")
+		So(page.InitialReleaseDate, ShouldEqual, "01-01-2021")
+		So(page.Version.ReleaseDate, ShouldEqual, "15-02-2021")
+		So(page.DatasetLandingPage.HasOtherVersions, ShouldEqual, true)
 	})
 
 	noContact := dataset.Contact{
@@ -538,7 +558,7 @@ func TestCreateCensusDatasetLandingPage(t *testing.T) {
 	}
 
 	Convey("No contacts provided, contact section is not displayed", t, func() {
-		page := CreateCensusDatasetLandingPage(req, pageModel, noContactDM, "")
+		page := CreateCensusDatasetLandingPage(req, pageModel, noContactDM, versionOneDetails, "", false, "")
 		So(page.ContactDetails.Name, ShouldEqual, noContact.Name)
 		So(page.ContactDetails.Email, ShouldEqual, noContact.Email)
 		So(page.ContactDetails.Telephone, ShouldEqual, noContact.Telephone)
@@ -557,7 +577,7 @@ func TestCreateCensusDatasetLandingPage(t *testing.T) {
 	}
 
 	Convey("One contact detail provided, contact section is displayed", t, func() {
-		page := CreateCensusDatasetLandingPage(req, pageModel, oneContactDetailDM, "")
+		page := CreateCensusDatasetLandingPage(req, pageModel, oneContactDetailDM, versionOneDetails, "", false, "")
 		So(page.ContactDetails.Name, ShouldEqual, oneContactDetail.Name)
 		So(page.ContactDetails.Email, ShouldEqual, oneContactDetail.Email)
 		So(page.ContactDetails.Telephone, ShouldEqual, oneContactDetail.Telephone)

--- a/mapper/mapper_test.go
+++ b/mapper/mapper_test.go
@@ -541,8 +541,8 @@ func TestCreateCensusDatasetLandingPage(t *testing.T) {
 
 	Convey("Release date and hasOtherVersions is mapped correctly when v2 of Census DLP dataset is loaded", t, func() {
 		page := CreateCensusDatasetLandingPage(req, pageModel, datasetModel, versionTwoDetails, versionOneDetails.ReleaseDate, true, "")
-		So(page.InitialReleaseDate, ShouldEqual, "01-01-2021")
-		So(page.Version.ReleaseDate, ShouldEqual, "15-02-2021")
+		So(page.InitialReleaseDate, ShouldEqual, versionOneDetails.ReleaseDate)
+		So(page.Version.ReleaseDate, ShouldEqual, versionTwoDetails.ReleaseDate)
 		So(page.DatasetLandingPage.HasOtherVersions, ShouldEqual, true)
 	})
 

--- a/model/datasetLandingPageCensus/model.go
+++ b/model/datasetLandingPageCensus/model.go
@@ -9,16 +9,25 @@ import (
 type Page struct {
 	model.Page
 	DatasetLandingPage DatasetLandingPage            `json:"data"`
+	Version            Version                       `json:"version"`
+	InitialReleaseDate string                        `json:"initial_release_date"`
+	ID                 string                        `json:"id"`
 	ContactDetails     contactDetails.ContactDetails `json:"contact_details"`
 	HasContactDetails  bool                          `json:"has_contact_details"`
 }
 
+// Version contains dataset version specific metadata
+type Version struct {
+	ReleaseDate string `json:"release_date"`
+}
+
 // DatasetLandingPage contains properties related to the census dataset landing page
 type DatasetLandingPage struct {
-	GuideContents GuideContents
-	Sections      map[string]Section
-	ShareDetails  ShareDetails
-	Methodologies []Methodology `json:"methodology"`
+	HasOtherVersions bool `json:"has_other_versions"`
+	GuideContents    GuideContents
+	Sections         map[string]Section
+	ShareDetails     ShareDetails
+	Methodologies    []Methodology `json:"methodology"`
 }
 
 // GuideContents contains the contents of the page and the language attribute


### PR DESCRIPTION
### What

- Implemented dataset ID and release date metadata onto Census DLP, including versions history addition when there is more than one version of the dataset (**note:** the versions history component has not yet been implemented)
- Updated `filterableLanding` and `censusLanding` handlers to allow for relevant data to be fetched for the census landing page

![image](https://user-images.githubusercontent.com/23668262/134134093-e865129f-03c5-4caf-9dbc-1c4089c0f4d7.png)

![image](https://user-images.githubusercontent.com/23668262/134133303-e51feaac-ca32-47c3-82b6-2293fe16aceb.png)

### How to review

Sense check changes and review screenshots as per design

You can dummy the other versions check/version history markup by updating the `censusLanding` handler function to include the following lines before the mapper is called. (`handlers.go`, L171):

```
hasOtherVersions = true
initialVersionReleaseDate = "2021-09-01T07:37:03+00:00"
m := mapper.CreateCensusDatasetLandingPage(req, basePage, datasetModel, version, initialVersionReleaseDate, hasOtherVersions, lang)
``` 

### Who can review

Frontend dev
