### PR TITLE
Feature/other versions panel

### DIFF
--- a/assets/locales/service.cy.toml
+++ b/assets/locales/service.cy.toml
@@ -257,3 +257,11 @@ other = "supporting information"
 [Download]
 description = "Download"
 one = "download,"
+
+[ImportantInformation]
+description = "Important information"
+one = "Important information:"
+
+[NewVersionAvailable]
+description = "There is a new version of this dataset. View the <a href=\"{{ .DatasetLandingPage.LatestVersionURL }}\">latest version</a>."
+one = "There is a new version of this dataset. View the <a href=\"{{.arg0}}\">latest version</a>."

--- a/assets/locales/service.en.toml
+++ b/assets/locales/service.en.toml
@@ -238,3 +238,11 @@ other = "supporting information"
 [Download]
 description = "Download"
 one = "download,"
+
+[ImportantInformation]
+description = "Important information"
+one = "Important information:"
+
+[NewVersionAvailable]
+description = "There is a new version of this dataset. View the <a href=\"{{ .DatasetLandingPage.LatestVersionURL }}\">latest version</a>."
+one = "There is a new version of this dataset. View the <a href=\"{{.arg0}}\">latest version</a>."

--- a/assets/templates/census-landing.tmpl
+++ b/assets/templates/census-landing.tmpl
@@ -7,6 +7,9 @@
         <section class="ons-u-mb-xl">
             <h1 class="ons-u-fs-xxxl ons-u-mt-s ons-u-mb-m ons-u-pb-no ons-u-pt-no">{{ .Metadata.Title }}</h1>
             {{ template "partials/census/id-datestamp" . }}
+            {{ if .DatasetLandingPage.ShowOtherVersionsPanel }}
+                {{ template "partials/census/other-versions-panel" . }}
+            {{ end }}
         </section>
         <div class="ons-grid__col ons-col-4@m ons-u-pl-no ons-grid__col--sticky@m">
             {{ template "partials/table-of-contents" .DatasetLandingPage.GuideContents }}

--- a/assets/templates/partials/census/get-data.tmpl
+++ b/assets/templates/partials/census/get-data.tmpl
@@ -20,7 +20,7 @@
                     <span class="ons-radios__item ons-radios__item--no-border ons-u-mb-s">
                         <span class="ons-radio ons-radio--no-border">
                             <input type="radio" id="{{ .Extension }}" class="ons-radio__input ons-js-radio" value="{{ .Extension }}" name="format">
-                                <label class="ons-radio__label{{ if or (eq .Extension "TXT") (eq .Extension "CSVW") (eq .Extension "XLS") }} ons-label--with-description{{ end }}" for="{{ .Extension }}" id="{{ .Extension }}-label">{{ .Extension }} format ({{ humanSize .Size }})
+                                <label class="ons-radio__label{{ if or (eq .Extension "TXT") (eq .Extension "CSVW") (eq .Extension "XLS") }} ons-label--with-description{{ end }}" for="{{ .Extension }}" id="{{ .Extension }}-label"><span class="ons-u-tt-u">{{ .Extension }}</span> format ({{ humanSize .Size }})
                                     <span id="{{ .Extension }}-label-description-hint" class="ons-label__description ons-radio__label--with-description">
                                         {{ if eq .Extension "XLS" }}
                                             {{ localise "IncludesSupportingInfo" $.Language 1 }}

--- a/assets/templates/partials/census/id-datestamp.tmpl
+++ b/assets/templates/partials/census/id-datestamp.tmpl
@@ -1,4 +1,4 @@
-<dl class="ons-metadata metadata__list ons-grid ons-grid--gutterless ons-u-cf ons-u-mb-l" title="{{ localise "CensusDatasetLandingPageMetadataLabel" .Language 1 }}" aria-label="{{ localise "CensusDatasetLandingPageMetadataLabel" .Language 1 }}">
+<dl class="ons-metadata metadata__list ons-grid ons-grid--gutterless ons-u-cf ons-u-mb-m" title="{{ localise "CensusDatasetLandingPageMetadataLabel" .Language 1 }}" aria-label="{{ localise "CensusDatasetLandingPageMetadataLabel" .Language 1 }}">
     <div class="ons-grid__col ons-col-12@m">
         <dt class="ons-metadata__term ons-u-mr-xs">{{ localise "DatasetID" .Language 1 }}</dt>
         <dd class="ons-metadata__value ons-u-f-no">{{ .ID }}</dd>

