### PR TITLE
Feature/version history for census dataset landing page

### DIFF
--- a/assets/locales/service.cy.toml
+++ b/assets/locales/service.cy.toml
@@ -208,6 +208,22 @@ one = "Last updated"
 description = "See version history"
 one = "See version history"
 
+[VersionHistory]
+description = "Version history"
+one = "Version history"
+
+[UpdateReasonHeading]
+description = "Update reason"
+one = "Reason for update"
+
+[VersionSuperseded]
+description = "Version superseded"
+one = "Version superseded" 
+
+[OriginalRelease]
+description = "Original release"
+one = "Original release" 
+
 [CensusDatasetLandingPageMetadataLabel]
 description = "Census DLP metadata label - datestamp and dataset ID"
 one = "Dataset ID and release date information"

--- a/assets/locales/service.en.toml
+++ b/assets/locales/service.en.toml
@@ -189,6 +189,22 @@ one = "Last updated"
 description = "See version history"
 one = "See version history"
 
+[VersionHistory]
+description = "Version history"
+one = "Version history"
+
+[UpdateReasonHeading]
+description = "Update reason heading"
+one = "Reason for update"
+
+[VersionSuperseded]
+description = "Version superseded"
+one = "Version superseded" 
+
+[OriginalRelease]
+description = "Original release"
+one = "Original release" 
+
 [CensusDatasetLandingPageMetadataLabel]
 description = "Census DLP metadata label - datestamp and dataset ID"
 one = "Dataset ID and release date information"

--- a/assets/templates/census-landing.tmpl
+++ b/assets/templates/census-landing.tmpl
@@ -24,6 +24,9 @@
             {{ if .DatasetLandingPage.Methodologies }}
                 {{ template "partials/census/methodologies" . }}
             {{ end }}
+            {{ if .DatasetLandingPage.HasOtherVersions }}
+                {{ template "partials/census/version-history" . }}
+            {{ end }}
         </div>
     </div>
     <div class="ons-grid ons-u-ml-no ons-u-mb-xl">

--- a/assets/templates/partials/census/id-datestamp.tmpl
+++ b/assets/templates/partials/census/id-datestamp.tmpl
@@ -6,18 +6,18 @@
     {{ if .DatasetLandingPage.HasOtherVersions }}
         <div class="ons-grid__col ons-col-4@m ons-u-mt-xs">
             <dt class="ons-metadata__term ons-u-mr-xs">{{ localise "Released" .Language 1 }}:</dt>
-            <dd class="ons-metadata__value ons-u-f-no">{{ dateFormat .InitialReleaseDate }}</dd>
+            <dd class="ons-metadata__value ons-u-f-no"><time datetime="{{ .InitialReleaseDate }}">{{ dateFormat .InitialReleaseDate }}</time></dd>
         </div>
         <div class="ons-grid__col ons-col-8@m ons-u-mt-xs">
             <dt class="ons-metadata__term ons-u-mr-xs">{{ localise "LastUpdated" .Language 1 }}:</dt>
-            <dd class="ons-metadata__value ons-u-f-no">{{ dateFormat .Version.ReleaseDate }} &mdash;
+            <dd class="ons-metadata__value ons-u-f-no"><time datetime="{{ .Version.ReleaseDate }}">{{ dateFormat .Version.ReleaseDate }}</time> &mdash;
                 <a href="#version-history">{{ localise "SeeVersionHistory" .Language 1 }}</a>
             </dd>
         </div>
     {{ else }}
         <div class="ons-grid__col ons-col-12@m ons-u-mt-xs">
             <dt class="ons-metadata__term ons-u-mr-xs">{{ localise "Released" .Language 1 }}:</dt>
-            <dd class="ons-metadata__value ons-u-f-no">{{ dateFormat .InitialReleaseDate }}</dd>
+            <dd class="ons-metadata__value ons-u-f-no"><time datetime="{{ .InitialReleaseDate }}">{{ dateFormat .InitialReleaseDate }}<time></dd>
         </div>
     {{ end }}
 </dl>

