### PR TITLE
Update dp-renderer to 1.8.0 and make dp-design-system the priority over sixteens

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -34,7 +34,7 @@ func Get() (*Config, error) {
 	}
 
 	if cfg.Debug {
-		cfg.PatternLibraryAssetsPath = "http://localhost:9001/dist/assets"
+		cfg.PatternLibraryAssetsPath = "http://localhost:9002/dist/assets"
 	} else {
 		cfg.PatternLibraryAssetsPath = "//cdn.ons.gov.uk/dp-design-system/ba32e79"
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -36,7 +36,7 @@ func Get() (*Config, error) {
 	if cfg.Debug {
 		cfg.PatternLibraryAssetsPath = "http://localhost:9002/dist/assets"
 	} else {
-		cfg.PatternLibraryAssetsPath = "//cdn.ons.gov.uk/dp-design-system/ba32e79"
+		cfg.PatternLibraryAssetsPath = "//cdn.ons.gov.uk/dp-design-system/2a0a094"
 	}
 	return cfg, nil
 }

--- a/config/config.go
+++ b/config/config.go
@@ -36,7 +36,7 @@ func Get() (*Config, error) {
 	if cfg.Debug {
 		cfg.PatternLibraryAssetsPath = "http://localhost:9002/dist/assets"
 	} else {
-		cfg.PatternLibraryAssetsPath = "//cdn.ons.gov.uk/dp-design-system/2a0a094"
+		cfg.PatternLibraryAssetsPath = "//cdn.ons.gov.uk/dp-design-system/431b81f"
 	}
 	return cfg, nil
 }

--- a/config/config.go
+++ b/config/config.go
@@ -34,9 +34,9 @@ func Get() (*Config, error) {
 	}
 
 	if cfg.Debug {
-		cfg.PatternLibraryAssetsPath = "http://localhost:9000/dist"
+		cfg.PatternLibraryAssetsPath = "http://localhost:9001/dist/assets"
 	} else {
-		cfg.PatternLibraryAssetsPath = "//cdn.ons.gov.uk/sixteens/c690dcd"
+		cfg.PatternLibraryAssetsPath = "//cdn.ons.gov.uk/dp-design-system/ba32e79"
 	}
 	return cfg, nil
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -31,7 +31,7 @@ func TestConfig(t *testing.T) {
 				So(cfg.HealthCheckInterval, ShouldEqual, 30*time.Second)
 				So(cfg.HealthCheckCriticalTimeout, ShouldEqual, 90*time.Second)
 				So(cfg.EnableProfiler, ShouldBeFalse)
-				So(cfg.PatternLibraryAssetsPath, ShouldEqual, "//cdn.ons.gov.uk/dp-design-system/2a0a094")
+				So(cfg.PatternLibraryAssetsPath, ShouldEqual, "//cdn.ons.gov.uk/dp-design-system/431b81f")
 			})
 		})
 	})

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -31,7 +31,7 @@ func TestConfig(t *testing.T) {
 				So(cfg.HealthCheckInterval, ShouldEqual, 30*time.Second)
 				So(cfg.HealthCheckCriticalTimeout, ShouldEqual, 90*time.Second)
 				So(cfg.EnableProfiler, ShouldBeFalse)
-				So(cfg.PatternLibraryAssetsPath, ShouldEqual, "//cdn.ons.gov.uk/sixteens/c690dcd")
+				So(cfg.PatternLibraryAssetsPath, ShouldEqual, "//cdn.ons.gov.uk/dp-design-system/ba32e79")
 			})
 		})
 	})

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -31,7 +31,7 @@ func TestConfig(t *testing.T) {
 				So(cfg.HealthCheckInterval, ShouldEqual, 30*time.Second)
 				So(cfg.HealthCheckCriticalTimeout, ShouldEqual, 90*time.Second)
 				So(cfg.EnableProfiler, ShouldBeFalse)
-				So(cfg.PatternLibraryAssetsPath, ShouldEqual, "//cdn.ons.gov.uk/dp-design-system/ba32e79")
+				So(cfg.PatternLibraryAssetsPath, ShouldEqual, "//cdn.ons.gov.uk/dp-design-system/2a0a094")
 			})
 		})
 	})

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/ONSdigital/dp-cookies v0.2.0
 	github.com/ONSdigital/dp-healthcheck v1.0.5
 	github.com/ONSdigital/dp-net v1.0.12
-	github.com/ONSdigital/dp-renderer v1.8.0
+	github.com/ONSdigital/dp-renderer v1.8.2-0.20211110135111-a7ec52878b3f
 	github.com/ONSdigital/log.go/v2 v2.0.9
 	github.com/golang/mock v1.6.0
 	github.com/gorilla/mux v1.8.0

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/ONSdigital/dp-cookies v0.2.0
 	github.com/ONSdigital/dp-healthcheck v1.0.5
 	github.com/ONSdigital/dp-net v1.0.12
-	github.com/ONSdigital/dp-renderer v1.7.0
+	github.com/ONSdigital/dp-renderer v1.8.0
 	github.com/ONSdigital/log.go/v2 v2.0.9
 	github.com/golang/mock v1.6.0
 	github.com/gorilla/mux v1.8.0