--- a/assets/templates/partials/census/other-versions-panel.tmpl
+++ b/assets/templates/partials/census/other-versions-panel.tmpl
@@ -1,0 +1,7 @@
+<div class="ons-panel ons-panel--info ons-panel--no-title">
+    <span class="ons-u-vh">{{ localise "ImportantInformation" .Language 1 }}
+    </span>
+    <div class="ons-panel__body">
+        <p class="ons-u-fs-r">{{ localise "NewVersionAvailable" .Language 1 .DatasetLandingPage.LatestVersionURL | safeHTML  }}</p>
+    </div>
+</div>

--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -153,7 +153,7 @@ func VersionsList(dc DatasetClient, rend RenderClient, cfg config.Config) http.H
 	})
 }
 
-func censusLanding(ctx context.Context, w http.ResponseWriter, req *http.Request, dc DatasetClient, datasetModel dataset.DatasetDetails, rend RenderClient, edition string, version dataset.Version, hasOtherVersions bool, allVersions []dataset.Version, collectionID, lang, userAccessToken string) {
+func censusLanding(ctx context.Context, w http.ResponseWriter, req *http.Request, dc DatasetClient, datasetModel dataset.DatasetDetails, rend RenderClient, edition string, version dataset.Version, hasOtherVersions bool, allVersions []dataset.Version, latestVersionNumber int, latestVersionURL string, collectionID, lang, userAccessToken string) {
 	const numOptsSummary = 1000
 	var initialVersion dataset.Version
 	var initialVersionReleaseDate string
@@ -197,7 +197,7 @@ func censusLanding(ctx context.Context, w http.ResponseWriter, req *http.Request
 	}
 
 	basePage := rend.NewBasePageModel()
-	m := mapper.CreateCensusDatasetLandingPage(ctx, req, basePage, datasetModel, version, opts, dims, initialVersionReleaseDate, hasOtherVersions, allVersions, lang, numOptsSummary, isValidationError)
+	m := mapper.CreateCensusDatasetLandingPage(ctx, req, basePage, datasetModel, version, opts, dims, initialVersionReleaseDate, hasOtherVersions, allVersions, latestVersionNumber, latestVersionURL, lang, numOptsSummary, isValidationError)
 	rend.BuildPage(w, m, "census-landing")
 }
 
@@ -331,7 +331,7 @@ func filterableLanding(w http.ResponseWriter, req *http.Request, dc DatasetClien
 	}
 
 	if cfg.EnableCensusPages && strings.Contains(datasetModel.Type, "cantabular") {
-		censusLanding(ctx, w, req, dc, datasetModel, rend, edition, ver, displayOtherVersionsLink, allVers, collectionID, lang, userAccessToken)
+		censusLanding(ctx, w, req, dc, datasetModel, rend, edition, ver, displayOtherVersionsLink, allVers, latestVersionNumber, latestVersionOfEditionURL, collectionID, lang, userAccessToken)
 		return
 	}
 

--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -316,11 +316,11 @@ func filterableLanding(w http.ResponseWriter, req *http.Request, dc DatasetClien
 		}
 	}
 
-	latestVersionOfEditionURL := helpers.DatasetVersionUrl(datasetID, edition, strconv.Itoa(latestVersionNumber))
+	latestVersionURL := helpers.DatasetVersionUrl(datasetID, edition, strconv.Itoa(latestVersionNumber))
 
 	if version == "" {
-		log.Info(ctx, "no version provided, therefore redirecting to latest version", log.Data{"latestVersionOfEditionURL": latestVersionOfEditionURL})
-		http.Redirect(w, req, latestVersionOfEditionURL, http.StatusFound)
+		log.Info(ctx, "no version provided, therefore redirecting to latest version", log.Data{"latestVersionURL": latestVersionURL})
+		http.Redirect(w, req, latestVersionURL, http.StatusFound)
 		return
 	}
 
