### PR TITLE
Feature/map collapsible to description

### DIFF
--- a/assets/locales/service.cy.toml
+++ b/assets/locales/service.cy.toml
@@ -183,6 +183,11 @@ one = "Skip to page content"
 description = "Variables"
 one = "Variables"
 
+[VariablesExplanation]
+description = "What do the variables mean"
+one = "What do the variables mean?"
+other = "What do the variables mean"
+
 [Category]
 description = "Category"
 one = "Category"

--- a/assets/locales/service.cy.toml
+++ b/assets/locales/service.cy.toml
@@ -185,7 +185,7 @@ one = "Variables"
 
 [VariablesExplanation]
 description = "What do the variables mean"
-one = "What do the variables mean?"
+one = "What does the variable mean"
 other = "What do the variables mean"
 
 [Category]

--- a/assets/locales/service.en.toml
+++ b/assets/locales/service.en.toml
@@ -165,8 +165,8 @@ description = "Variables"
 one = "Variables"
 
 [VariablesExplanation]
-description = "What do the variables mean?"
-one = "What do the variables mean?"
+description = "What do the variables mean"
+one = "What does the variable mean"
 other = "What do the variables mean"
 
 [Category]

--- a/assets/locales/service.en.toml
+++ b/assets/locales/service.en.toml
@@ -164,6 +164,11 @@ one = "Skip to page content"
 description = "Variables"
 one = "Variables"
 
+[VariablesExplanation]
+description = "What do the variables mean?"
+one = "What do the variables mean?"
+other = "What do the variables mean"
+
 [Category]
 description = "Category"
 one = "Category"

--- a/assets/templates/census-landing.tmpl
+++ b/assets/templates/census-landing.tmpl
@@ -15,9 +15,7 @@
             {{ template "partials/table-of-contents" .DatasetLandingPage.GuideContents }}
         </div>
         <div class="ons-grid__col ons-col-8@m ons-u-pl-no">
-            <section id="{{ .DatasetLandingPage.Sections.summary.ID }}" aria-label="{{ localise "Summary" .Language 1 }}">
-                {{ template "partials/census/section" .DatasetLandingPage.Sections.summary }}
-            </section>
+            {{ template "partials/census/summary" . }}
             {{ template "partials/census/variables-table" . }}
             {{ template "partials/census/get-data" . }}
             {{ if .HasContactDetails }}

--- a/assets/templates/partials/census/collapsible.tmpl
+++ b/assets/templates/partials/census/collapsible.tmpl
@@ -1,7 +1,7 @@
 <div id="collapsible" class="ons-collapsible ons-js-collapsible" data-btn-close="{{ localise "HideThis" .Language 1 }}">
     <div class="ons-collapsible__heading ons-js-collapsible-heading">
         <div class="ons-collapsible__controls">
-            <h2 class="ons-collapsible__title">{{ .Title }}</h2>
+            <h3 class="ons-collapsible__title">{{ localise "VariablesExplanation" .Language 1 }}</h3>
             <span class="ons-collapsible__icon">
                 <svg class="ons-svg-icon" viewBox="0 0 8 13" xmlns="http://www.w3.org/2000/svg" focusable="false">
                     <path
@@ -12,15 +12,21 @@
         </div>
     </div>
     <div id="collapsible-content" class="ons-collapsible__content ons-js-collapsible-content">
-        {{ range $i, $v := .Content }}
-            <p class="ons-u-fs-r ons-u-mb-s ons-u-p-no">{{ $v }}</p>
+        {{ range .DatasetLandingPage.Collapsible }}
+            {{ if .Subheading }}
+                <h4>{{ .Subheading }}</h4>
+            {{ end }}
+            {{ range .Content }}
+                <p class="ons-u-fs-r ons-u-mb-s ons-u-p-no">{{ . }}</p>
+            {{ end }}
+            <br>
         {{ end }}
