### PR TITLE
Feature/update census dataset landing page design

### DIFF
--- a/assets/templates/census-landing.tmpl
+++ b/assets/templates/census-landing.tmpl
@@ -1,5 +1,5 @@
-<div class="ons-page__container ons-container ">
-    <div class="ons-grid ons-u-ml-m@m ons-u-mr-m@m ons-u-ml-no ons-js-toc-container">
+<div class="ons-page__container ons-container">
+    <div class="ons-grid ons-js-toc-container ons-u-ml-no">
         {{ template "partials/breadcrumb" . }}
         <section class="ons-u-mb-xl">
             <h1 class="ons-u-fs-xxxl ons-u-mt-s ons-u-mb-m ons-u-pb-no ons-u-pt-no">{{ .Metadata.Title }}</h1>
@@ -9,7 +9,7 @@
             {{ template "partials/table-of-contents" .DatasetLandingPage.GuideContents }}
         </div>
         <div class="ons-grid__col ons-col-8@m ons-u-pl-no">
-            <section id="{{ .DatasetLandingPage.Sections.summary.ID }}" class="ons-u-mt-no ons-u-mb-l" aria-label="{{ localise "Summary" .Language 1 }}">
+            <section id="{{ .DatasetLandingPage.Sections.summary.ID }}" aria-label="{{ localise "Summary" .Language 1 }}">
                 {{ template "partials/census/section" .DatasetLandingPage.Sections.summary }}
             </section>
             {{ template "partials/census/variables-table" . }}
@@ -23,7 +23,7 @@
             {{ end }}
         </div>
     </div>
-    <div class="ons-grid ons-u-ml-m@m ons-u-mr-m@m ons-u-ml-no">
+    <div class="ons-grid ons-u-ml-no ons-u-mb-xl">
         {{ if .DatasetLandingPage.ShareDetails }}
             {{ template "partials/share-dataset/share-this-dataset" .DatasetLandingPage.ShareDetails }}
         {{ end }}

--- a/assets/templates/partials/census/collapsible.tmpl
+++ b/assets/templates/partials/census/collapsible.tmpl
@@ -1,10 +1,12 @@
-<div id="collapsible" class="ons-collapsible ons-js-collapsible ons-collapsible--initialised ons-u-pb-no" data-btn-close="{{ localise "HideThis" .Language 1 }}">
+<div id="collapsible" class="ons-collapsible ons-js-collapsible" data-btn-close="{{ localise "HideThis" .Language 1 }}">
     <div class="ons-collapsible__heading ons-js-collapsible-heading">
         <div class="ons-collapsible__controls">
-            <h2 class="ons-collapsible__title ons-u-mt-no">{{ .Title }}</h2>
-            <span class="ons-collapsible__icon ons-u-pt-xxs">
+            <h2 class="ons-collapsible__title">{{ .Title }}</h2>
+            <span class="ons-collapsible__icon">
                 <svg class="ons-svg-icon" viewBox="0 0 8 13" xmlns="http://www.w3.org/2000/svg" focusable="false">
-                    <path d="M5.74,14.28l-.57-.56a.5.5,0,0,1,0-.71h0l5-5-5-5a.5.5,0,0,1,0-.71h0l.57-.56a.5.5,0,0,1,.71,0h0l5.93,5.93a.5.5,0,0,1,0,.7L6.45,14.28a.5.5,0,0,1-.71,0Z" transform="translate(-5.02 -1.59)"></path>
+                    <path
+                        d="M5.74,14.28l-.57-.56a.5.5,0,0,1,0-.71h0l5-5-5-5a.5.5,0,0,1,0-.71h0l.57-.56a.5.5,0,0,1,.71,0h0l5.93,5.93a.5.5,0,0,1,0,.7L6.45,14.28a.5.5,0,0,1-.71,0Z"
+                        transform="translate(-5.02 -1.59)"></path>
                 </svg>
             </span>
         </div>
@@ -13,8 +15,12 @@
         {{ range $i, $v := .Content }}
             <p class="ons-u-fs-r ons-u-mb-s ons-u-p-no">{{ $v }}</p>
         {{ end }}
