### PR TITLE
Fix/update census landing page mapping

### DIFF
--- a/mapper/mapper.go
+++ b/mapper/mapper.go
@@ -367,17 +367,13 @@ func CreateCensusDatasetLandingPage(ctx context.Context, req *http.Request, base
 		p.Version.Downloads = append(p.Version.Downloads, sharedModel.Download{
 			Extension: ext,
 			Size:      download.Size,
-			URI:       download.URL,
+			URI:       download.Public,
 			Name:      fmt.Sprintf("%s.%s", filename, strings.ToLower(ext)),
 		})
 	}
 
 	if d.Contacts != nil && len(*d.Contacts) > 0 {
 		contacts := *d.Contacts
-		if contacts[0].Name != "" {
-			p.ContactDetails.Name = contacts[0].Name
-			p.HasContactDetails = true
-		}
 		if contacts[0].Telephone != "" {
 			p.ContactDetails.Telephone = contacts[0].Telephone
 			p.HasContactDetails = true

--- a/mapper/mapper_test.go
+++ b/mapper/mapper_test.go
@@ -491,7 +491,6 @@ func TestCreateCensusDatasetLandingPage(t *testing.T) {
 	req := httptest.NewRequest("", "/", nil)
 	pageModel := model.Page{}
 	contact := dataset.Contact{
-		Name:      "Test contact",
 		Telephone: "01232 123 123",
 		Email:     "hello@testing.com",
 	}
@@ -517,8 +516,8 @@ func TestCreateCensusDatasetLandingPage(t *testing.T) {
 		ReleaseDate: "01-01-2021",
 		Downloads: map[string]dataset.Download{
 			"XLSX": {
-				Size: "438290",
-				URL:  "my-url",
+				Size:   "438290",
+				Public: "my-url",
 			},
 		},
 	}
@@ -603,8 +602,8 @@ func TestCreateCensusDatasetLandingPage(t *testing.T) {
 		versionDetails := dataset.Version{
 			Downloads: map[string]dataset.Download{
 				"XLSX": {
-					Size: "438290",
-					URL:  "my-url",
+					Size:   "438290",
+					Public: "my-url",
 				},
 			},
 		}
@@ -613,7 +612,6 @@ func TestCreateCensusDatasetLandingPage(t *testing.T) {
 	})
 
 	noContact := dataset.Contact{
-		Name:      "",
 		Telephone: "",
 		Email:     "",
 	}
@@ -625,15 +623,13 @@ func TestCreateCensusDatasetLandingPage(t *testing.T) {
 
 	Convey("No contacts provided, contact section is not displayed", t, func() {
 		page := CreateCensusDatasetLandingPage(context.Background(), req, pageModel, noContactDM, versionOneDetails, datasetOptions, dataset.VersionDimensions{}, "", false, "", 50)
-		So(page.ContactDetails.Name, ShouldEqual, noContact.Name)
 		So(page.ContactDetails.Email, ShouldEqual, noContact.Email)
 		So(page.ContactDetails.Telephone, ShouldEqual, noContact.Telephone)
 		So(page.HasContactDetails, ShouldBeFalse)
 	})
 
 	oneContactDetail := dataset.Contact{
-		Name:      "Only a name",
-		Telephone: "",
+		Telephone: "123",
 		Email:     "",
 	}
 	oneContactDetailDM := dataset.DatasetDetails{
@@ -644,7 +640,6 @@ func TestCreateCensusDatasetLandingPage(t *testing.T) {
 
 	Convey("One contact detail provided, contact section is displayed", t, func() {
 		page := CreateCensusDatasetLandingPage(context.Background(), req, pageModel, oneContactDetailDM, versionOneDetails, datasetOptions, dataset.VersionDimensions{}, "", false, "", 50)
-		So(page.ContactDetails.Name, ShouldEqual, oneContactDetail.Name)
 		So(page.ContactDetails.Email, ShouldEqual, oneContactDetail.Email)
 		So(page.ContactDetails.Telephone, ShouldEqual, oneContactDetail.Telephone)
 		So(page.HasContactDetails, ShouldBeTrue)


### PR DESCRIPTION
### What

Updated mappings to latest
- Removed unnecessary mapping to contact name (not used on census DLP)
- Downloadable file URL has moved to `Public`

### How to review

- Sense check
- Tests pass

### Who can review

Anyone but me
