### PR TITLE
Feature/enabling start of filter/flex journey

### DIFF
--- a/assets/locales/service.cy.toml
+++ b/assets/locales/service.cy.toml
@@ -176,8 +176,9 @@ description = "Contents skip link"
 one = "Skip to page content"
 
 [Variables]
-description = "Variables"
-one = "Variables"
+description = "Variable"
+one = "Variable"
+other = "Variables"
 
 [VariablesExplanation]
 description = "What do the variables mean"
@@ -266,3 +267,7 @@ one = "Important information:"
 [NewVersionAvailable]
 description = "There is a new version of this dataset. View the <a href=\"{{ .DatasetLandingPage.LatestVersionURL }}\">latest version</a>."
 one = "There is a new version of this dataset. View the <a href=\"{{.arg0}}\">latest version</a>."
+
+[Change]
+description = "Change"
+one = "Change"

--- a/assets/locales/service.en.toml
+++ b/assets/locales/service.en.toml
@@ -157,8 +157,9 @@ description = "Contents skip link"
 one = "Skip to page content"
 
 [Variables]
-description = "Variables"
-one = "Variables"
+description = "Variable"
+one = "Variable"
+other = "Variables"
 
 [VariablesExplanation]
 description = "What do the variables mean"
@@ -247,3 +248,7 @@ one = "Important information:"
 [NewVersionAvailable]
 description = "There is a new version of this dataset. View the <a href=\"{{ .DatasetLandingPage.LatestVersionURL }}\">latest version</a>."
 one = "There is a new version of this dataset. View the <a href=\"{{.arg0}}\">latest version</a>."
+
+[Change]
+description = "Change"
+one = "Change"

--- a/assets/templates/partials/census/variables-table.tmpl
+++ b/assets/templates/partials/census/variables-table.tmpl
@@ -1,7 +1,11 @@
 {{$dims := .DatasetLandingPage.Dimensions}}
 {{$language := .Language }}
-<section id="variables" aria-label="{{ localise "Variables" .Language 1}}">
-    <h2 class="ons-u-mt-xl">{{ localise "Variables" .Language 1}}</h2>
+{{$flexible := .DatasetLandingPage.IsFlexible}}
+<section id="variables" aria-label="{{ localise "Variables" .Language 4}}">
+    <h2 class="ons-u-mt-xl">{{ localise "Variables" .Language 4}}</h2>
+    {{ if $flexible }}
+    <form action="{{.DatasetLandingPage.FormAction}}" method="post">
+    {{ end }}
     <table class="ons-table">
         <tbody class="ons-table__body">
             {{range $i, $dim := $dims}}
@@ -27,16 +31,27 @@
                             <div class="ons-u-mt-s">
                                 {{ range $j, $val := $dim.Values}}
                                     {{ if notLastItem $length $j }}
-                                        <small class="u-fs-s">{{ $val }},</small>
+                                        <small>{{ $val }},</small>
                                     {{ else }}
-                                        <small class="u-fs-s">{{ $val }}</small>
+                                        <small>{{ $val }}</small>
                                     {{ end }}
                                 {{ end }}
                             </div>
                         {{end}}
                     </td>
+                    {{ if $flexible }}
+                    <td class="ons-table__cell ons-u-pb-s ons-u-pt-s ons-u-ta-right">
+                        <button type="submit" class="ons-btn ons-btn__btn--link" name="dimension" value="{{ $dim.Title }}" role="link">
+                            {{ localise "Change" $language 1 }} 
+                            <span class="ons-u-vh">{{ localise "Variables" $language 1 }} {{ $dim.Title }}</span>
+                        </button>
+                    </td>
+                    {{ end }}
                 </tr>
             {{ end }}
         </tbody>
     </table>
+    {{ if $flexible }}
+    </form>
+    {{ end }}
 </section>

--- a/assets/templates/partials/table-of-contents.tmpl
+++ b/assets/templates/partials/table-of-contents.tmpl
@@ -8,7 +8,7 @@
                 <li class="ons-list__item">
                     <a href="#{{ .ID }}" class="ons-list__link">
                         {{ if .LocaliseKey }}