-        <button type="button" class="ons-btn ons-btn--small ons-js-collapsible-button ons-btn--secondary ons-u-d-no ons-u-p-no" aria-controls="collapsible">
+        <button
+            type="button"
+            class="ons-btn ons-js-collapsible-button ons-u-d-no ons-btn--secondary ons-btn--small"
+            aria-controls="collapsible">
             <span class="ons-btn__inner ons-js-collapsible-button-inner">{{ localise "HideThis" .Language 1 }}</span>
+            <span class="ons-btn__context ons-u-vh">{{ .Title }} content</span>
         </button>
     </div>
 </div>

--- a/assets/templates/partials/census/contact-details.tmpl
+++ b/assets/templates/partials/census/contact-details.tmpl
@@ -1,17 +1,17 @@
-<section id="contact" class="ons-u-mt-l ons-u-mb-l" aria-label="{{ localise "RelatedLinksForCensus" .Language 1 }}">
-    <h2 class="ons-u-fw-b ons-u-mt-l ons-u-pb-no ons-u-pt-no" id="contact-details">{{ localise "ContactDetails" .Language 1 }}</h2>
+<section id="contact" aria-label="{{ localise "RelatedLinksForCensus" .Language 1 }}">
+    <h2 class="ons-u-mt-l ons-u-pb-no ons-u-pt-no" id="contact-details">{{ localise "ContactDetails" .Language 1 }}</h2>
     <nav class="ons-related-content__navigation" aria-labelledby="contact-details">
         <ul class="ons-list ons-list--bare ons-u-fs-r">
             {{ if .ContactDetails.Email }}
-                <li class="ons-list__item ons-u-mt-s ons-u-mb-s ons-u-pl-no ons-u-pb-no ons-u-pt-no ons-u-fs-r">
-                    <p class="ons-u-mt-no ons-u-mt-no ons-u-mb-no ons-u-fs-r ons-u-pt-no ons-u-pb-no">{{ localise "Email" .Language 1 }}</p>
-                    <a href="mailto:{{.ContactDetails.Email}}" class="ons-list__link underline-link">{{ .ContactDetails.Email }}</a>
+                <li class="ons-list__item ons-u-mt-s">
+                    <p class="ons-u-mb-no">{{ localise "Email" .Language 1 }}</p>
+                    <a href="mailto:{{.ContactDetails.Email}}" class="ons-list__link">{{ .ContactDetails.Email }}</a>
                 </li>
             {{ end }}
             {{ if .ContactDetails.Telephone }}
-                <li class="ons-list__item ons-u-mt-s ons-u-mb-s ons-u-pl-no ons-u-pb-no ons-u-pt-no ons-u-fs-r">
-                    <p class="ons-u-mt-no ons-u-mb-no ons-u-fs-r ons-u-pt-no ons-u-pb-no">{{ localise "Phone" .Language 1 }}</p>
-                    <a href="tel:{{ .ContactDetails.Telephone | safeHTML }}" class="ons-list__link underline-link">{{ .ContactDetails.Telephone }}</a>
+                <li class="ons-list__item ons-u-mt-s">
+                    <p class="ons-u-mb-no">{{ localise "Phone" .Language 1 }}</p>
+                    <a href="tel:{{ .ContactDetails.Telephone | safeHTML }}" class="ons-list__link">{{ .ContactDetails.Telephone }}</a>
                 </li>
             {{ end }}
         </ul>

--- a/assets/templates/partials/census/get-data.tmpl
+++ b/assets/templates/partials/census/get-data.tmpl
@@ -1,15 +1,15 @@
 {{ $length := len .Version.Downloads }}
