### PR TITLE
update dp-renderer to v1.5.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/ONSdigital/dp-cookies v0.2.0
 	github.com/ONSdigital/dp-healthcheck v1.0.5
 	github.com/ONSdigital/dp-net v1.0.12
-	github.com/ONSdigital/dp-renderer v1.5.0
+	github.com/ONSdigital/dp-renderer v1.5.1
 	github.com/ONSdigital/log.go/v2 v2.0.9
 	github.com/golang/mock v1.6.0
 	github.com/gorilla/mux v1.8.0

--- a/go.sum
+++ b/go.sum
@@ -26,6 +26,8 @@ github.com/ONSdigital/dp-renderer v1.4.0 h1:Z5A8Fwed7eca1bAWoZRo9AxXiZxg1Rm80t7z
 github.com/ONSdigital/dp-renderer v1.4.0/go.mod h1:Z5sbyS0ApY6D8ikGDt2KIl5bt2p5kk73PeeMxGs1pEM=
 github.com/ONSdigital/dp-renderer v1.5.0 h1:VLPDM/x1emTzVtdwuEggS3DJd3OS+CqyIVdXxjN4BfQ=
 github.com/ONSdigital/dp-renderer v1.5.0/go.mod h1:Z5sbyS0ApY6D8ikGDt2KIl5bt2p5kk73PeeMxGs1pEM=
+github.com/ONSdigital/dp-renderer v1.5.1 h1:uBcpWkQgBu55L6U7d1z4vD8zLs1L/tDyhLWm4aNlhwk=
+github.com/ONSdigital/dp-renderer v1.5.1/go.mod h1:Z5sbyS0ApY6D8ikGDt2KIl5bt2p5kk73PeeMxGs1pEM=
 github.com/ONSdigital/go-ns v0.0.0-20191104121206-f144c4ec2e58/go.mod h1:iWos35il+NjbvDEqwtB736pyHru0MPFE/LqcwkV1wDc=
 github.com/ONSdigital/log.go v1.0.0/go.mod h1:UnGu9Q14gNC+kz0DOkdnLYGoqugCvnokHBRBxFRpVoQ=
 github.com/ONSdigital/log.go v1.0.1-0.20200805084515-ee61165ea36a/go.mod h1:dDnQATFXCBOknvj6ZQuKfmDhbOWf3e8mtV+dPEfWJqs=


### PR DESCRIPTION
### What

- Bump `dp-renderer` from `v1.5.0` to `v1.5.1`. This version of `dp-renderer` fixes the beta banner margins in the mobile viewport to correctly align with the rest of the page layout

### How to review

- Sense check

### Who can review

Anyone