@@ -331,7 +331,7 @@ func filterableLanding(w http.ResponseWriter, req *http.Request, dc DatasetClien
 	}
 
 	if cfg.EnableCensusPages && strings.Contains(datasetModel.Type, "cantabular") {
-		censusLanding(ctx, w, req, dc, datasetModel, rend, edition, ver, displayOtherVersionsLink, allVers, latestVersionNumber, latestVersionOfEditionURL, collectionID, lang, userAccessToken)
+		censusLanding(ctx, w, req, dc, datasetModel, rend, edition, ver, displayOtherVersionsLink, allVers, latestVersionNumber, latestVersionURL, collectionID, lang, userAccessToken)
 		return
 	}
 
@@ -378,7 +378,7 @@ func filterableLanding(w http.ResponseWriter, req *http.Request, dc DatasetClien
 	}
 
 	basePage := rend.NewBasePageModel()
-	m := mapper.CreateFilterableLandingPage(basePage, ctx, req, datasetModel, ver, datasetID, opts, dims, displayOtherVersionsLink, bc, latestVersionNumber, latestVersionOfEditionURL, lang, apiRouterVersion, numOptsSummary)
+	m := mapper.CreateFilterableLandingPage(basePage, ctx, req, datasetModel, ver, datasetID, opts, dims, displayOtherVersionsLink, bc, latestVersionNumber, latestVersionURL, lang, apiRouterVersion, numOptsSummary)
 
 	for i, d := range m.DatasetLandingPage.Version.Downloads {
 		if len(cfg.DownloadServiceURL) > 0 {

--- a/mapper/mapper.go
+++ b/mapper/mapper.go
@@ -330,7 +330,7 @@ func CreateEditionsList(basePage coreModel.Page, ctx context.Context, req *http.
 }
 
 // CreateCensusDatasetLandingPage creates a census-landing page based on api model responses
-func CreateCensusDatasetLandingPage(ctx context.Context, req *http.Request, basePage coreModel.Page, d dataset.DatasetDetails, version dataset.Version, opts []dataset.Options, dims dataset.VersionDimensions, initialVersionReleaseDate string, hasOtherVersions bool, allVersions []dataset.Version, lang string, maxNumberOfOptions int, isValidationError bool) datasetLandingPageCensus.Page {
+func CreateCensusDatasetLandingPage(ctx context.Context, req *http.Request, basePage coreModel.Page, d dataset.DatasetDetails, version dataset.Version, opts []dataset.Options, dims dataset.VersionDimensions, initialVersionReleaseDate string, hasOtherVersions bool, allVersions []dataset.Version, latestVersionNumber int, latestVersionURL string, lang string, maxNumberOfOptions int, isValidationError bool) datasetLandingPageCensus.Page {
 	p := datasetLandingPageCensus.Page{
 		Page: basePage,
 	}
@@ -476,6 +476,9 @@ func CreateCensusDatasetLandingPage(ctx context.Context, req *http.Request, base
 		}
 
 		sort.Slice(p.Versions, func(i, j int) bool { return p.Versions[i].VersionNumber > p.Versions[j].VersionNumber })
+
+		p.DatasetLandingPage.ShowOtherVersionsPanel = latestVersionNumber != version.Version && hasOtherVersions
+		p.DatasetLandingPage.LatestVersionURL = latestVersionURL
 	}
 
 	p.DatasetLandingPage.ShareDetails.Language = lang

--- a/mapper/mapper_test.go
+++ b/mapper/mapper_test.go
@@ -593,7 +593,7 @@ func TestCreateCensusDatasetLandingPage(t *testing.T) {
 	}
 
 	Convey("Census dataset landing page maps correctly as version 1", t, func() {
-		page := CreateCensusDatasetLandingPage(context.Background(), req, pageModel, datasetModel, versionOneDetails, datasetOptions, dataset.VersionDimensions{}, "", false, []dataset.Version{versionOneDetails}, "", 50, false)
+		page := CreateCensusDatasetLandingPage(context.Background(), req, pageModel, datasetModel, versionOneDetails, datasetOptions, dataset.VersionDimensions{}, "", false, []dataset.Version{versionOneDetails}, 1, "/a/version/1", "", 50, false)
 		So(page.Type, ShouldEqual, datasetModel.Type)
 		So(page.ID, ShouldEqual, datasetModel.ID)
 		So(page.Version.ReleaseDate, ShouldEqual, versionOneDetails.ReleaseDate)
@@ -611,11 +611,12 @@ func TestCreateCensusDatasetLandingPage(t *testing.T) {
 		So(page.DatasetLandingPage.Methodologies[0].Description, ShouldEqual, methodology.Description)
 		So(page.DatasetLandingPage.Methodologies[0].Title, ShouldEqual, methodology.Title)
 		So(page.DatasetLandingPage.Methodologies[0].URL, ShouldEqual, methodology.URL)
+		So(page.DatasetLandingPage.LatestVersionURL, ShouldBeBlank)
 	})
 
 	Convey("Release date and hasOtherVersions is mapped correctly when v2 of Census DLP dataset is loaded", t, func() {
 		req := httptest.NewRequest("", "/datasets/cantabular-1/editions/2021/versions/2", nil)
-		page := CreateCensusDatasetLandingPage(context.Background(), req, pageModel, datasetModel, versionTwoDetails, datasetOptions, dataset.VersionDimensions{}, versionOneDetails.ReleaseDate, true, []dataset.Version{versionOneDetails, versionTwoDetails}, "", 50, false)
+		page := CreateCensusDatasetLandingPage(context.Background(), req, pageModel, datasetModel, versionTwoDetails, datasetOptions, dataset.VersionDimensions{}, versionOneDetails.ReleaseDate, true, []dataset.Version{versionOneDetails, versionTwoDetails}, 2, "/a/version/123", "", 50, false)
 		So(page.InitialReleaseDate, ShouldEqual, versionOneDetails.ReleaseDate)
 		So(page.Version.ReleaseDate, ShouldEqual, versionTwoDetails.ReleaseDate)
 		So(page.DatasetLandingPage.HasOtherVersions, ShouldBeTrue)
@@ -624,20 +625,35 @@ func TestCreateCensusDatasetLandingPage(t *testing.T) {
 		So(page.Versions[0].ReleaseDate, ShouldEqual, versionTwoDetails.ReleaseDate)
 		So(page.Versions[0].IsCurrentPage, ShouldBeTrue)
 		So(page.Versions[0].Corrections[0].Reason, ShouldEqual, "This is a correction")
+		So(page.DatasetLandingPage.LatestVersionURL, ShouldEqual, "/a/version/123")
 	})
 
 	Convey("IsCurrent returns false when request is for a different page", t, func() {
 		req := httptest.NewRequest("", "/datasets/cantabular-1/editions/2021/versions/1", nil)
-		page := CreateCensusDatasetLandingPage(context.Background(), req, pageModel, datasetModel, versionTwoDetails, datasetOptions, dataset.VersionDimensions{}, versionOneDetails.ReleaseDate, true, []dataset.Version{versionOneDetails, versionTwoDetails}, "", 50, false)
+		page := CreateCensusDatasetLandingPage(context.Background(), req, pageModel, datasetModel, versionTwoDetails, datasetOptions, dataset.VersionDimensions{}, versionOneDetails.ReleaseDate, true, []dataset.Version{versionOneDetails, versionTwoDetails}, 2, "", "", 50, false)
 		So(page.Versions[0].VersionURL, ShouldEqual, "/datasets/cantabular-1/editions/2021/versions/2")
 		So(page.Versions[0].IsCurrentPage, ShouldBeFalse)
 	})
 
 	Convey("Versions history is in descending order", t, func() {
-		page := CreateCensusDatasetLandingPage(context.Background(), req, pageModel, datasetModel, versionTwoDetails, datasetOptions, dataset.VersionDimensions{}, versionOneDetails.ReleaseDate, true, []dataset.Version{versionOneDetails, versionTwoDetails, versionThreeDetails}, "", 50, false)
+		page := CreateCensusDatasetLandingPage(context.Background(), req, pageModel, datasetModel, versionTwoDetails, datasetOptions, dataset.VersionDimensions{}, versionOneDetails.ReleaseDate, true, []dataset.Version{versionOneDetails, versionTwoDetails, versionThreeDetails}, 3, "", "", 50, false)
 		So(page.Versions[0].VersionNumber, ShouldEqual, 3)
 		So(page.Versions[1].VersionNumber, ShouldEqual, 2)
 		So(page.Versions[2].VersionNumber, ShouldEqual, 1)
+	})
+
+	Convey("ShowOtherVersionsPanel is set correctly", t, func() {
+		// Landed on version 1, more than one version available = panel displays
+		page := CreateCensusDatasetLandingPage(context.Background(), req, pageModel, datasetModel, versionOneDetails, datasetOptions, dataset.VersionDimensions{}, versionOneDetails.ReleaseDate, true, []dataset.Version{versionOneDetails, versionTwoDetails, versionThreeDetails}, 3, "", "", 50, false)
+		So(page.DatasetLandingPage.ShowOtherVersionsPanel, ShouldBeTrue)
+
+		// Only one version = panel hidden
+		page = CreateCensusDatasetLandingPage(context.Background(), req, pageModel, datasetModel, versionOneDetails, datasetOptions, dataset.VersionDimensions{}, versionOneDetails.ReleaseDate, false, []dataset.Version{versionOneDetails}, 1, "", "", 50, false)
+		So(page.DatasetLandingPage.ShowOtherVersionsPanel, ShouldBeFalse)
+
+		// More than one version, landed on latest version (3) = panel hidden
+		page = CreateCensusDatasetLandingPage(context.Background(), req, pageModel, datasetModel, versionThreeDetails, datasetOptions, dataset.VersionDimensions{}, versionThreeDetails.ReleaseDate, true, []dataset.Version{versionOneDetails, versionTwoDetails, versionThreeDetails}, 3, "", "", 50, false)
+		So(page.DatasetLandingPage.ShowOtherVersionsPanel, ShouldBeFalse)
 	})
 
 	Convey("Validation error passed as true, error title should be populated", t, func() {
@@ -650,7 +666,7 @@ func TestCreateCensusDatasetLandingPage(t *testing.T) {
 				},
 			},
 		}
-		page := CreateCensusDatasetLandingPage(context.Background(), req, pageModel, datasetModel, versionDetails, datasetOptions, dataset.VersionDimensions{}, versionOneDetails.ReleaseDate, false, []dataset.Version{}, "", 50, true)
+		page := CreateCensusDatasetLandingPage(context.Background(), req, pageModel, datasetModel, versionDetails, datasetOptions, dataset.VersionDimensions{}, versionOneDetails.ReleaseDate, false, []dataset.Version{}, 1, "", "", 50, true)
 		So(page.Error.Title, ShouldEqual, fmt.Sprintf("Error: %s", datasetModel.Title))
 	})
 
@@ -664,7 +680,7 @@ func TestCreateCensusDatasetLandingPage(t *testing.T) {
 				},
 			},
 		}
-		page := CreateCensusDatasetLandingPage(context.Background(), req, pageModel, datasetModel, versionDetails, datasetOptions, dataset.VersionDimensions{}, versionOneDetails.ReleaseDate, false, []dataset.Version{}, "", 50, false)
+		page := CreateCensusDatasetLandingPage(context.Background(), req, pageModel, datasetModel, versionDetails, datasetOptions, dataset.VersionDimensions{}, versionOneDetails.ReleaseDate, false, []dataset.Version{}, 1, "", "", 50, false)
 		So(page.Error.Title, ShouldBeBlank)
 	})
 
