### PR TITLE
Fix/broken components on census dateset landing page

### DIFF
--- a/assets/templates/partials/census/id-datestamp.tmpl
+++ b/assets/templates/partials/census/id-datestamp.tmpl
@@ -4,11 +4,15 @@
         <dd class="ons-metadata__value ons-u-f-no ons-u-dib">{{ .ID }}</dd>
     </div>
     {{ if .DatasetLandingPage.HasOtherVersions }}
-        <div class="ons-grid__col ons-col-12@m">
-            <dt class="ons-metadata__term ons-u-mr-xs ons-u-dib u-f-no">{{ localise "Released" .Language 1 }}:</dt>
+        <div class="ons-grid__col ons-col-4@m ons-u-mt-xs">
+            <dt class="ons-metadata__term ons-u-mr-xs ons-u-dib ons-u-f-no">{{ localise "Released" .Language 1 }}:</dt>
             <dd class="ons-metadata__value ons-u-f-no ons-u-mr-xs ons-u-dib">{{ dateFormat .InitialReleaseDate }}</dd>
+        </div>
+        <div class="ons-grid__col ons-col-8@m ons-u-mt-xs">
             <dt class="ons-metadata__term ons-u-dib ons-u-mt-no ons-u-f-no">{{ localise "LastUpdated" .Language 1 }}:</dt>
-            <dd class="ons-metadata__value ons-u-f-no ons-u-dib">{{ dateFormat .Version.ReleaseDate }} &mdash; <a href="#version-history">{{ localise "SeeVersionHistory" .Language 1 }}</a></dd>
+            <dd class="ons-metadata__value ons-u-f-no ons-u-dib">{{ dateFormat .Version.ReleaseDate }} &mdash;
+                <a href="#version-history">{{ localise "SeeVersionHistory" .Language 1 }}</a>
+            </dd>
         </div>
     {{ else }}
         <div class="ons-grid__col ons-col-12@m ons-u-mt-xs">

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/ONSdigital/dp-cookies v0.2.0
 	github.com/ONSdigital/dp-healthcheck v1.0.5
 	github.com/ONSdigital/dp-net v1.0.12
-	github.com/ONSdigital/dp-renderer v1.5.1
+	github.com/ONSdigital/dp-renderer v1.7.0
 	github.com/ONSdigital/log.go/v2 v2.0.9
 	github.com/golang/mock v1.6.0
 	github.com/gorilla/mux v1.8.0

--- a/go.sum
+++ b/go.sum
@@ -28,6 +28,8 @@ github.com/ONSdigital/dp-renderer v1.5.0 h1:VLPDM/x1emTzVtdwuEggS3DJd3OS+CqyIVdX
 github.com/ONSdigital/dp-renderer v1.5.0/go.mod h1:Z5sbyS0ApY6D8ikGDt2KIl5bt2p5kk73PeeMxGs1pEM=
 github.com/ONSdigital/dp-renderer v1.5.1 h1:uBcpWkQgBu55L6U7d1z4vD8zLs1L/tDyhLWm4aNlhwk=
 github.com/ONSdigital/dp-renderer v1.5.1/go.mod h1:Z5sbyS0ApY6D8ikGDt2KIl5bt2p5kk73PeeMxGs1pEM=
+github.com/ONSdigital/dp-renderer v1.7.0 h1:OwzOp/ATjp3ZkfDv7mb/nwc4NthC5q9brkPemHx+pzs=
+github.com/ONSdigital/dp-renderer v1.7.0/go.mod h1:Z5sbyS0ApY6D8ikGDt2KIl5bt2p5kk73PeeMxGs1pEM=
 github.com/ONSdigital/go-ns v0.0.0-20191104121206-f144c4ec2e58/go.mod h1:iWos35il+NjbvDEqwtB736pyHru0MPFE/LqcwkV1wDc=
 github.com/ONSdigital/log.go v1.0.0/go.mod h1:UnGu9Q14gNC+kz0DOkdnLYGoqugCvnokHBRBxFRpVoQ=
 github.com/ONSdigital/log.go v1.0.1-0.20200805084515-ee61165ea36a/go.mod h1:dDnQATFXCBOknvj6ZQuKfmDhbOWf3e8mtV+dPEfWJqs=

--- a/mapper/mapper.go
+++ b/mapper/mapper.go
@@ -493,7 +493,7 @@ func CreateCensusDatasetLandingPage(ctx context.Context, req *http.Request, base
 	}
 
 	p.BetaBannerEnabled = true
-	p.FeatureFlags.ONSDesignSystemVersion = "41.0.1"
+	p.FeatureFlags.ONSDesignSystemVersion = "42.0.0"
 
 	if len(opts) > 0 {
 		p.DatasetLandingPage.Dimensions = mapOptionsToDimensions(ctx, d.Type, dims, opts, d.Links.LatestVersion.URL, maxNumberOfOptions)


### PR DESCRIPTION
### What

- Updated to latest renderer library version
  - Latest download icon
  - Fixes page contents component 'stickyness'
- Updated to latest design system version
- Fixed alignment on version history 
- Fixed invalid html 

### How to review

Example broken page in dev := https://develop.onsdigital.co.uk/datasets/cantabular-today-1/editions/2021/versions/1

If you have the [Cantabular-import](https://github.com/ONSdigital/dp-compose/tree/main/cantabular-import) journey running locally, you can pull the branch and compare the changes against develop
- Add the following code into `handlers.go` above line 188; this will display downloads and the 'last updated' metadata
``` go
	downloads := map[string]dataset.Download{
		"XLS": {
			Size: "78600",
			URL:  "https://www.my-url.com/file.xls",
		},
		"CSV": {
			Size: "554700",
			URL:  "https://www.my-url.com/file.csv",
		},
		"CSVW": {
			Size: "1900",
			URL:  "https://www.my-url.com/file.csvw",
		},
		"JSON": {
			Size: "10900",
			URL:  "https://www.my-url.com/file.json",
		},
		"TXT": {
			Size: "2600",
			URL:  "https://www.my-url.com/metadata.txt",
		},
	}

	version.Downloads = downloads
	hasOtherVersions = true
	initialVersionReleaseDate = "2021-09-01T07:37:03+00:00"
```

- Sense check
- Check layout against figma design
- To check html validity:
   - Grab the markup from the broken page in dev and paste into the text area box on the [markup validation service](https://validator.w3.org/#validate_by_input) and click 'check'; note the error
   - Do the same for the local branch
   - You shouldn't have any errors

### Who can review

Frontend dev