-<section id="get-data" class="ons-u-mt-l ons-u-mb-l" aria-label="{{ localise "GetData" .Language 1 }}">
-    <h2 class="ons-u-fw-b ons-u-mt-l ons-u-pb-no ons-u-pt-no">{{ localise "GetData" .Language 1 }}</h2>
-    <p class="ons-u-fs-r ons-u-mt-s ons-u-mb-s ons-u-pt-no ons-u-pb-s">{{ localise "GetDataLeadText" .Language 1 }}</p>
+<section id="get-data" aria-label="{{ localise "GetData" .Language 1 }}">
+    <h2 class="ons-u-mt-xl ons-u-pb-no ons-u-pt-no">{{ localise "GetData" .Language 1 }}</h2>
+    <p class="ons-u-mt-s ons-u-mb-s ons-u-pb-s">{{ localise "GetDataLeadText" .Language 1 }}</p>
     <ul class="ons-list ons-list--bare ons-list--icons ons-u-fs-r ons-u-pb-s">
         {{ range $i, $el := .Version.Downloads }}
-            <li class="ons-list__item ons-u-mt-s ons-u-mb-no ons-u-pl-no ons-u-pb-s ons-u-pt-no ons-u-fs-r{{if notLastItem $length $i }} ons-u-bb{{end}}">
+            <li class="ons-list__item ons-u-mt-s ons-u-mb-no ons-u-pb-s{{if notLastItem $length $i }} ons-u-bb{{end}}">
                 <span class="ons-list__prefix ons-u-pt-xxs">
                     {{ template "icons/download" }}
                 </span>
-                <span class="ons-u-fs-r ons-u-m-no ons-u-p-no">
-                    <a href="{{ .URI }}" class="ons-list__link underline-link">{{ .Name }}
+                <span>
+                    <a href="{{ .URI }}" class="ons-list__link">{{ .Name }}
                         <span class="ons-u-vh">
                             {{ localise "Download" $.Language 1 }}
                             {{ if eq .Extension "XLS" }}

--- a/assets/templates/partials/census/id-datestamp.tmpl
+++ b/assets/templates/partials/census/id-datestamp.tmpl
@@ -1,23 +1,23 @@
-<dl class="ons-metadata ons-metadata__list ons-grid ons-grid--gutterless ons-u-cf" title="{{ localise "CensusDatasetLandingPageMetadataLabel" .Language 1 }}" aria-label="{{ localise "CensusDatasetLandingPageMetadataLabel" .Language 1 }}">
+<dl class="ons-metadata metadata__list ons-grid ons-grid--gutterless ons-u-cf ons-u-mb-l" title="{{ localise "CensusDatasetLandingPageMetadataLabel" .Language 1 }}" aria-label="{{ localise "CensusDatasetLandingPageMetadataLabel" .Language 1 }}">
     <div class="ons-grid__col ons-col-12@m">
-        <dt class="ons-metadata__term ons-u-mr-xs ons-u-dib ons-u-f-no">{{ localise "DatasetID" .Language 1 }}</dt>
-        <dd class="ons-metadata__value ons-u-f-no ons-u-dib">{{ .ID }}</dd>
+        <dt class="ons-metadata__term ons-u-mr-xs">{{ localise "DatasetID" .Language 1 }}</dt>
+        <dd class="ons-metadata__value ons-u-f-no">{{ .ID }}</dd>
     </div>
     {{ if .DatasetLandingPage.HasOtherVersions }}
         <div class="ons-grid__col ons-col-4@m ons-u-mt-xs">
-            <dt class="ons-metadata__term ons-u-mr-xs ons-u-dib ons-u-f-no">{{ localise "Released" .Language 1 }}:</dt>
-            <dd class="ons-metadata__value ons-u-f-no ons-u-mr-xs ons-u-dib">{{ dateFormat .InitialReleaseDate }}</dd>
+            <dt class="ons-metadata__term ons-u-mr-xs">{{ localise "Released" .Language 1 }}:</dt>
+            <dd class="ons-metadata__value ons-u-f-no">{{ dateFormat .InitialReleaseDate }}</dd>
         </div>
         <div class="ons-grid__col ons-col-8@m ons-u-mt-xs">