-        <button
-            type="button"
-            class="ons-btn ons-js-collapsible-button ons-u-d-no ons-btn--secondary ons-btn--small"
-            aria-controls="collapsible">
-            <span class="ons-btn__inner ons-js-collapsible-button-inner">{{ localise "HideThis" .Language 1 }}</span>
-            <span class="ons-btn__context ons-u-vh">{{ .Title }} content</span>
-        </button>
+            <button
+                type="button"
+                class="ons-btn ons-js-collapsible-button ons-u-d-no ons-btn--secondary ons-btn--small"
+                aria-controls="collapsible">
+                <span class="ons-btn__inner ons-js-collapsible-button-inner">{{ localise "HideThis" .Language 1 }}</span>
+                <span class="ons-btn__context ons-u-vh">{{ localise "VariablesExplanation" .Language 2 }} content</span>
+            </button>
+        </div>
     </div>
-</div>

--- a/assets/templates/partials/census/collapsible.tmpl
+++ b/assets/templates/partials/census/collapsible.tmpl
@@ -1,7 +1,7 @@
 <div id="collapsible" class="ons-collapsible ons-js-collapsible" data-btn-close="{{ localise "HideThis" .Language 1 }}">
     <div class="ons-collapsible__heading ons-js-collapsible-heading">
         <div class="ons-collapsible__controls">
-            <h3 class="ons-collapsible__title">{{ localise "VariablesExplanation" .Language 2 }}&#63;</h3>
+            <h3 class="ons-collapsible__title">{{ localise "VariablesExplanation" .Language 4 }}&#63;</h3>
             <span class="ons-collapsible__icon">
                 <svg class="ons-svg-icon" viewBox="0 0 8 13" xmlns="http://www.w3.org/2000/svg" focusable="false">
                     <path
@@ -26,7 +26,7 @@
                 class="ons-btn ons-js-collapsible-button ons-u-d-no ons-btn--secondary ons-btn--small"
                 aria-controls="collapsible">
                 <span class="ons-btn__inner ons-js-collapsible-button-inner">{{ localise "HideThis" .Language 1 }}</span>
-                <span class="ons-btn__context ons-u-vh">{{ localise "VariablesExplanation" .Language 2 }} content</span>
+                <span class="ons-btn__context ons-u-vh">{{ localise "VariablesExplanation" .Language 4 }} content</span>
             </button>
         </div>
     </div>

--- a/assets/templates/partials/census/collapsible.tmpl
+++ b/assets/templates/partials/census/collapsible.tmpl
@@ -1,7 +1,7 @@
 <div id="collapsible" class="ons-collapsible ons-js-collapsible" data-btn-close="{{ localise "HideThis" .Language 1 }}">
     <div class="ons-collapsible__heading ons-js-collapsible-heading">
         <div class="ons-collapsible__controls">
-            <h3 class="ons-collapsible__title">{{ localise "VariablesExplanation" .Language 1 }}</h3>
+            <h3 class="ons-collapsible__title">{{ localise "VariablesExplanation" .Language 2 }}&#63;</h3>
             <span class="ons-collapsible__icon">
                 <svg class="ons-svg-icon" viewBox="0 0 8 13" xmlns="http://www.w3.org/2000/svg" focusable="false">
                     <path

--- a/assets/templates/partials/census/section.tmpl
+++ b/assets/templates/partials/census/section.tmpl
@@ -1,7 +1,0 @@
-<h2>{{ .Title }}</h2>
-{{ range $i, $v := .Description }}
-<p>{{ $v }}</p>
-{{ end }}
-{{ if .Collapsible.Title }}
-    {{ template "partials/census/collapsible" .Collapsible }}
-{{ end }}

--- a/assets/templates/partials/census/summary.tmpl
+++ b/assets/templates/partials/census/summary.tmpl
@@ -1,0 +1,9 @@
+<section id="summary" aria-label="{{ localise "Summary" .Language 1 }}">
+    <h2>{{ localise "Summary" .Language 1 }}</h2>
+    {{ range .DatasetLandingPage.Description }}
+        <p>{{ . }}</p>
+    {{ end }}
+    {{ if .DatasetLandingPage.Collapsible }}
+        {{ template "partials/census/collapsible" . }}
+    {{ end }}
+</section>