-                            {{ localise .LocaliseKey $guideContents.Language 1 }}
+                            {{ localise .LocaliseKey $guideContents.Language .LocalisePluralInt }}
                         {{ else }}
                             {{ .Title }}
                         {{ end }}

--- a/config/config.go
+++ b/config/config.go
@@ -36,7 +36,7 @@ func Get() (*Config, error) {
 	if cfg.Debug {
 		cfg.PatternLibraryAssetsPath = "http://localhost:9002/dist/assets"
 	} else {
-		cfg.PatternLibraryAssetsPath = "//cdn.ons.gov.uk/dp-design-system/613c855"
+		cfg.PatternLibraryAssetsPath = "//cdn.ons.gov.uk/dp-design-system/54d8753"
 	}
 	return cfg, nil
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -31,7 +31,7 @@ func TestConfig(t *testing.T) {
 				So(cfg.HealthCheckInterval, ShouldEqual, 30*time.Second)
 				So(cfg.HealthCheckCriticalTimeout, ShouldEqual, 90*time.Second)
 				So(cfg.EnableProfiler, ShouldBeFalse)
-				So(cfg.PatternLibraryAssetsPath, ShouldEqual, "//cdn.ons.gov.uk/dp-design-system/613c855")
+				So(cfg.PatternLibraryAssetsPath, ShouldEqual, "//cdn.ons.gov.uk/dp-design-system/54d8753")
 			})
 		})
 	})

--- a/go.sum
+++ b/go.sum
@@ -5,8 +5,6 @@ github.com/ONSdigital/dp-api-clients-go v1.34.3/go.mod h1:kX+YKuoLYLfkeLHMvQKRRy
 github.com/ONSdigital/dp-api-clients-go v1.41.1 h1:xkeT6dCTFSAoBpZxgiJUiuqgcfjCX+c52CIiZo1Y2iU=
 github.com/ONSdigital/dp-api-clients-go v1.41.1/go.mod h1:Ga1+ANjviu21NFJI9wp5NctJIdB4TJLDGbpQFl2V8Wc=
 github.com/ONSdigital/dp-api-clients-go/v2 v2.1.7-beta/go.mod h1:p9Ig0jUJmOXYpsZFZkb+mBeUgNBKoTiTVqHt1kJlVrM=
-github.com/ONSdigital/dp-api-clients-go/v2 v2.6.1 h1:4Au7WuP/AHTJM75hMXpHJhGahNkwVeN2yCG4SgJZjHQ=
-github.com/ONSdigital/dp-api-clients-go/v2 v2.6.1/go.mod h1:oB+Pw1BJlLHUh+a6BJY52VFTRGBEM5RSPlg2Xkq7D9k=
 github.com/ONSdigital/dp-api-clients-go/v2 v2.6.2 h1:q7xqa7tXeLs68z8sTPwXASdW3mycgS5aUYEC+eAjxDQ=
 github.com/ONSdigital/dp-api-clients-go/v2 v2.6.2/go.mod h1:oB+Pw1BJlLHUh+a6BJY52VFTRGBEM5RSPlg2Xkq7D9k=
 github.com/ONSdigital/dp-cookies v0.2.0 h1:x+B7ka1VCS8lS5A8cA0hKVZCvf5ZYYXIMk8HAk1qUDo=
@@ -25,8 +23,6 @@ github.com/ONSdigital/dp-net v1.2.0 h1:gP9pBt/J8gktYeKsb7hq6uOC2xx1tfvTorUBNXp6p
 github.com/ONSdigital/dp-net v1.2.0/go.mod h1:NinlaqcsPbIR+X7j5PXCl3UI5G2zCL041SDF6WIiiO4=
 github.com/ONSdigital/dp-net/v2 v2.2.0-beta h1:AZFUvizC17H9FMj34cKqTm8v9Gjm5LrgXhcWeDPJ6Cs=
 github.com/ONSdigital/dp-net/v2 v2.2.0-beta/go.mod h1:lL/AjGwUqdxb+RtYlxZXSVgN7Bev9vw+f/NrKZOc1JQ=