-            <dt class="ons-metadata__term ons-u-dib ons-u-mt-no ons-u-f-no">{{ localise "LastUpdated" .Language 1 }}:</dt>
-            <dd class="ons-metadata__value ons-u-f-no ons-u-dib">{{ dateFormat .Version.ReleaseDate }} &mdash;
+            <dt class="ons-metadata__term ons-u-mr-xs">{{ localise "LastUpdated" .Language 1 }}:</dt>
+            <dd class="ons-metadata__value ons-u-f-no">{{ dateFormat .Version.ReleaseDate }} &mdash;
                 <a href="#version-history">{{ localise "SeeVersionHistory" .Language 1 }}</a>
             </dd>
         </div>
     {{ else }}
         <div class="ons-grid__col ons-col-12@m ons-u-mt-xs">
-            <dt class="ons-metadata__term ons-u-mr-xs ons-u-dib ons-u-f-no">{{ localise "Released" .Language 1 }}:</dt>
-            <dd class="ons-metadata__value ons-u-f-no ons-u-dib">{{ dateFormat .InitialReleaseDate }}</dd>
+            <dt class="ons-metadata__term ons-u-mr-xs">{{ localise "Released" .Language 1 }}:</dt>
+            <dd class="ons-metadata__value ons-u-f-no">{{ dateFormat .InitialReleaseDate }}</dd>
         </div>
     {{ end }}
 </dl>

--- a/assets/templates/partials/census/methodologies.tmpl
+++ b/assets/templates/partials/census/methodologies.tmpl
@@ -1,6 +1,6 @@
-<section id="methodology" class="ons-u-mt-l ons-u-mb-l" aria-label="{{ localise "Methodology" .Language 1 }}">
-    <h2 class="ons-u-fw-b ons-u-mt-l ons-u-pb-no ons-u-pt-no">{{ localise "Methodology" .Language 1 }}</h2>
+<section id="methodology" aria-label="{{ localise "Methodology" .Language 1 }}">
+    <h2 class="ons-u-mt-xl ons-u-pb-no ons-u-pt-no">{{ localise "Methodology" .Language 1 }}</h2>
     {{ range .DatasetLandingPage.Methodologies }}
-        <p class="ons-u-fs-r ons-u-pt-no ons-u-pb-no ons-u-mt-s ons-u-mb-s">{{ .Description }}</p>
+        <p>{{ .Description }}</p>
     {{ end }}
 </section>

--- a/assets/templates/partials/census/section.tmpl
+++ b/assets/templates/partials/census/section.tmpl
@@ -1,6 +1,6 @@
-<h2 class="ons-u-fw-b ons-u-pb-no ons-u-mt-no ons-u-pt-no">{{ .Title }}</h2>
+<h2>{{ .Title }}</h2>
 {{ range $i, $v := .Description }}
-<p class="ons-u-fs-r ons-u-mt-s ons-u-mb-s ons-u-pt-no ons-u-pb-no">{{ $v }}</p>
+<p>{{ $v }}</p>
 {{ end }}
 {{ if .Collapsible.Title }}
     {{ template "partials/census/collapsible" .Collapsible }}

--- a/assets/templates/partials/census/stats-disclosure.tmpl
+++ b/assets/templates/partials/census/stats-disclosure.tmpl
@@ -1,5 +1,5 @@
-<section id="stats-disclosure" class="ons-u-mt-l ons-u-mb-l" aria-label="{{ localise "StatsDisclosureTitle" .Language 1 }}">
-    <h2 class="ons-u-fw-b ons-u-mt-l ons-u-pb-no ons-u-pt-no">{{ localise "StatsDisclosureTitle" .Language 1 }}</h2>
-    <p class="ons-u-fs-r ons-u-mt-s ons-u-mb-s ons-u-pt-no ons-u-pb-no">{{ localise "StatsDisclosureReasoning" .Language 1 }}</p>
-    <p class="ons-u-fs-r ons-u-mt-s ons-u-mb-s ons-u-pt-no ons-u-pb-no">{{ localise "StatsDisclosureEffect" .Language 1 }}</p>
+<section id="stats-disclosure" aria-label="{{ localise "StatsDisclosureTitle" .Language 1 }}">
+    <h2 class="ons-u-mt-xl ons-u-pb-no ons-u-pt-no">{{ localise "StatsDisclosureTitle" .Language 1 }}</h2>
+    <p>{{ localise "StatsDisclosureReasoning" .Language 1 }}</p>
+    <p>{{ localise "StatsDisclosureEffect" .Language 1 }}</p>
 </section>

