### PR TITLE
Feature/sticky page contents

### DIFF
--- a/assets/templates/census-landing.tmpl
+++ b/assets/templates/census-landing.tmpl
@@ -1,16 +1,16 @@
 <div class="ons-page__container ons-container ">
-    <div class="ons-grid ons-u-ml-m ons-u-mr-m">
+    <div class="ons-grid ons-u-ml-m ons-u-mr-m ons-js-toc-container">
         {{ template "partials/breadcrumb" . }}
         <section class="ons-u-mb-xl">
             <h1 class="ons-u-fs-xxxl ons-u-mt-l ons-u-mb-m ons-u-pb-no ons-u-pt-no">{{ .Metadata.Title }}</h1>
             {{ template "partials/census/id-datestamp" . }}
         </section>
-        <div class="ons-grid__col ons-col-4@m ons-u-pl-no">
+        <div class="ons-grid__col ons-col-4@m ons-u-pl-no ons-grid__col--sticky@m">
             {{ template "partials/table-of-contents" .DatasetLandingPage.GuideContents }}
         </div>
         <div class="ons-grid__col ons-col-8@m ons-u-pl-no">
-            <section class="ons-u-mt-no ons-u-mb-l" aria-label="{{ localise "Summary" .Language 1 }}">
-            {{ template "partials/census/section" .DatasetLandingPage.Sections.summary }}
+            <section id="{{ .DatasetLandingPage.Sections.summary.ID }}" class="ons-u-mt-no ons-u-mb-l" aria-label="{{ localise "Summary" .Language 1 }}">
+                {{ template "partials/census/section" .DatasetLandingPage.Sections.summary }}
             </section>
             {{ template "partials/census/get-data" . }}
             {{ if .HasContactDetails }}
@@ -21,6 +21,8 @@
                 {{ template "partials/census/methodologies" . }}
             {{ end }}
         </div>
+    </div>
+    <div class="ons-grid ons-u-ml-m ons-u-mr-m">
         {{ if .DatasetLandingPage.ShareDetails }}
             {{ template "partials/share-dataset/share-this-dataset" .DatasetLandingPage.ShareDetails }}
         {{ end }}

--- a/assets/templates/partials/census/section.tmpl
+++ b/assets/templates/partials/census/section.tmpl
@@ -1,4 +1,4 @@
-<h2 id="{{ .ID }}" class="ons-u-fw-b ons-u-pb-no ons-u-mt-no ons-u-pt-no">{{ .Title }}</h2>
+<h2 class="ons-u-fw-b ons-u-pb-no ons-u-mt-no ons-u-pt-no">{{ .Title }}</h2>
 {{ range $i, $v := .Description }}
 <p class="ons-u-fs-r ons-u-mt-s ons-u-mb-s ons-u-pt-no ons-u-pb-no">{{ $v }}</p>
 {{ end }}

--- a/assets/templates/partials/table-of-contents.tmpl
+++ b/assets/templates/partials/table-of-contents.tmpl
@@ -1,7 +1,7 @@
 {{ $guideContents := . }}
 <aside>
     <a class="skiplink" href="#guide-content">{{ localise "ContentsSkipLink" .Language 1 }}</a>
-    <nav class="toc" aria-label="Pages in this guide">
+    <nav class="ons-toc" aria-label="Pages in this guide">
         <h2 class="ons-toc__title ons-u-fs-r--b ons-u-mb-s ons-u-pt-no ons-u-mt-no">{{ localise "Contents" .Language 1 }}</h2>
         <ol id="guide-content" class="ons-list ons-list--dashed ons-u-mb-m">
             {{ range .GuideContent }}

--- a/mapper/mapper.go
+++ b/mapper/mapper.go
@@ -625,7 +625,7 @@ func CreateCensusDatasetLandingPage(req *http.Request, basePage coreModel.Page, 
 	}
 
 	p.BetaBannerEnabled = true
-	p.FeatureFlags.ONSDesignSystemVersion = "40.0.1"
+	p.FeatureFlags.ONSDesignSystemVersion = "41.0.1"
 
 	return p
 }


### PR DESCRIPTION
### What

- Added css classes needed to hook into the [sticky table of contents](https://ons-design-system.netlify.app/components/table-of-contents/) variant
- Updated `design-system` to the latest version

### How to review

- Check the image below
![image](https://user-images.githubusercontent.com/19624419/135606454-5449c7a8-f747-4048-b312-87342c78cf89.png)

- If you have the Cantabular journey setup locally, you can pull the branch and load a census dataset landing page; the page contents should now be 'sticky'
- Verify that the page contents are not 'sticky' in mobile view

### Who can review

Frontend dev
