### PR TITLE
Feature/move phase banner

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/ONSdigital/dp-cookies v0.2.0
 	github.com/ONSdigital/dp-healthcheck v1.0.5
 	github.com/ONSdigital/dp-net v1.0.12
-	github.com/ONSdigital/dp-renderer v1.9.2
+	github.com/ONSdigital/dp-renderer v1.9.3
 	github.com/ONSdigital/log.go/v2 v2.0.9
 	github.com/golang/mock v1.6.0
 	github.com/gorilla/mux v1.8.0

--- a/go.sum
+++ b/go.sum
@@ -38,6 +38,8 @@ github.com/ONSdigital/dp-renderer v1.9.0 h1:lM9PikNMSDCu627asqFTXChDL4FyVJY3XJ6g
 github.com/ONSdigital/dp-renderer v1.9.0/go.mod h1:Z5sbyS0ApY6D8ikGDt2KIl5bt2p5kk73PeeMxGs1pEM=
 github.com/ONSdigital/dp-renderer v1.9.2 h1:wfU1zcx1Hlr9QppR2oFdDneaQI3w2VDD1HlJ7+Vuq5E=
 github.com/ONSdigital/dp-renderer v1.9.2/go.mod h1:Z5sbyS0ApY6D8ikGDt2KIl5bt2p5kk73PeeMxGs1pEM=
+github.com/ONSdigital/dp-renderer v1.9.3 h1:z0D9vccS4T8m+ML6txR9i24h5k7YDX763eK5tKf8T8o=
+github.com/ONSdigital/dp-renderer v1.9.3/go.mod h1:Z5sbyS0ApY6D8ikGDt2KIl5bt2p5kk73PeeMxGs1pEM=
 github.com/ONSdigital/go-ns v0.0.0-20191104121206-f144c4ec2e58/go.mod h1:iWos35il+NjbvDEqwtB736pyHru0MPFE/LqcwkV1wDc=
 github.com/ONSdigital/log.go v1.0.0/go.mod h1:UnGu9Q14gNC+kz0DOkdnLYGoqugCvnokHBRBxFRpVoQ=
 github.com/ONSdigital/log.go v1.0.1-0.20200805084515-ee61165ea36a/go.mod h1:dDnQATFXCBOknvj6ZQuKfmDhbOWf3e8mtV+dPEfWJqs=


### PR DESCRIPTION
### What

Updated to version 1.9.3 of `dp-renderer` to move the phase banner to above the header as per the [design-system](https://ons-design-system.netlify.app/components/phase-banner/) requirements

### How to review

Sense check
Check images

**Note** you can view these pages if you follow the [guidance](https://github.com/ONSdigital/dp-compose/tree/main/cantabular-import#readme) to setup your local services to perform a cantabular and CMD dataset import (helpers/init-db.sh). Then you should be able to see both instances of the phase banner OR call me and I can show you locally 😄 

#### Phase banner on census pages
![image](https://user-images.githubusercontent.com/19624419/145397538-5d0b415c-2920-461d-be88-b4eb2d2b7e65.png)

#### Phase banner on CMD pages is unchanged
![image](https://user-images.githubusercontent.com/19624419/145398113-4e54651b-1569-4c8c-8a34-4960f524807e.png)

### Who can review

Frontend dev

