### PR TITLE
Fix/update limit on category count

### DIFF
--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -154,6 +154,7 @@ func VersionsList(dc DatasetClient, rend RenderClient, cfg config.Config) http.H
 }
 
 func censusLanding(ctx context.Context, w http.ResponseWriter, req *http.Request, dc DatasetClient, datasetModel dataset.DatasetDetails, rend RenderClient, edition string, version dataset.Version, hasOtherVersions bool, collectionID, lang, userAccessToken string) {
+	const numOptsSummary = 1000
 	var initialVersion dataset.Version
 	var initialVersionReleaseDate string
 	var err error

--- a/handlers/handlers_test.go
+++ b/handlers/handlers_test.go
@@ -338,6 +338,7 @@ func TestUnitHandlers(t *testing.T) {
 	})
 
 	Convey("test census landing page", t, func() {
+		const numOptsSummary = 1000
 		mockClient := NewMockDatasetClient(mockCtrl)
 		mockZebedeeClient := NewMockZebedeeClient(mockCtrl)
 		mockRend := NewMockRenderClient(mockCtrl)
@@ -448,6 +449,7 @@ func TestUnitHandlers(t *testing.T) {
 		})
 
 		Convey("filterable landing page returned if census config is false", func() {
+			const numOptsSummary = 50
 			mockConfig := config.Config{EnableCensusPages: false}
 			mockClient.EXPECT().Get(ctx, userAuthToken, serviceAuthToken, collectionID, "12345").Return(dataset.DatasetDetails{Contacts: &[]dataset.Contact{{Name: "Nick"}}, Type: "cantabular-table", URI: "/economy/grossdomesticproduct/datasets/gdpjanuary2018", Links: dataset.Links{LatestVersion: dataset.Link{URL: "/datasets/1234/editions/5678/versions/2017"}}}, nil)
 			versions := []dataset.Version{{ReleaseDate: "02-01-2005", Links: dataset.Links{Self: dataset.Link{URL: "/datasets/12345/editions/2016/versions/1"}}}}


### PR DESCRIPTION
### What

Changed query string limit parameter from 50 to 1000.

Previously we were sending a query similar to := https://api.develop.onsdigital.co.uk/v1/datasets/People-Households-Testing-v1/editions/2021/versions/1/dimensions/LA/options?offset=0&limit=50

This change alters the query to be similar to := https://api.develop.onsdigital.co.uk/v1/datasets/People-Households-Testing-v1/editions/2021/versions/1/dimensions/LA/options?offset=0&limit=1000

Limiting the results to 50 also throttled the amount of labels being displayed in `mapper.go`, this piece of code causes the throttle:

```go
if opt.TotalCount > maxNumberOfOptions {
  if i > 9 {
    break
  }
}
```

Increasing the limit negates this problem and all labels are returned. There is progressive enhancement work to hide/show the labels coming up but as a MVP all results need to be available.

### How to review

#### Easy way
- Tests pass
- Sense check
- 🤙 me so I can show you locally

#### Hard way
- [Setup census pages](https://github.com/ONSdigital/dp-compose/tree/main/cantabular-import#readme)
- Tests pass
- You'll need to mock the data as a recipe that shows the problem can't be used locally

#### How to mock
- Initially, work from the `develop` branch
- Grab the data returned from https://api.develop.onsdigital.co.uk/v1/datasets/People-Households-Testing-v1/editions/2021/versions/1/dimensions/LA/options?offset=0&limit=50 and store in a `json` file
- Insert this code in `handlers.go` on line 184 to read the data from your json file. I stored the file at route for ease and called it `data.json` 
```go
data, err := ioutil.ReadFile("./data.json")
if err != nil {
	fmt.Print(err)
}

var options []dataset.Options
err = json.Unmarshal(data, &options)
if err != nil {
	fmt.Println("error:", err)
}

opts = options
```
- The results should be similar to develop := https://develop.onsdigital.co.uk/datasets/People-Households-Testing-v1/editions/2021/versions/1
- Switch to this branch `fix/category-label-count`
- Update the `data.json` to include the results from the proposed change := https://api.develop.onsdigital.co.uk/v1/datasets/People-Households-Testing-v1/editions/2021/versions/1/dimensions/LA/options?offset=0&limit=1000
- The count should now be 348 and all the local authorities should be displayed  

### Who can review

Frontend dev