--- a/assets/templates/partials/census/variables-table.tmpl
+++ b/assets/templates/partials/census/variables-table.tmpl
@@ -1,11 +1,11 @@
 {{$dims := .DatasetLandingPage.Dimensions}}
 {{$language := .Language }}
-<section id="variables" class="ons-u-mt-l ons-u-mb-l" aria-label="{{ localise "Variables" .Language 1}}">
-    <h2 class="ons-u-fw-b ons-u-mt-l ons-u-pb-s ons-u-pt-no ons-u-bb">{{ localise "Variables" .Language 1}}</h2>
+<section id="variables" aria-label="{{ localise "Variables" .Language 1}}">
+    <h2 class="ons-u-mt-l">{{ localise "Variables" .Language 1}}</h2>
     <table class="ons-table">
         <tbody class="ons-table__body">
             {{range $i, $dim := $dims}}
-                <tr class="ons-table__row ons-u-bt">
+                <tr class="ons-table__row ons-u-bb{{ if eq $i 0 }} ons-u-bt{{ end }}">
                     <th scope="col" class="ons-table__header ons-table__cell ons-u-pb-s ons-u-pt-s">
                         <span>{{ $dim.Title }}</span>
                     </th>

--- a/assets/templates/partials/share-dataset/share-this-dataset.tmpl
+++ b/assets/templates/partials/share-dataset/share-this-dataset.tmpl
@@ -6,7 +6,7 @@
   <li class="ons-list__item ons-u-pl-no ons-u-pr-xs">
     <span class="ons-list__prefix">
     {{ template "partials/share-dataset/icon-handler" .Icon }}
-    </span><a href="{{.Link}}" class="ons-list__link ons-u-fs-r ons-u-pt-xxs underline-link" target="_blank" rel="noreferrer external">{{ .Title }}<span class="ons-u-vh">{{ localise "ShareLinkA11yText" $shareDetails.Language 1 }}</span></a>
+    </span><a href="{{.Link}}" class="ons-list__link ons-u-fs-r ons-u-pt-xxs" target="_blank" rel="noreferrer external">{{ .Title }}<span class="ons-u-vh">{{ localise "ShareLinkA11yText" $shareDetails.Language 1 }}</span></a>
   </li>
   {{ end }}
 </ul>

--- a/assets/templates/partials/table-of-contents.tmpl
+++ b/assets/templates/partials/table-of-contents.tmpl
@@ -1,12 +1,12 @@
 {{ $guideContents := . }}
-<aside>
-    <a class="skiplink" href="#guide-content">{{ localise "ContentsSkipLink" .Language 1 }}</a>
+<aside class="ons-toc-container">
+    <a class="ons-skip-link" href="#guide-content">{{ localise "ContentsSkipLink" .Language 1 }}</a>
     <nav class="ons-toc" aria-label="Pages in this guide">
-        <h2 class="ons-toc__title ons-u-fs-r--b ons-u-mb-s ons-u-pt-no ons-u-mt-no">{{ localise "Contents" .Language 1 }}</h2>
+        <h2 class="ons-toc__title ons-u-fs-r--b ons-u-mb-s">{{ localise "Contents" .Language 1 }}</h2>
         <ol id="guide-content" class="ons-list ons-list--dashed ons-u-mb-m">
             {{ range .GuideContent }}
-                <li class="ons-list__item ons-u-mb-xs ons-u-p-no ons-u-fs-r">
-                    <a href="#{{ .ID }}" class="ons-list__link underline-link">
+                <li class="ons-list__item">
+                    <a href="#{{ .ID }}" class="ons-list__link">
                         {{ if .LocaliseKey }}
                             {{ localise .LocaliseKey $guideContents.Language 1 }}
                         {{ else }}