--- a/assets/templates/partials/census/variables-table.tmpl
+++ b/assets/templates/partials/census/variables-table.tmpl
@@ -1,7 +1,7 @@
 {{$dims := .DatasetLandingPage.Dimensions}}
 {{$language := .Language }}
 <section id="variables" aria-label="{{ localise "Variables" .Language 1}}">
-    <h2 class="ons-u-mt-l">{{ localise "Variables" .Language 1}}</h2>
+    <h2 class="ons-u-mt-xl">{{ localise "Variables" .Language 1}}</h2>
     <table class="ons-table">
         <tbody class="ons-table__body">
             {{range $i, $dim := $dims}}

--- a/mapper/mapper.go
+++ b/mapper/mapper.go
@@ -374,23 +374,16 @@ func CreateCensusDatasetLandingPage(ctx context.Context, req *http.Request, base
 		}
 	}
 
-	sections := make(map[string]datasetLandingPageCensus.Section)
+	p.DatasetLandingPage.Description = strings.Split(d.Description, "\n")
 
-	sections["summary"] = datasetLandingPageCensus.Section{
-		Title:       "Summary",
-		ID:          "summary",
-		Description: []string{d.Description},
-		Collapsible: datasetLandingPageCensus.Collapsible{
-			Language: p.Language,
-			Title:    "Why is this useful",
-			Content: []string{
-				"Information about why this is useful goes here.",
-				"Second paragraph expanding on why this is useful goes here.",
-			},
-		},
+	for _, dims := range version.Dimensions {
+		if dims.Description != "" {
+			var collapsibleContent datasetLandingPageCensus.Collapsible
+			collapsibleContent.Subheading = dims.Name
+			collapsibleContent.Content = strings.Split(dims.Description, "\n")
+			p.DatasetLandingPage.Collapsible = append(p.DatasetLandingPage.Collapsible, collapsibleContent)
+		}
 	}
-
-	p.DatasetLandingPage.Sections = sections
 
 	hasMethodologies := false
 	if d.Methodologies != nil {
@@ -422,8 +415,8 @@ func CreateCensusDatasetLandingPage(ctx context.Context, req *http.Request, base
 	p.DatasetLandingPage.GuideContents.Language = lang
 	p.DatasetLandingPage.GuideContents.GuideContent = []datasetLandingPageCensus.Content{
 		{
-			Title: sections["summary"].Title,
-			ID:    sections["summary"].ID,
+			LocaliseKey: "Summary",
+			ID:          "summary",
 		},
 		{
 			LocaliseKey: "Variables",

--- a/mapper/mapper_test.go
+++ b/mapper/mapper_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/ONSdigital/dp-api-clients-go/dataset"
@@ -517,7 +518,7 @@ func TestCreateCensusDatasetLandingPage(t *testing.T) {
 			contact,
 		},
 		ID:          "12345",
-		Description: "An interesting test description",
+		Description: "An interesting test description \n with a line break",
 		Methodologies: &[]dataset.Methodology{
 			methodology,
 		},
@@ -539,6 +540,20 @@ func TestCreateCensusDatasetLandingPage(t *testing.T) {
 			Dataset: dataset.Link{
 				URL: "http://localhost:22000/datasets/cantabular-1",
 				ID:  "cantabular-1",
+			},
+		},
+		Dimensions: []dataset.VersionDimension{
+			{
+				Description: "A description on one line",
+				Name:        "Dimension 1",
+			},
+			{
+				Description: "A description on one line \n Then a line break",
+				Name:        "Dimension 2",
+			},
+			{
+				Description: "",
+				Name:        "Only a name - I shouldn't map",
 			},
 		},
 	}
@@ -604,6 +619,7 @@ func TestCreateCensusDatasetLandingPage(t *testing.T) {
 		So(page.Version.Downloads[0].URI, ShouldEqual, "https://mydomain.com/my-request")
 		So(page.Metadata.Title, ShouldEqual, datasetModel.Title)
 		So(page.Metadata.Description, ShouldEqual, datasetModel.Description)
+		So(page.DatasetLandingPage.Description, ShouldResemble, strings.Split(datasetModel.Description, "\n"))
 		So(page.ContactDetails.Name, ShouldEqual, contact.Name)
 		So(page.ContactDetails.Email, ShouldEqual, contact.Email)
 		So(page.ContactDetails.Telephone, ShouldEqual, contact.Telephone)
@@ -612,6 +628,11 @@ func TestCreateCensusDatasetLandingPage(t *testing.T) {
 		So(page.DatasetLandingPage.Methodologies[0].Title, ShouldEqual, methodology.Title)
 		So(page.DatasetLandingPage.Methodologies[0].URL, ShouldEqual, methodology.URL)
 		So(page.DatasetLandingPage.LatestVersionURL, ShouldBeBlank)
+		So(page.DatasetLandingPage.Collapsible[0].Subheading, ShouldEqual, versionOneDetails.Dimensions[0].Name)
+		So(page.DatasetLandingPage.Collapsible[0].Content[0], ShouldEqual, versionOneDetails.Dimensions[0].Description)
+		So(page.DatasetLandingPage.Collapsible[1].Subheading, ShouldEqual, versionOneDetails.Dimensions[1].Name)
+		So(page.DatasetLandingPage.Collapsible[1].Content, ShouldResemble, strings.Split(versionOneDetails.Dimensions[1].Description, "\n"))
+		So(page.DatasetLandingPage.Collapsible, ShouldHaveLength, 2)
 	})
 
 	Convey("Release date and hasOtherVersions is mapped correctly when v2 of Census DLP dataset is loaded", t, func() {

--- a/model/datasetLandingPageCensus/model.go
+++ b/model/datasetLandingPageCensus/model.go
@@ -26,9 +26,10 @@ type DatasetLandingPage struct {
 	LatestVersionURL       string                  `json:"latest_version_url"`
 	Dimensions             []sharedModel.Dimension `json:"dimensions"`
 	GuideContents          GuideContents
-	Sections               map[string]Section
+	Collapsible            []Collapsible
 	ShareDetails           ShareDetails
 	Methodologies          []Methodology `json:"methodology"`
+	Description            []string      `json:"description"`
 }
 
 // GuideContents contains the contents of the page and the language attribute
@@ -54,14 +55,6 @@ type ShareDetails struct {
 	Language       string  `json:"language"`
 }
 
-// Section corresponds to a section of the landing page with title, description and collapsible section (optional)
-type Section struct {
-	Title       string      `json:"title"`
-	ID          string      `json:"id"`
-	Description []string    `json:"description"`
-	Collapsible Collapsible `json:"collapsible"`
-}
-
 /* Share includes details for a specific place the dataset can be shared
    Included icons: 'facebook', 'twitter', 'email', 'linkedin'
 */
@@ -73,9 +66,8 @@ type Share struct {
 
 // Collapsible is a representation of the data required in a collapsible UI component
 type Collapsible struct {
-	Language string   `json:"language"`
-	Title    string   `json:"title"`
-	Content  []string `json:"content"`
+	Subheading string   `json:"subheading"`
+	Content    []string `json:"content"`
 }
 
 // Methodology links


### PR DESCRIPTION
### What

- Refactored collapsible
- Mapped collapsible to `dimension.description` field
- Splitting string arrays on line breaks so the web page actually displays distinct paragraphs
- Removed 'section' model props and refactored 'collapsible' to be a child of the page

### How to review

- Sense check
- Tests pass
- To see it in action either call me 🤙 or [setup cantabular](https://github.com/ONSdigital/dp-compose/tree/main/cantabular-import#readme) to work locally. If going with the latter, make sure you enter some data into the `Dimension description` fields in Florence
- Look at the image ⬇️ 
![image](https://user-images.githubusercontent.com/19624419/144597559-e1e63651-120a-4f7a-8df7-76b2fc7819b8.png)

**Note** the `Dimension.Name` fields used as subheading on the collapsible do not exactly match the title fields used on the 'variables' table component, this is being looked into 👀 

### Who can review

- Frontend dev