--- a/go.sum
+++ b/go.sum
@@ -30,6 +30,8 @@ github.com/ONSdigital/dp-renderer v1.5.1 h1:uBcpWkQgBu55L6U7d1z4vD8zLs1L/tDyhLWm
 github.com/ONSdigital/dp-renderer v1.5.1/go.mod h1:Z5sbyS0ApY6D8ikGDt2KIl5bt2p5kk73PeeMxGs1pEM=
 github.com/ONSdigital/dp-renderer v1.7.0 h1:OwzOp/ATjp3ZkfDv7mb/nwc4NthC5q9brkPemHx+pzs=
 github.com/ONSdigital/dp-renderer v1.7.0/go.mod h1:Z5sbyS0ApY6D8ikGDt2KIl5bt2p5kk73PeeMxGs1pEM=
+github.com/ONSdigital/dp-renderer v1.8.0 h1:9i4q8Ogbs6bLsOvbvPYPe5a7VA1fKJuozcH+4Q1SEpM=
+github.com/ONSdigital/dp-renderer v1.8.0/go.mod h1:Z5sbyS0ApY6D8ikGDt2KIl5bt2p5kk73PeeMxGs1pEM=
 github.com/ONSdigital/go-ns v0.0.0-20191104121206-f144c4ec2e58/go.mod h1:iWos35il+NjbvDEqwtB736pyHru0MPFE/LqcwkV1wDc=
 github.com/ONSdigital/log.go v1.0.0/go.mod h1:UnGu9Q14gNC+kz0DOkdnLYGoqugCvnokHBRBxFRpVoQ=
 github.com/ONSdigital/log.go v1.0.1-0.20200805084515-ee61165ea36a/go.mod h1:dDnQATFXCBOknvj6ZQuKfmDhbOWf3e8mtV+dPEfWJqs=

--- a/go.sum
+++ b/go.sum
@@ -32,6 +32,8 @@ github.com/ONSdigital/dp-renderer v1.7.0 h1:OwzOp/ATjp3ZkfDv7mb/nwc4NthC5q9brkPe
 github.com/ONSdigital/dp-renderer v1.7.0/go.mod h1:Z5sbyS0ApY6D8ikGDt2KIl5bt2p5kk73PeeMxGs1pEM=
 github.com/ONSdigital/dp-renderer v1.8.0 h1:9i4q8Ogbs6bLsOvbvPYPe5a7VA1fKJuozcH+4Q1SEpM=
 github.com/ONSdigital/dp-renderer v1.8.0/go.mod h1:Z5sbyS0ApY6D8ikGDt2KIl5bt2p5kk73PeeMxGs1pEM=
+github.com/ONSdigital/dp-renderer v1.8.2-0.20211110135111-a7ec52878b3f h1:TeofniNiwjIWRiLZmg1kWaAybARn4HxexqyuSyKopzk=
+github.com/ONSdigital/dp-renderer v1.8.2-0.20211110135111-a7ec52878b3f/go.mod h1:Z5sbyS0ApY6D8ikGDt2KIl5bt2p5kk73PeeMxGs1pEM=
 github.com/ONSdigital/go-ns v0.0.0-20191104121206-f144c4ec2e58/go.mod h1:iWos35il+NjbvDEqwtB736pyHru0MPFE/LqcwkV1wDc=
 github.com/ONSdigital/log.go v1.0.0/go.mod h1:UnGu9Q14gNC+kz0DOkdnLYGoqugCvnokHBRBxFRpVoQ=
 github.com/ONSdigital/log.go v1.0.1-0.20200805084515-ee61165ea36a/go.mod h1:dDnQATFXCBOknvj6ZQuKfmDhbOWf3e8mtV+dPEfWJqs=