--- a/config/config.go
+++ b/config/config.go
@@ -36,7 +36,7 @@ func Get() (*Config, error) {
 	if cfg.Debug {
 		cfg.PatternLibraryAssetsPath = "http://localhost:9002/dist/assets"
 	} else {
-		cfg.PatternLibraryAssetsPath = "//cdn.ons.gov.uk/dp-design-system/431b81f"
+		cfg.PatternLibraryAssetsPath = "//cdn.ons.gov.uk/dp-design-system/784c7aa"
 	}
 	return cfg, nil
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -31,7 +31,7 @@ func TestConfig(t *testing.T) {
 				So(cfg.HealthCheckInterval, ShouldEqual, 30*time.Second)
 				So(cfg.HealthCheckCriticalTimeout, ShouldEqual, 90*time.Second)
 				So(cfg.EnableProfiler, ShouldBeFalse)
-				So(cfg.PatternLibraryAssetsPath, ShouldEqual, "//cdn.ons.gov.uk/dp-design-system/431b81f")
+				So(cfg.PatternLibraryAssetsPath, ShouldEqual, "//cdn.ons.gov.uk/dp-design-system/784c7aa")
 			})
 		})
 	})

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/ONSdigital/dp-cookies v0.2.0
 	github.com/ONSdigital/dp-healthcheck v1.0.5
 	github.com/ONSdigital/dp-net v1.0.12
-	github.com/ONSdigital/dp-renderer v1.8.2-0.20211110135111-a7ec52878b3f
+	github.com/ONSdigital/dp-renderer v1.9.0
 	github.com/ONSdigital/log.go/v2 v2.0.9
 	github.com/golang/mock v1.6.0
 	github.com/gorilla/mux v1.8.0

--- a/go.sum
+++ b/go.sum
@@ -34,6 +34,8 @@ github.com/ONSdigital/dp-renderer v1.8.0 h1:9i4q8Ogbs6bLsOvbvPYPe5a7VA1fKJuozcH+
 github.com/ONSdigital/dp-renderer v1.8.0/go.mod h1:Z5sbyS0ApY6D8ikGDt2KIl5bt2p5kk73PeeMxGs1pEM=
 github.com/ONSdigital/dp-renderer v1.8.2-0.20211110135111-a7ec52878b3f h1:TeofniNiwjIWRiLZmg1kWaAybARn4HxexqyuSyKopzk=
 github.com/ONSdigital/dp-renderer v1.8.2-0.20211110135111-a7ec52878b3f/go.mod h1:Z5sbyS0ApY6D8ikGDt2KIl5bt2p5kk73PeeMxGs1pEM=
+github.com/ONSdigital/dp-renderer v1.9.0 h1:lM9PikNMSDCu627asqFTXChDL4FyVJY3XJ6gcaaTzjo=
+github.com/ONSdigital/dp-renderer v1.9.0/go.mod h1:Z5sbyS0ApY6D8ikGDt2KIl5bt2p5kk73PeeMxGs1pEM=
 github.com/ONSdigital/go-ns v0.0.0-20191104121206-f144c4ec2e58/go.mod h1:iWos35il+NjbvDEqwtB736pyHru0MPFE/LqcwkV1wDc=
 github.com/ONSdigital/log.go v1.0.0/go.mod h1:UnGu9Q14gNC+kz0DOkdnLYGoqugCvnokHBRBxFRpVoQ=
 github.com/ONSdigital/log.go v1.0.1-0.20200805084515-ee61165ea36a/go.mod h1:dDnQATFXCBOknvj6ZQuKfmDhbOWf3e8mtV+dPEfWJqs=


### PR DESCRIPTION
### What

- Removed superfluous utility classes
- Amended components to match latest design (except 'Get the data')
- Updated to latest `dp-renderer` and `dp-design-system` version 

### How to review

- [Run services](https://github.com/ONSdigital/dp-compose/tree/main/cantabular-import) to display a census dataset landing page
- Visual check against figma design (see images)
- Cross browser check

#### Desktop/Laptop
![image](https://user-images.githubusercontent.com/19624419/141332851-7f402dab-59c5-481a-b335-da9d3422d47c.png)

#### Mobile 
![image](https://user-images.githubusercontent.com/19624419/141333085-0776f054-b03f-43a7-8189-7cdd498f5798.png)

### Who can review

Frontend dev