-github.com/ONSdigital/dp-renderer v1.10.1 h1:hxKb9JJLir2uEUi+UFkCcLwTfHA0ys0fHfZ1Yq//meA=
-github.com/ONSdigital/dp-renderer v1.10.1/go.mod h1:Z5sbyS0ApY6D8ikGDt2KIl5bt2p5kk73PeeMxGs1pEM=
 github.com/ONSdigital/dp-renderer v1.10.7 h1:x/6N0LJ61FJO4io/Woe/BxK2PmnwmJFWCQ86BbSgu+k=
 github.com/ONSdigital/dp-renderer v1.10.7/go.mod h1:Z5sbyS0ApY6D8ikGDt2KIl5bt2p5kk73PeeMxGs1pEM=
 github.com/ONSdigital/go-ns v0.0.0-20191104121206-f144c4ec2e58/go.mod h1:iWos35il+NjbvDEqwtB736pyHru0MPFE/LqcwkV1wDc=

--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -129,6 +129,31 @@ func CreateFilterID(c FilterClient, dc DatasetClient) http.HandlerFunc {
 	})
 }
 
+// CreateFilterFlexID creates a new filter ID for filter flex journeys
+func CreateFilterFlexID(c FilterClient, cfg config.Config) http.HandlerFunc {
+	return handlers.ControllerHandler(func(w http.ResponseWriter, req *http.Request, lang, collectionID, userAccessToken string) {
+		ctx := req.Context()
+
+		if !cfg.EnableCensusPages {
+			err := errors.New("not implemented")
+			log.Error(ctx, "route not implemented", err)
+			setStatusCode(req, w, err)
+			return
+		}
+
+		if err := req.ParseForm(); err != nil {
+			log.Error(ctx, "unable to parse request form", err)
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		// TODO: get the real filter id from successful POST request
+		fid := "1234"
+		dimension := req.FormValue("dimension")
+		flexPath := fmt.Sprintf("/flex/%s/dimensions/%s", fid, strings.ToLower(dimension))
+		http.Redirect(w, req, flexPath, http.StatusMovedPermanently)
+	})
+}
+
 // LegacyLanding will load a zebedee landing page
 func LegacyLanding(zc ZebedeeClient, dc DatasetClient, rend RenderClient, cfg config.Config) http.HandlerFunc {
 	return handlers.ControllerHandler(func(w http.ResponseWriter, req *http.Request, lang, collectionID, userAccessToken string) {

--- a/handlers/handlers_test.go
+++ b/handlers/handlers_test.go
@@ -687,6 +687,32 @@ func TestUnitHandlers(t *testing.T) {
 		})
 	})
 
+	Convey("test CreateFilterFlexID", t, func() {
+		Convey("test CreateFilterFlexID handler, creates a filter id and redirects", func() {
+			mockClient := NewMockFilterClient(mockCtrl)
+			mockConfig := config.Config{EnableCensusPages: true}
+			router := mux.NewRouter()
+			router.HandleFunc("/datasets/{datasetID}/editions/{editionID}/versions/{versionID}/flex", CreateFilterFlexID(mockClient, mockConfig))
+			w := httptest.NewRecorder()
+			req := httptest.NewRequest("POST", "/datasets/12345/editions/2012/versions/1/flex", nil)
+			router.ServeHTTP(w, req)
+
+			So(w.Code, ShouldEqual, http.StatusMovedPermanently)
+		})
+
+		Convey("test post route fails if config is false", func() {
+			mockClient := NewMockFilterClient(mockCtrl)
+			mockConfig := config.Config{EnableCensusPages: false}
+			router := mux.NewRouter()
+			router.HandleFunc("/datasets/{datasetID}/editions/{editionID}/versions/{versionID}/flex", CreateFilterFlexID(mockClient, mockConfig))
+			w := httptest.NewRecorder()
+			req := httptest.NewRequest("POST", "/datasets/12345/editions/2012/versions/1/flex", nil)
+			router.ServeHTTP(w, req)
+
+			So(w.Code, ShouldEqual, http.StatusInternalServerError)
+		})
+	})
+
 }
 
 func testResponse(code int, respBody, url string, fc FilterClient, dc DatasetClient) *httptest.ResponseRecorder {

--- a/main.go
+++ b/main.go
@@ -124,6 +124,9 @@ func run(ctx context.Context) error {
 	router.StrictSlash(true).Path("/datasets/{datasetID}/editions/{edition}/versions/{version}/metadata.txt").Methods("GET").HandlerFunc(handlers.MetadataText(dc, *cfg))
 
 	router.StrictSlash(true).Path("/datasets/{datasetID}/editions/{editionID}/versions/{versionID}/filter").Methods("POST").HandlerFunc(handlers.CreateFilterID(f, dc))
+	if cfg.EnableCensusPages {
+		router.StrictSlash(true).Path("/datasets/{datasetID}/editions/{editionID}/versions/{versionID}/flex").Methods("POST").HandlerFunc(handlers.CreateFilterFlexID(f, *cfg))
+	}
 
 	router.StrictSlash(true).HandleFunc("/{uri:.*}", handlers.LegacyLanding(zc, dc, rend, *cfg))
 

--- a/mapper/mapper.go
+++ b/mapper/mapper.go
@@ -434,28 +434,33 @@ func CreateCensusDatasetLandingPage(ctx context.Context, req *http.Request, base
 	p.DatasetLandingPage.GuideContents.Language = lang
 	p.DatasetLandingPage.GuideContents.GuideContent = []datasetLandingPageCensus.Content{
 		{
-			LocaliseKey: "Summary",
-			ID:          "summary",
+			LocaliseKey:       "Summary",
+			LocalisePluralInt: 1,
+			ID:                "summary",
 		},
 		{
-			LocaliseKey: "Variables",
-			ID:          "variables",
+			LocaliseKey:       "Variables",
+			LocalisePluralInt: 4,
+			ID:                "variables",
 		},
 		{
-			LocaliseKey: "GetData",
-			ID:          "get-data",
+			LocaliseKey:       "GetData",
+			LocalisePluralInt: 1,
+			ID:                "get-data",
 		},
 		{
-			LocaliseKey: "StatisticalDisclosureControl",
-			ID:          "stats-disclosure",
+			LocaliseKey:       "StatisticalDisclosureControl",
+			LocalisePluralInt: 1,
+			ID:                "stats-disclosure",
 		},
 	}
 
 	if p.HasContactDetails {
 		contactsContents := []datasetLandingPageCensus.Content{
 			{
-				LocaliseKey: "ContactDetails",
-				ID:          "contact",
+				LocaliseKey:       "ContactDetails",
+				LocalisePluralInt: 1,
+				ID:                "contact",
 			},
 		}
 		temp := append(contactsContents, p.DatasetLandingPage.GuideContents.GuideContent[3:]...)
@@ -464,15 +469,17 @@ func CreateCensusDatasetLandingPage(ctx context.Context, req *http.Request, base
 
 	if hasMethodologies {
 		p.DatasetLandingPage.GuideContents.GuideContent = append(p.DatasetLandingPage.GuideContents.GuideContent, datasetLandingPageCensus.Content{
-			LocaliseKey: "Methodology",
-			ID:          "methodology",
+			LocaliseKey:       "Methodology",
+			LocalisePluralInt: 1,
+			ID:                "methodology",
 		})
 	}
 
 	if hasOtherVersions {
 		p.DatasetLandingPage.GuideContents.GuideContent = append(p.DatasetLandingPage.GuideContents.GuideContent, datasetLandingPageCensus.Content{
-			LocaliseKey: "VersionHistory",
-			ID:          "version-history",
+			LocaliseKey:       "VersionHistory",
+			LocalisePluralInt: 1,
+			ID:                "version-history",
 		})
 
 		for _, ver := range allVersions {
@@ -527,6 +534,11 @@ func CreateCensusDatasetLandingPage(ctx context.Context, req *http.Request, base
 
 	if isValidationError {
 		p.Error.Title = fmt.Sprintf("Error: %s", d.Title)
+	}
+
+	if strings.Contains(d.Type, "flex") {
+		p.DatasetLandingPage.IsFlexible = true
+		p.DatasetLandingPage.FormAction = fmt.Sprintf("/datasets/%s/editions/%s/versions/%s/flex", d.ID, version.Edition, strconv.Itoa(version.Version))
 	}
 
 	return p

--- a/mapper/mapper_test.go
+++ b/mapper/mapper_test.go
@@ -664,6 +664,7 @@ func TestCreateCensusDatasetLandingPage(t *testing.T) {
 		So(page.Collapsible.CollapsibleItems[1].Subheading, ShouldEqual, versionOneDetails.Dimensions[1].Name)
 		So(page.Collapsible.CollapsibleItems[1].Content, ShouldResemble, strings.Split(versionOneDetails.Dimensions[1].Description, "\n"))
 		So(page.Collapsible.CollapsibleItems, ShouldHaveLength, 2)
+		So(page.DatasetLandingPage.IsFlexible, ShouldBeFalse)
 	})
 
 	Convey("Release date and hasOtherVersions is mapped correctly when v2 of Census DLP dataset is loaded", t, func() {
@@ -782,6 +783,16 @@ func TestCreateCensusDatasetLandingPage(t *testing.T) {
 		So(page.ContactDetails.Email, ShouldEqual, oneContactDetail.Email)
 		So(page.ContactDetails.Telephone, ShouldEqual, oneContactDetail.Telephone)
 		So(page.HasContactDetails, ShouldBeTrue)
+	})
+
+	Convey("Dataset type is flexible, additional mapping is correct", t, func() {
+		flexDm := dataset.DatasetDetails{
+			Type: "cantabular_flexible_table",
+			ID:   "test-flex",
+		}
+		page := CreateCensusDatasetLandingPage(context.Background(), req, pageModel, flexDm, versionOneDetails, datasetOptions, dataset.VersionDimensions{}, "", false, []dataset.Version{}, 1, "", "", 50, false)
+		So(page.DatasetLandingPage.IsFlexible, ShouldBeTrue)
+		So(page.DatasetLandingPage.FormAction, ShouldEqual, fmt.Sprintf("/datasets/%s/editions/%s/versions/%s/flex", flexDm.ID, versionOneDetails.Edition, strconv.Itoa(versionOneDetails.Version)))
 	})
 }
 

--- a/model/datasetLandingPageCensus/model.go
+++ b/model/datasetLandingPageCensus/model.go
@@ -29,6 +29,8 @@ type DatasetLandingPage struct {
 	ShareDetails           ShareDetails
 	Methodologies          []Methodology `json:"methodology"`
 	Description            []string      `json:"description"`
+	IsFlexible             bool          `json:"is_flexible"`
+	FormAction             string        `json:"form_action"`
 }
 
 // GuideContents contains the contents of the page and the language attribute
@@ -40,12 +42,14 @@ type GuideContents struct {
 /* Content maps the content details.
 The visible text can be either a 'Title' or a 'LocaliseKey'.
 The 'LocaliseKey' has to correspond to the localisation key found in the toml files within assets/locales, otherwise the page will error.
+LocalisePluralInt refers to the plural int used in the toml file.
 ID refers to the html element's ID that is needed to form the href.
 */
 type Content struct {
-	Title       string `json:"title"`
-	ID          string `json:"id"`
-	LocaliseKey string `json:"localise_key"`
+	Title             string `json:"title"`
+	ID                string `json:"id"`
+	LocaliseKey       string `json:"localise_key"`
+	LocalisePluralInt int    `json:"localise_plural_int"`
 }
 
 // ShareDetails contains the locations the page can be shared to, as well as the language attribute for localisation


### PR DESCRIPTION
### What

- Added foundations to start a filter/flex journey for census dataset landing pages
- Used latest version of `dp-design-system`
- Expanded `guide content` model to include the localisation plural int
- Removed superfluous css utility class
- Updated unit tests

**Note the following** 
- This is a WIP that sits behind a feature toggle
- The backend endpoint to POST the create filter/flex id is not ready yet 
- 'flexible' datatype is not yet being returned

### How to review

- Sense check
- Tests pass
- Check image
- **Optional** You can _relatively_ easily run the [cantabular import](https://github.com/ONSdigital/dp-compose/tree/main/cantabular-import#readme) journey and run the import scripts
```go 
  d.Type = "flex"
``` 
  - Add the above snippet ⬆️ onto line `539` of `mapper.go`
  - Upload a cantabular dataset and publish
  - Make sure you set the env config for `dp-frontend-dataset-controller` to `debug = true` and start the `dp-design-service`
- Or call me 🤙 and I can show you locally 😄 

![image](https://user-images.githubusercontent.com/19624419/151005587-653a76bc-1520-4a15-9e09-17ce4380de1d.png)


### Who can review

Frontend dev