--- a/mapper/legacy.go
+++ b/mapper/legacy.go
@@ -40,6 +40,7 @@ func CreateLegacyDatasetLanding(basePage coreModel.Page, ctx context.Context, re
 	sdlp.Metadata.Description = dlp.Description.Summary
 	sdlp.Language = localeCode
 	sdlp.HasJSONLD = true
+	sdlp.FeatureFlags.SixteensVersion = CurrentSixteensVersion
 
 	for _, d := range dlp.RelatedDatasets {
 		sdlp.DatasetLandingPage.Related.Datasets = append(sdlp.DatasetLandingPage.Related.Datasets, related.Related(d))

--- a/mapper/legacy.go
+++ b/mapper/legacy.go
@@ -40,7 +40,7 @@ func CreateLegacyDatasetLanding(basePage coreModel.Page, ctx context.Context, re
 	sdlp.Metadata.Description = dlp.Description.Summary
 	sdlp.Language = localeCode
 	sdlp.HasJSONLD = true
-	sdlp.FeatureFlags.SixteensVersion = CurrentSixteensVersion
+	sdlp.FeatureFlags.SixteensVersion = SixteensVersion
 
 	for _, d := range dlp.RelatedDatasets {
 		sdlp.DatasetLandingPage.Related.Datasets = append(sdlp.DatasetLandingPage.Related.Datasets, related.Related(d))

--- a/mapper/mapper.go
+++ b/mapper/mapper.go
@@ -29,9 +29,10 @@ type TimeSlice []time.Time
 
 // Dimension names
 const (
-	DimensionTime      = "time"
-	DimensionAge       = "age"
-	DimensionGeography = "geography"
+	DimensionTime          = "time"
+	DimensionAge           = "age"
+	DimensionGeography     = "geography"
+	CurrentSixteensVersion = "67f6982"
 )
 
 func (p TimeSlice) Len() int {
@@ -74,6 +75,7 @@ func CreateFilterableLandingPage(basePage coreModel.Page, ctx context.Context, r
 	p.DatasetId = datasetID
 	p.ReleaseDate = ver.ReleaseDate
 	p.BetaBannerEnabled = true
+	p.FeatureFlags.SixteensVersion = CurrentSixteensVersion
 
 	if d.Type == "nomis" {
 		p.DatasetLandingPage.NomisReferenceURL = d.NomisReferenceURL
@@ -230,6 +232,7 @@ func CreateVersionsList(basePage coreModel.Page, req *http.Request, d dataset.Da
 	p.Data.LatestVersionURL = helpers.DatasetVersionUrl(d.ID, edition.Edition, edition.Links.LatestVersion.ID)
 	p.DatasetId = d.ID
 	p.URI = req.URL.Path
+	p.FeatureFlags.SixteensVersion = CurrentSixteensVersion
 
 	latestVersionNumber := 1
 	for _, ver := range versions {
@@ -299,6 +302,7 @@ func CreateEditionsList(basePage coreModel.Page, ctx context.Context, req *http.
 	p.Metadata.Description = d.Description
 	p.DatasetId = datasetID
 	p.BetaBannerEnabled = true
+	p.FeatureFlags.SixteensVersion = CurrentSixteensVersion
 
 	for _, bc := range breadcrumbs {
 		p.Breadcrumb = append(p.Breadcrumb, coreModel.TaxonomyNode{
@@ -493,7 +497,6 @@ func CreateCensusDatasetLandingPage(ctx context.Context, req *http.Request, base
 	}
 
 	p.BetaBannerEnabled = true
-	p.FeatureFlags.ONSDesignSystemVersion = "42.0.0"
 
 	if len(opts) > 0 {
 		p.DatasetLandingPage.Dimensions = mapOptionsToDimensions(ctx, d.Type, dims, opts, d.Links.LatestVersion.URL, maxNumberOfOptions)

--- a/mapper/mapper.go
+++ b/mapper/mapper.go
@@ -29,10 +29,10 @@ type TimeSlice []time.Time
 
 // Dimension names
 const (
-	DimensionTime          = "time"
-	DimensionAge           = "age"
-	DimensionGeography     = "geography"
-	CurrentSixteensVersion = "67f6982"
+	DimensionTime      = "time"
+	DimensionAge       = "age"
+	DimensionGeography = "geography"
+	SixteensVersion    = "67f6982"
 )
 
 func (p TimeSlice) Len() int {
@@ -75,7 +75,7 @@ func CreateFilterableLandingPage(basePage coreModel.Page, ctx context.Context, r
 	p.DatasetId = datasetID
 	p.ReleaseDate = ver.ReleaseDate
 	p.BetaBannerEnabled = true
-	p.FeatureFlags.SixteensVersion = CurrentSixteensVersion
+	p.FeatureFlags.SixteensVersion = SixteensVersion
 
 	if d.Type == "nomis" {
 		p.DatasetLandingPage.NomisReferenceURL = d.NomisReferenceURL
@@ -232,7 +232,7 @@ func CreateVersionsList(basePage coreModel.Page, req *http.Request, d dataset.Da
 	p.Data.LatestVersionURL = helpers.DatasetVersionUrl(d.ID, edition.Edition, edition.Links.LatestVersion.ID)
 	p.DatasetId = d.ID
 	p.URI = req.URL.Path
-	p.FeatureFlags.SixteensVersion = CurrentSixteensVersion
+	p.FeatureFlags.SixteensVersion = SixteensVersion
 
 	latestVersionNumber := 1
 	for _, ver := range versions {
@@ -302,7 +302,7 @@ func CreateEditionsList(basePage coreModel.Page, ctx context.Context, req *http.
 	p.Metadata.Description = d.Description
 	p.DatasetId = datasetID
 	p.BetaBannerEnabled = true
-	p.FeatureFlags.SixteensVersion = CurrentSixteensVersion
+	p.FeatureFlags.SixteensVersion = SixteensVersion
 
 	for _, bc := range breadcrumbs {
 		p.Breadcrumb = append(p.Breadcrumb, coreModel.TaxonomyNode{


### PR DESCRIPTION
### What

Updated `dp-renderer` to 1.8.0 and updated mapper functions to use `SixteensVersion` where pertinent

### How to review

- Sense check code
- Check pages handled by the dataset controller locally to ensure that they are loading in either Sixteens or dp-design-system. If it is a CMD or legacy dataset page, then that should be loading in Sixteens. If it's the Census dataset landing page, then dp-design-system should be loaded in

### Who can review

Anyone