@@ -678,7 +694,7 @@ func TestCreateCensusDatasetLandingPage(t *testing.T) {
 				},
 			},
 		}
-		page := CreateCensusDatasetLandingPage(context.Background(), req, pageModel, datasetModel, versionDetails, datasetOptions, dataset.VersionDimensions{}, versionOneDetails.ReleaseDate, false, []dataset.Version{}, "", 50, false)
+		page := CreateCensusDatasetLandingPage(context.Background(), req, pageModel, datasetModel, versionDetails, datasetOptions, dataset.VersionDimensions{}, versionOneDetails.ReleaseDate, false, []dataset.Version{}, 1, "", "", 50, false)
 		So(page.Error.Title, ShouldBeBlank)
 	})
 
@@ -693,7 +709,7 @@ func TestCreateCensusDatasetLandingPage(t *testing.T) {
 	}
 
 	Convey("No contacts provided, contact section is not displayed", t, func() {
-		page := CreateCensusDatasetLandingPage(context.Background(), req, pageModel, noContactDM, versionOneDetails, datasetOptions, dataset.VersionDimensions{}, "", false, []dataset.Version{}, "", 50, false)
+		page := CreateCensusDatasetLandingPage(context.Background(), req, pageModel, noContactDM, versionOneDetails, datasetOptions, dataset.VersionDimensions{}, "", false, []dataset.Version{}, 1, "", "", 50, false)
 		So(page.ContactDetails.Email, ShouldEqual, noContact.Email)
 		So(page.ContactDetails.Telephone, ShouldEqual, noContact.Telephone)
 		So(page.HasContactDetails, ShouldBeFalse)
@@ -710,7 +726,7 @@ func TestCreateCensusDatasetLandingPage(t *testing.T) {
 	}
 
 	Convey("One contact detail provided, contact section is displayed", t, func() {
-		page := CreateCensusDatasetLandingPage(context.Background(), req, pageModel, oneContactDetailDM, versionOneDetails, datasetOptions, dataset.VersionDimensions{}, "", false, []dataset.Version{}, "", 50, false)
+		page := CreateCensusDatasetLandingPage(context.Background(), req, pageModel, oneContactDetailDM, versionOneDetails, datasetOptions, dataset.VersionDimensions{}, "", false, []dataset.Version{}, 1, "", "", 50, false)
 		So(page.ContactDetails.Email, ShouldEqual, oneContactDetail.Email)
 		So(page.ContactDetails.Telephone, ShouldEqual, oneContactDetail.Telephone)
 		So(page.HasContactDetails, ShouldBeTrue)

--- a/model/datasetLandingPageCensus/model.go
+++ b/model/datasetLandingPageCensus/model.go
@@ -21,12 +21,14 @@ type Page struct {
 
 // DatasetLandingPage contains properties related to the census dataset landing page
 type DatasetLandingPage struct {
-	HasOtherVersions bool                    `json:"has_other_versions"`
-	Dimensions       []sharedModel.Dimension `json:"dimensions"`
-	GuideContents    GuideContents
-	Sections         map[string]Section
-	ShareDetails     ShareDetails
-	Methodologies    []Methodology `json:"methodology"`
+	HasOtherVersions       bool                    `json:"has_other_versions"`
+	ShowOtherVersionsPanel bool                    `json:"show_other_versions_panel"`
+	LatestVersionURL       string                  `json:"latest_version_url"`
+	Dimensions             []sharedModel.Dimension `json:"dimensions"`
+	GuideContents          GuideContents
+	Sections               map[string]Section
+	ShareDetails           ShareDetails
+	Methodologies          []Methodology `json:"methodology"`
 }
 
 // GuideContents contains the contents of the page and the language attribute


### PR DESCRIPTION
### What

- Created 'other versions panel' (similar but not identical to CMD release alert)
- Updated unit tests
- Minor design tweak to handle panel and text transform download format name

### How to review

- Sense check
- Tests pass
- To see it in action either 🤙 or [setup cantabular](https://github.com/ONSdigital/dp-compose/tree/main/cantabular-import#readme) to work locally. If going with the latter, you'll need to setup more that one version of the dataset
- Check image

![image](https://user-images.githubusercontent.com/19624419/144262892-1d5216fe-b5c4-4b11-8538-62753a67c66f.png)

### Who can review

- Frontend dev