--- a/assets/templates/partials/census/id-datestamp.tmpl
+++ b/assets/templates/partials/census/id-datestamp.tmpl
@@ -17,7 +17,7 @@
     {{ else }}
         <div class="ons-grid__col ons-col-12@m ons-u-mt-xs">
             <dt class="ons-metadata__term ons-u-mr-xs">{{ localise "Released" .Language 1 }}:</dt>
-            <dd class="ons-metadata__value ons-u-f-no"><time datetime="{{ .InitialReleaseDate }}">{{ dateFormat .InitialReleaseDate }}<time></dd>
+            <dd class="ons-metadata__value ons-u-f-no"><time datetime="{{ .InitialReleaseDate }}">{{ dateFormat .InitialReleaseDate }}</time></dd>
         </div>
     {{ end }}
 </dl>

--- a/assets/templates/partials/census/version-history.tmpl
+++ b/assets/templates/partials/census/version-history.tmpl
@@ -1,0 +1,41 @@
+<section id="version-history" aria-label="{{ localise "VersionHistory" .Language 1 }}">
+    <h2 class="ons-u-mt-xl ons-u-pt-no ons-u-mb-m">{{ localise "VersionHistory" .Language 1 }}</h2>
+    <table class="ons-table">
+        <thead class="ons-table__head">
+            <tr class="ons-table__row">
+                <th scope="col" class="ons-table__header ons-u-pb-s">
+                    <span>{{ localise "ReleaseDate" .Language 1 }}</span>
+                </th>
+                <th scope="col" class="ons-table__header ons-u-pb-s">
+                    <span>{{ localise "UpdateReasonHeading" .Language 1 }}</span>
+                </th>
+            </tr>
+        </thead>
+        <tbody class="ons-table__body">
+            {{ range $i, $version := .Versions }}
+                <tr class="ons-table__row">
+                    <td class="ons-table__cell ons-u-pb-s ons-u-pt-s">
+                        {{ if .IsCurrentPage }}
+                            <time datetime="{{ $version.ReleaseDate }}">{{ dateFormat $version.ReleaseDate }}</time>
+                        {{ else }}
+                            <a href="{{ $version.VersionURL }}"><time datetime="{{ $version.ReleaseDate }}">{{ dateFormat $version.ReleaseDate }}</time></a>
+                        {{ end }}
+                    </td>
+                    <td class="ons-table__cell ons-u-pb-s ons-u-pt-s">
+                        {{ if .Corrections }}
+                            {{ range $i, $correction := .Corrections }}
+                                {{ .Reason }}
+                            {{ end }}
+                        {{ else }}
+                            {{ if ne $version.VersionNumber 1 }}
+                                {{ localise "VersionSuperseded" $.Language 1 }}
+                            {{ else }}
+                                {{ localise "OriginalRelease" $.Language 1 }}
+                            {{ end }}
+                        {{ end }}
+                    </td>
+                </tr>
+            {{ end }}
+        </tbody>
+    </table>
+</section>

--- a/config/config.go
+++ b/config/config.go
@@ -36,7 +36,7 @@ func Get() (*Config, error) {
 	if cfg.Debug {
 		cfg.PatternLibraryAssetsPath = "http://localhost:9002/dist/assets"
 	} else {
-		cfg.PatternLibraryAssetsPath = "//cdn.ons.gov.uk/dp-design-system/7ce8a71"
+		cfg.PatternLibraryAssetsPath = "//cdn.ons.gov.uk/dp-design-system/613c855"
 	}
 	return cfg, nil
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -31,7 +31,7 @@ func TestConfig(t *testing.T) {
 				So(cfg.HealthCheckInterval, ShouldEqual, 30*time.Second)
 				So(cfg.HealthCheckCriticalTimeout, ShouldEqual, 90*time.Second)
 				So(cfg.EnableProfiler, ShouldBeFalse)
-				So(cfg.PatternLibraryAssetsPath, ShouldEqual, "//cdn.ons.gov.uk/dp-design-system/7ce8a71")
+				So(cfg.PatternLibraryAssetsPath, ShouldEqual, "//cdn.ons.gov.uk/dp-design-system/613c855")
 			})
 		})
 	})

--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -153,7 +153,7 @@ func VersionsList(dc DatasetClient, rend RenderClient, cfg config.Config) http.H
 	})
 }
 
-func censusLanding(ctx context.Context, w http.ResponseWriter, req *http.Request, dc DatasetClient, datasetModel dataset.DatasetDetails, rend RenderClient, edition string, version dataset.Version, hasOtherVersions bool, collectionID, lang, userAccessToken string) {
+func censusLanding(ctx context.Context, w http.ResponseWriter, req *http.Request, dc DatasetClient, datasetModel dataset.DatasetDetails, rend RenderClient, edition string, version dataset.Version, hasOtherVersions bool, allVersions []dataset.Version, collectionID, lang, userAccessToken string) {
 	const numOptsSummary = 1000
 	var initialVersion dataset.Version
 	var initialVersionReleaseDate string
@@ -197,7 +197,7 @@ func censusLanding(ctx context.Context, w http.ResponseWriter, req *http.Request
 	}
 
 	basePage := rend.NewBasePageModel()
-	m := mapper.CreateCensusDatasetLandingPage(ctx, req, basePage, datasetModel, version, opts, dims, initialVersionReleaseDate, hasOtherVersions, lang, numOptsSummary, isValidationError)
+	m := mapper.CreateCensusDatasetLandingPage(ctx, req, basePage, datasetModel, version, opts, dims, initialVersionReleaseDate, hasOtherVersions, allVersions, lang, numOptsSummary, isValidationError)
 	rend.BuildPage(w, m, "census-landing")
 }
 
@@ -331,7 +331,7 @@ func filterableLanding(w http.ResponseWriter, req *http.Request, dc DatasetClien
 	}
 
 	if cfg.EnableCensusPages && strings.Contains(datasetModel.Type, "cantabular") {
-		censusLanding(ctx, w, req, dc, datasetModel, rend, edition, ver, displayOtherVersionsLink, collectionID, lang, userAccessToken)
+		censusLanding(ctx, w, req, dc, datasetModel, rend, edition, ver, displayOtherVersionsLink, allVers, collectionID, lang, userAccessToken)
 		return
 	}
 

--- a/mapper/mapper.go
+++ b/mapper/mapper.go
@@ -27,12 +27,13 @@ import (
 // TimeSlice allows sorting of a list of time.Time
 type TimeSlice []time.Time
 
-// Dimension names
+// Constants names
 const (
-	DimensionTime      = "time"
-	DimensionAge       = "age"
-	DimensionGeography = "geography"
-	SixteensVersion    = "67f6982"
+	DimensionTime       = "time"
+	DimensionAge        = "age"
+	DimensionGeography  = "geography"
+	SixteensVersion     = "67f6982"
+	CorrectionAlertType = "correction"
 )
 
 func (p TimeSlice) Len() int {
@@ -517,10 +518,9 @@ func CreateCensusDatasetLandingPage(ctx context.Context, req *http.Request, base
 }
 
 func mapCorrectionAlert(ver *dataset.Version, version *sharedModel.Version) {
-	const correctionAlertType = "correction"
 	if ver.Alerts != nil {
 		for _, alert := range *ver.Alerts {
-			if alert.Type == correctionAlertType {
+			if alert.Type == CorrectionAlertType {
 				version.Corrections = append(version.Corrections, sharedModel.Correction{
 					Reason: alert.Description,
 					Date:   alert.Date,

--- a/mapper/mapper.go
+++ b/mapper/mapper.go
@@ -236,7 +236,7 @@ func CreateVersionsList(basePage coreModel.Page, req *http.Request, d dataset.Da
 
 	latestVersionNumber := 1
 	for _, ver := range versions {
-		var version datasetVersionsList.Version
+		var version sharedModel.Version
 		version.IsLatest = false
 		version.VersionNumber = ver.Version
 		version.Title = d.Title
@@ -256,24 +256,14 @@ func CreateVersionsList(basePage coreModel.Page, req *http.Request, d dataset.Da
 		}
 
 		for ext, download := range ver.Downloads {
-			version.Downloads = append(version.Downloads, datasetVersionsList.Download{
+			version.Downloads = append(version.Downloads, sharedModel.Download{
 				Extension: ext,
 				Size:      download.Size,
 				URI:       download.URL,
 			})
 		}
 
-		const correctionAlertType = "correction"
-		if ver.Alerts != nil {
-			for _, alert := range *ver.Alerts {
-				if alert.Type == correctionAlertType {
-					version.Corrections = append(version.Corrections, datasetVersionsList.Correction{
-						Reason: alert.Description,
-						Date:   alert.Date,
-					})
-				}
-			}
-		}
+		mapCorrectionAlert(&ver, &version)
 
 		p.Data.Versions = append(p.Data.Versions, version)
 	}
@@ -339,7 +329,7 @@ func CreateEditionsList(basePage coreModel.Page, ctx context.Context, req *http.
 }
 
 // CreateCensusDatasetLandingPage creates a census-landing page based on api model responses
-func CreateCensusDatasetLandingPage(ctx context.Context, req *http.Request, basePage coreModel.Page, d dataset.DatasetDetails, version dataset.Version, opts []dataset.Options, dims dataset.VersionDimensions, initialVersionReleaseDate string, hasOtherVersions bool, lang string, maxNumberOfOptions int, isValidationError bool) datasetLandingPageCensus.Page {
+func CreateCensusDatasetLandingPage(ctx context.Context, req *http.Request, basePage coreModel.Page, d dataset.DatasetDetails, version dataset.Version, opts []dataset.Options, dims dataset.VersionDimensions, initialVersionReleaseDate string, hasOtherVersions bool, allVersions []dataset.Version, lang string, maxNumberOfOptions int, isValidationError bool) datasetLandingPageCensus.Page {
 	p := datasetLandingPageCensus.Page{
 		Page: basePage,
 	}
@@ -466,6 +456,27 @@ func CreateCensusDatasetLandingPage(ctx context.Context, req *http.Request, base
 		})
 	}
 
+	if hasOtherVersions {
+		p.DatasetLandingPage.GuideContents.GuideContent = append(p.DatasetLandingPage.GuideContents.GuideContent, datasetLandingPageCensus.Content{
+			LocaliseKey: "VersionHistory",
+			ID:          "version-history",
+		})
+
+		for _, ver := range allVersions {
+			var version sharedModel.Version
+			version.VersionNumber = ver.Version
+			version.ReleaseDate = ver.ReleaseDate
+			versionUrl := helpers.DatasetVersionUrl(ver.Links.Dataset.ID, ver.Edition, strconv.Itoa(ver.Version))
+			version.VersionURL = versionUrl
+			version.IsCurrentPage = versionUrl == req.URL.Path
+			mapCorrectionAlert(&ver, &version)
+
+			p.Versions = append(p.Versions, version)
+		}
+
+		sort.Slice(p.Versions, func(i, j int) bool { return p.Versions[i].VersionNumber > p.Versions[j].VersionNumber })
+	}
+
 	p.DatasetLandingPage.ShareDetails.Language = lang
 	currentUrl := helpers.GetCurrentUrl(lang, p.SiteDomain, req.URL.Path)
 
@@ -503,6 +514,20 @@ func CreateCensusDatasetLandingPage(ctx context.Context, req *http.Request, base
 	}
 
 	return p
+}
+
+func mapCorrectionAlert(ver *dataset.Version, version *sharedModel.Version) {
+	const correctionAlertType = "correction"
+	if ver.Alerts != nil {
+		for _, alert := range *ver.Alerts {
+			if alert.Type == correctionAlertType {
+				version.Corrections = append(version.Corrections, sharedModel.Correction{
+					Reason: alert.Description,
+					Date:   alert.Date,
+				})
+			}
+		}
+	}
 }
 
 func mapOptionsToDimensions(ctx context.Context, datasetType string, dims dataset.VersionDimensions, opts []dataset.Options, latestVersionURL string, maxNumberOfOptions int) []sharedModel.Dimension {

--- a/mapper/mapper_test.go
+++ b/mapper/mapper_test.go
@@ -429,6 +429,13 @@ func TestCreateVersionsList(t *testing.T) {
 	dummyVersion2.Version = 2
 	dummyVersion3 := dummyVersion1
 	dummyVersion3.Version = 3
+	dummyVersion3.Alerts = &[]dataset.Alert{
+		{
+			Date:        "",
+			Description: "This is a correction",
+			Type:        "correction",
+		},
+	}
 
 	Convey("test latest version page", t, func() {
 		dummySingleVersionList := []dataset.Version{dummyVersion3}
@@ -461,6 +468,11 @@ func TestCreateVersionsList(t *testing.T) {
 			So(page.Data.Versions[0].Superseded, ShouldEqual, "/datasets/cpih01/editions/time-series/versions/2")
 			So(page.Data.Versions[1].Superseded, ShouldEqual, "/datasets/cpih01/editions/time-series/versions/1")
 			So(page.Data.Versions[2].Superseded, ShouldEqual, "")
+		})
+		Convey("correction notice maps when present", func() {
+			So(page.Data.Versions[2].Corrections, ShouldBeEmpty)
+			So(page.Data.Versions[1].Corrections, ShouldBeEmpty)
+			So(page.Data.Versions[0].Corrections[0].Reason, ShouldEqual, "This is a correction")
 		})
 	})
 }
@@ -521,11 +533,37 @@ func TestCreateCensusDatasetLandingPage(t *testing.T) {
 				URL:  "https://mydomain.com/my-request",
 			},
 		},
+		Edition: "2021",
+		Version: 1,
+		Links: dataset.Links{
+			Dataset: dataset.Link{
+				URL: "http://localhost:22000/datasets/cantabular-1",
+				ID:  "cantabular-1",
+			},
+		},
 	}
 
 	versionTwoDetails := dataset.Version{
 		ReleaseDate: "15-02-2021",
+		Version:     2,
+		Edition:     "2021",
+		Links: dataset.Links{
+			Dataset: dataset.Link{
+				URL: "http://localhost:22000/datasets/cantabular-1",
+				ID:  "cantabular-1",
+			},
+		},
+		Alerts: &[]dataset.Alert{
+			{
+				Date:        "",
+				Description: "This is a correction",
+				Type:        "correction",
+			},
+		},
 	}
+
+	versionThreeDetails := versionTwoDetails
+	versionThreeDetails.Version = 3
 
 	datasetOptions := []dataset.Options{
 		{
@@ -555,12 +593,12 @@ func TestCreateCensusDatasetLandingPage(t *testing.T) {
 	}
 
 	Convey("Census dataset landing page maps correctly as version 1", t, func() {
-		page := CreateCensusDatasetLandingPage(context.Background(), req, pageModel, datasetModel, versionOneDetails, datasetOptions, dataset.VersionDimensions{}, "", false, "", 50, false)
+		page := CreateCensusDatasetLandingPage(context.Background(), req, pageModel, datasetModel, versionOneDetails, datasetOptions, dataset.VersionDimensions{}, "", false, []dataset.Version{versionOneDetails}, "", 50, false)
 		So(page.Type, ShouldEqual, datasetModel.Type)
 		So(page.ID, ShouldEqual, datasetModel.ID)
 		So(page.Version.ReleaseDate, ShouldEqual, versionOneDetails.ReleaseDate)
 		So(page.InitialReleaseDate, ShouldEqual, page.Version.ReleaseDate)
-		So(page.DatasetLandingPage.HasOtherVersions, ShouldEqual, false)
+		So(page.DatasetLandingPage.HasOtherVersions, ShouldBeFalse)
 		So(page.Version.Downloads[0].Size, ShouldEqual, "438290")
 		So(page.Version.Downloads[0].Extension, ShouldEqual, "XLSX")
 		So(page.Version.Downloads[0].URI, ShouldEqual, "https://mydomain.com/my-request")
@@ -576,10 +614,30 @@ func TestCreateCensusDatasetLandingPage(t *testing.T) {
 	})
 
 	Convey("Release date and hasOtherVersions is mapped correctly when v2 of Census DLP dataset is loaded", t, func() {
-		page := CreateCensusDatasetLandingPage(context.Background(), req, pageModel, datasetModel, versionTwoDetails, datasetOptions, dataset.VersionDimensions{}, versionOneDetails.ReleaseDate, true, "", 50, false)
+		req := httptest.NewRequest("", "/datasets/cantabular-1/editions/2021/versions/2", nil)
+		page := CreateCensusDatasetLandingPage(context.Background(), req, pageModel, datasetModel, versionTwoDetails, datasetOptions, dataset.VersionDimensions{}, versionOneDetails.ReleaseDate, true, []dataset.Version{versionOneDetails, versionTwoDetails}, "", 50, false)
 		So(page.InitialReleaseDate, ShouldEqual, versionOneDetails.ReleaseDate)
 		So(page.Version.ReleaseDate, ShouldEqual, versionTwoDetails.ReleaseDate)
-		So(page.DatasetLandingPage.HasOtherVersions, ShouldEqual, true)
+		So(page.DatasetLandingPage.HasOtherVersions, ShouldBeTrue)
+		So(page.Versions[0].VersionURL, ShouldEqual, "/datasets/cantabular-1/editions/2021/versions/2")
+		So(page.Versions[0].VersionNumber, ShouldEqual, 2)
+		So(page.Versions[0].ReleaseDate, ShouldEqual, versionTwoDetails.ReleaseDate)
+		So(page.Versions[0].IsCurrentPage, ShouldBeTrue)
+		So(page.Versions[0].Corrections[0].Reason, ShouldEqual, "This is a correction")
+	})
+
+	Convey("IsCurrent returns false when request is for a different page", t, func() {
+		req := httptest.NewRequest("", "/datasets/cantabular-1/editions/2021/versions/1", nil)
+		page := CreateCensusDatasetLandingPage(context.Background(), req, pageModel, datasetModel, versionTwoDetails, datasetOptions, dataset.VersionDimensions{}, versionOneDetails.ReleaseDate, true, []dataset.Version{versionOneDetails, versionTwoDetails}, "", 50, false)
+		So(page.Versions[0].VersionURL, ShouldEqual, "/datasets/cantabular-1/editions/2021/versions/2")
+		So(page.Versions[0].IsCurrentPage, ShouldBeFalse)
+	})
+
+	Convey("Versions history is in descending order", t, func() {
+		page := CreateCensusDatasetLandingPage(context.Background(), req, pageModel, datasetModel, versionTwoDetails, datasetOptions, dataset.VersionDimensions{}, versionOneDetails.ReleaseDate, true, []dataset.Version{versionOneDetails, versionTwoDetails, versionThreeDetails}, "", 50, false)
+		So(page.Versions[0].VersionNumber, ShouldEqual, 3)
+		So(page.Versions[1].VersionNumber, ShouldEqual, 2)
+		So(page.Versions[2].VersionNumber, ShouldEqual, 1)
 	})
 
 	Convey("Validation error passed as true, error title should be populated", t, func() {
@@ -592,7 +650,7 @@ func TestCreateCensusDatasetLandingPage(t *testing.T) {
 				},
 			},
 		}
-		page := CreateCensusDatasetLandingPage(context.Background(), req, pageModel, datasetModel, versionDetails, datasetOptions, dataset.VersionDimensions{}, versionOneDetails.ReleaseDate, false, "", 50, true)
+		page := CreateCensusDatasetLandingPage(context.Background(), req, pageModel, datasetModel, versionDetails, datasetOptions, dataset.VersionDimensions{}, versionOneDetails.ReleaseDate, false, []dataset.Version{}, "", 50, true)
 		So(page.Error.Title, ShouldEqual, fmt.Sprintf("Error: %s", datasetModel.Title))
 	})
 
@@ -606,7 +664,7 @@ func TestCreateCensusDatasetLandingPage(t *testing.T) {
 				},
 			},
 		}
-		page := CreateCensusDatasetLandingPage(context.Background(), req, pageModel, datasetModel, versionDetails, datasetOptions, dataset.VersionDimensions{}, versionOneDetails.ReleaseDate, false, "", 50, false)
+		page := CreateCensusDatasetLandingPage(context.Background(), req, pageModel, datasetModel, versionDetails, datasetOptions, dataset.VersionDimensions{}, versionOneDetails.ReleaseDate, false, []dataset.Version{}, "", 50, false)
 		So(page.Error.Title, ShouldBeBlank)
 	})
 
@@ -620,7 +678,7 @@ func TestCreateCensusDatasetLandingPage(t *testing.T) {
 				},
 			},
 		}
-		page := CreateCensusDatasetLandingPage(context.Background(), req, pageModel, datasetModel, versionDetails, datasetOptions, dataset.VersionDimensions{}, versionOneDetails.ReleaseDate, false, "", 50, false)
+		page := CreateCensusDatasetLandingPage(context.Background(), req, pageModel, datasetModel, versionDetails, datasetOptions, dataset.VersionDimensions{}, versionOneDetails.ReleaseDate, false, []dataset.Version{}, "", 50, false)
 		So(page.Error.Title, ShouldBeBlank)
 	})
 
@@ -635,7 +693,7 @@ func TestCreateCensusDatasetLandingPage(t *testing.T) {
 	}
 
 	Convey("No contacts provided, contact section is not displayed", t, func() {
-		page := CreateCensusDatasetLandingPage(context.Background(), req, pageModel, noContactDM, versionOneDetails, datasetOptions, dataset.VersionDimensions{}, "", false, "", 50, false)
+		page := CreateCensusDatasetLandingPage(context.Background(), req, pageModel, noContactDM, versionOneDetails, datasetOptions, dataset.VersionDimensions{}, "", false, []dataset.Version{}, "", 50, false)
 		So(page.ContactDetails.Email, ShouldEqual, noContact.Email)
 		So(page.ContactDetails.Telephone, ShouldEqual, noContact.Telephone)
 		So(page.HasContactDetails, ShouldBeFalse)
@@ -652,7 +710,7 @@ func TestCreateCensusDatasetLandingPage(t *testing.T) {
 	}
 
 	Convey("One contact detail provided, contact section is displayed", t, func() {
-		page := CreateCensusDatasetLandingPage(context.Background(), req, pageModel, oneContactDetailDM, versionOneDetails, datasetOptions, dataset.VersionDimensions{}, "", false, "", 50, false)
+		page := CreateCensusDatasetLandingPage(context.Background(), req, pageModel, oneContactDetailDM, versionOneDetails, datasetOptions, dataset.VersionDimensions{}, "", false, []dataset.Version{}, "", 50, false)
 		So(page.ContactDetails.Email, ShouldEqual, oneContactDetail.Email)
 		So(page.ContactDetails.Telephone, ShouldEqual, oneContactDetail.Telephone)
 		So(page.HasContactDetails, ShouldBeTrue)

--- a/model/correction.go
+++ b/model/correction.go
@@ -1,0 +1,7 @@
+package model
+
+// Correction represents a single correction on a version
+type Correction struct {
+	Reason string `json:"reason"`
+	Date   string `json:"date"`
+}

--- a/model/datasetLandingPageCensus/model.go
+++ b/model/datasetLandingPageCensus/model.go
@@ -12,6 +12,7 @@ type Page struct {
 	model.Page
 	DatasetLandingPage DatasetLandingPage            `json:"data"`
 	Version            sharedModel.Version           `json:"version"`
+	Versions           []sharedModel.Version         `json:"versions"`
 	InitialReleaseDate string                        `json:"initial_release_date"`
 	ID                 string                        `json:"id"`
 	ContactDetails     contactDetails.ContactDetails `json:"contact_details"`

--- a/model/datasetVersionsList/model.go
+++ b/model/datasetVersionsList/model.go
@@ -1,6 +1,9 @@
 package datasetVersionsList
 
-import "github.com/ONSdigital/dp-renderer/model"
+import (
+	sharedModel "github.com/ONSdigital/dp-frontend-dataset-controller/model"
+	"github.com/ONSdigital/dp-renderer/model"
+)
 
 // Page contains the data re-used on each page as well as the data for the current page
 type Page struct {
@@ -10,28 +13,8 @@ type Page struct {
 
 // VersionsList represents the data on the versions list page
 type VersionsList struct {
-	LatestVersionURL string    `json:"latest_version_url"`
-	Versions         []Version `json:"versions"`
-}
-
-// Version represents an edition version on the version list page
-type Version struct {
-	Date          string       `json:"date"`
-	Corrections   []Correction `json:"correction"`
-	Downloads     []Download   `json:"downloads"`
-	FilterURL     string       `json:"filter_url"`
-	VersionURL    string       `json:"version_url"`
-	VersionNumber int          `json:"version_number"`
-	Superseded    string       `json:"superseded"`
-	IsLatest      bool         `json:"is_latest"`
-	Title         string       `json:"title"`
-	Edition       string       `json:"edition"`
-}
-
-// Correction represents a single correction on the versions list page
-type Correction struct {
-	Reason string `json:"reason"`
-	Date   string `json:"date"`
+	LatestVersionURL string                `json:"latest_version_url"`
+	Versions         []sharedModel.Version `json:"versions"`
 }
 
 // Download has the details for the an individual dataset's downloadable files

--- a/model/version.go
+++ b/model/version.go
@@ -4,13 +4,21 @@ import "github.com/ONSdigital/dp-frontend-dataset-controller/model/contactDetail
 
 // Version represents the data for a single version
 type Version struct {
-	Title       string                        `json:"title"`
-	Description string                        `json:"description"`
-	URL         string                        `json:"url"`
-	ReleaseDate string                        `json:"release_date"`
-	NextRelease string                        `json:"next_release"`
-	Downloads   []Download                    `json:"downloads"`
-	Edition     string                        `json:"edition"`
-	Version     string                        `json:"version"`
-	Contact     contactDetails.ContactDetails `json:"contact"`
+	Title         string                        `json:"title"`
+	Description   string                        `json:"description"`
+	URL           string                        `json:"url"`
+	ReleaseDate   string                        `json:"release_date"`
+	NextRelease   string                        `json:"next_release"`
+	Downloads     []Download                    `json:"downloads"`
+	Edition       string                        `json:"edition"`
+	Version       string                        `json:"version"`
+	Contact       contactDetails.ContactDetails `json:"contact"`
+	IsCurrentPage bool                          `json:"is_current"`
+	VersionURL    string                        `json:"version_url"`
+	Superseded    string                        `json:"superseded"`
+	VersionNumber int                           `json:"version_number"`
+	Date          string                        `json:"date"`
+	Corrections   []Correction                  `json:"correction"`
+	FilterURL     string                        `json:"filter_url"`
+	IsLatest      bool                          `json:"is_latest"`
 }


### PR DESCRIPTION
### What

- Updated to latest `dp-design-system` commit
- Created version history component 
- Refactored shared code
- Updated/created unit tests

### How to review

You'll need Cantabular setup locally to see this working end-to-end; follow [these instructions](https://github.com/ONSdigital/dp-compose/tree/main/cantabular-import#readme) to get started

Once you're up and running (create a new instance of the example dataset), you should be able to see the census dataset landing page

Now, create a new version of the same dataset. The version history should appear at the bottom of the page. Try creating another version and include a correction notice. Eventually, you should end up with a table similar to the image.

#### Image
![image](https://user-images.githubusercontent.com/19624419/143903170-b3543e1e-38ec-40b5-acb3-f546f19bfc60.png)

#### Other things to check
- Sense check
- Tests pass
- HTML is valid and accessible
- Check different viewports and browsers

### Who can review

Frontend dev
