### PR TITLE
Feature/create filter id via new handler

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/ONSdigital/dp-frontend-dataset-controller
 go 1.15
 
 require (
-	github.com/ONSdigital/dp-api-clients-go/v2 v2.92.2
+	github.com/ONSdigital/dp-api-clients-go/v2 v2.92.5
 	github.com/ONSdigital/dp-cookies v0.2.0
 	github.com/ONSdigital/dp-healthcheck v1.1.0
 	github.com/ONSdigital/dp-net v1.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -9,6 +9,8 @@ github.com/ONSdigital/dp-api-clients-go/v2 v2.6.2 h1:q7xqa7tXeLs68z8sTPwXASdW3my
 github.com/ONSdigital/dp-api-clients-go/v2 v2.6.2/go.mod h1:oB+Pw1BJlLHUh+a6BJY52VFTRGBEM5RSPlg2Xkq7D9k=
 github.com/ONSdigital/dp-api-clients-go/v2 v2.92.2 h1:KlxSi4kRz9nO5j5OjCgnjQsyoRAky5WOmMKQPbNPHA8=
 github.com/ONSdigital/dp-api-clients-go/v2 v2.92.2/go.mod h1:P3GYyqqXnbp4RjWhz0oYpUFjHPT6Ca4fEoh4huNkxHU=
+github.com/ONSdigital/dp-api-clients-go/v2 v2.92.5 h1:UbJj/eeHvJ33Th8f3LnqVPwvSQn8a3Qk4VuXhPD+lhg=
+github.com/ONSdigital/dp-api-clients-go/v2 v2.92.5/go.mod h1:P3GYyqqXnbp4RjWhz0oYpUFjHPT6Ca4fEoh4huNkxHU=
 github.com/ONSdigital/dp-cookies v0.2.0 h1:x+B7ka1VCS8lS5A8cA0hKVZCvf5ZYYXIMk8HAk1qUDo=
 github.com/ONSdigital/dp-cookies v0.2.0/go.mod h1:DG82eMupUGBO+/y514swhhYva1YnzxhWqfG6RnRQXIA=
 github.com/ONSdigital/dp-healthcheck v1.0.5/go.mod h1:2wbVAUHMl9+4tWhUlxYUuA1dnf2+NrwzC+So5f5BMLk=

--- a/handlers/handlers_test.go
+++ b/handlers/handlers_test.go
@@ -4,6 +4,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/ONSdigital/dp-api-clients-go/v2/dataset"
@@ -92,6 +93,8 @@ func TestUnitHandlers(t *testing.T) {
 	})
 
 	Convey("test CreateFilterID", t, func() {
+		mockCfg := config.Config{}
+
 		Convey("test CreateFilterID handler, creates a filter id and redirects", func() {
 			mockClient := NewMockFilterClient(mockCtrl)
 			mockClient.EXPECT().CreateBlueprint(ctx, userAuthToken, serviceAuthToken, "", collectionID, "1234", "5678", "2017", []string{"aggregate", "time"}).Return("12345", "testETag", nil)
@@ -113,7 +116,8 @@ func TestUnitHandlers(t *testing.T) {
 			mockDatasetClient.EXPECT().GetOptions(ctx, userAuthToken, serviceAuthToken, collectionID, "1234", "5678", "2017", "time",
 				&dataset.QueryParams{Offset: 0, Limit: 0}).Return(datasetOptions(0, 0), nil)
 
-			w := testResponse(301, "", "/datasets/1234/editions/5678/versions/2017/filter", mockClient, mockDatasetClient)
+			body := strings.NewReader("")
+			w := testResponse(301, body, "/datasets/1234/editions/5678/versions/2017/filter", mockClient, mockDatasetClient, false, mockCfg)
 
 			location := w.Header().Get("Location")
 			So(location, ShouldNotBeEmpty)
@@ -128,7 +132,67 @@ func TestUnitHandlers(t *testing.T) {
 			mockDatasetClient := NewMockDatasetClient(mockCtrl)
 			mockDatasetClient.EXPECT().GetVersionDimensions(ctx, userAuthToken, serviceAuthToken, collectionID, "1234", "5678", "2017").Return(dataset.VersionDimensions{}, nil)
 
-			testResponse(500, "", "/datasets/1234/editions/5678/versions/2017/filter", mockClient, mockDatasetClient)
+			body := strings.NewReader("")
+
+			testResponse(500, body, "/datasets/1234/editions/5678/versions/2017/filter", mockClient, mockDatasetClient, false, mockCfg)
+		})
+	})
+
+	Convey("test CreateFilterFlexID", t, func() {
+		mockCfg := config.Config{EnableCensusPages: true}
+		mockVersions := dataset.VersionsList{
+			Items: []dataset.Version{
+				{}, // deliberately empty
+				{
+					Dimensions: []dataset.VersionDimension{
+						{
+							Name: "aggregate",
+						},
+						{
+							Name: "time",
+						},
+					},
+				},
+			},
+		}
+
+		Convey("test CreateFilterFlexID handler, creates a filter id and redirect includes dimension name", func() {
+			mockClient := NewMockFilterClient(mockCtrl)
+			mockClient.EXPECT().CreateBlueprint(ctx, userAuthToken, serviceAuthToken, "", collectionID, "1234", "2021", "1", []string{"aggregate", "time"}).Return("12345", "testETag", nil)
+
+			mockDatasetClient := NewMockDatasetClient(mockCtrl)
+			mockDatasetClient.EXPECT().GetVersion(ctx, userAuthToken, serviceAuthToken, "", collectionID, "1234", "2021", "1").Return(mockVersions.Items[1], nil)
+			mockDatasetClient.EXPECT().GetOptions(ctx, userAuthToken, serviceAuthToken, collectionID, "1234", "2021", "1", "aggregate",
+				&dataset.QueryParams{Offset: 0, Limit: 0}).Return(datasetOptions(0, 0), nil)
+			mockDatasetClient.EXPECT().GetOptions(ctx, userAuthToken, serviceAuthToken, collectionID, "1234", "2021", "1", "time",
+				&dataset.QueryParams{Offset: 0, Limit: 0}).Return(datasetOptions(0, 0), nil)
+
+			body := strings.NewReader("dimension=aggregate")
+			w := testResponse(301, body, "/datasets/1234/editions/2021/versions/1/filter-flex", mockClient, mockDatasetClient, true, mockCfg)
+
+			location := w.Header().Get("Location")
+			So(location, ShouldNotBeEmpty)
+
+			So(location, ShouldEqual, "/filters/12345/dimensions/aggregate")
+		})
+
+		Convey("test post route fails if config is false", func() {
+			mockCfg := config.Config{EnableCensusPages: false}
+			mockDatasetClient := NewMockDatasetClient(mockCtrl)
+			mockFilterClient := NewMockFilterClient(mockCtrl)
+			body := strings.NewReader("")
+
+			testResponse(500, body, "/datasets/1234/editions/2021/versions/1/filter-flex", mockFilterClient, mockDatasetClient, true, mockCfg)
+		})
+
+		Convey("test CreateFilterFlexID returns 500 if unable to create a blueprint on filter api", func() {
+			mockDatasetClient := NewMockDatasetClient(mockCtrl)
+			mockDatasetClient.EXPECT().GetVersion(ctx, userAuthToken, serviceAuthToken, "", collectionID, "1234", "2021", "1").Return(mockVersions.Items[0], nil)
+			mockFilterClient := NewMockFilterClient(mockCtrl)
+			mockFilterClient.EXPECT().CreateBlueprint(ctx, userAuthToken, serviceAuthToken, "", collectionID, "1234", "2021", "1", gomock.Any()).Return("", "", errors.New("unable to create filter blueprint"))
+			body := strings.NewReader("")
+
+			testResponse(500, body, "/datasets/1234/editions/2021/versions/1/filter-flex", mockFilterClient, mockDatasetClient, true, mockCfg)
 		})
 	})
 
@@ -688,14 +752,18 @@ func TestUnitHandlers(t *testing.T) {
 	})
 }
 
-func testResponse(code int, respBody, url string, fc FilterClient, dc DatasetClient) *httptest.ResponseRecorder {
-	req, err := http.NewRequest("POST", url, nil)
-	So(err, ShouldBeNil)
+func testResponse(code int, body *strings.Reader, url string, fc FilterClient, dc DatasetClient, filterFlexRoute bool, cfg config.Config) *httptest.ResponseRecorder {
+	req := httptest.NewRequest("POST", url, body)
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 
 	w := httptest.NewRecorder()
 
 	router := mux.NewRouter()
-	router.HandleFunc("/datasets/{datasetID}/editions/{editionID}/versions/{versionID}/filter", CreateFilterID(fc, dc))
+	if filterFlexRoute {
+		router.HandleFunc("/datasets/{datasetID}/editions/{editionID}/versions/{versionID}/filter-flex", CreateFilterFlexID(fc, dc, cfg))
+	} else {
+		router.HandleFunc("/datasets/{datasetID}/editions/{editionID}/versions/{versionID}/filter", CreateFilterID(fc, dc))
+	}
 
 	router.ServeHTTP(w, req)
 
@@ -703,8 +771,8 @@ func testResponse(code int, respBody, url string, fc FilterClient, dc DatasetCli
 
 	b, err := ioutil.ReadAll(w.Body)
 	So(err, ShouldBeNil)
-
-	So(string(b), ShouldEqual, respBody)
+	// Writer body should be empty, we don't write a response
+	So(b, ShouldBeEmpty)
 
 	return w
 }

--- a/main.go
+++ b/main.go
@@ -124,6 +124,9 @@ func run(ctx context.Context) error {
 	router.StrictSlash(true).Path("/datasets/{datasetID}/editions/{edition}/versions/{version}/metadata.txt").Methods("GET").HandlerFunc(handlers.MetadataText(dc, *cfg))
 
 	router.StrictSlash(true).Path("/datasets/{datasetID}/editions/{editionID}/versions/{versionID}/filter").Methods("POST").HandlerFunc(handlers.CreateFilterID(f, dc))
+	if cfg.EnableCensusPages {
+		router.StrictSlash(true).Path("/datasets/{datasetID}/editions/{editionID}/versions/{versionID}/filter-flex").Methods("POST").HandlerFunc(handlers.CreateFilterFlexID(f, dc, *cfg))
+	}
 
 	router.StrictSlash(true).HandleFunc("/{uri:.*}", handlers.LegacyLanding(zc, dc, rend, *cfg))
 

--- a/mapper/mapper.go
+++ b/mapper/mapper.go
@@ -538,7 +538,7 @@ func CreateCensusDatasetLandingPage(ctx context.Context, req *http.Request, base
 
 	if strings.Contains(d.Type, "flex") {
 		p.DatasetLandingPage.IsFlexible = true
-		p.DatasetLandingPage.FormAction = fmt.Sprintf("/datasets/%s/editions/%s/versions/%s/filter", d.ID, version.Edition, strconv.Itoa(version.Version))
+		p.DatasetLandingPage.FormAction = fmt.Sprintf("/datasets/%s/editions/%s/versions/%s/filter-flex", d.ID, version.Edition, strconv.Itoa(version.Version))
 	}
 
 	return p

--- a/mapper/mapper_test.go
+++ b/mapper/mapper_test.go
@@ -792,7 +792,7 @@ func TestCreateCensusDatasetLandingPage(t *testing.T) {
 		}
 		page := CreateCensusDatasetLandingPage(context.Background(), req, pageModel, flexDm, versionOneDetails, datasetOptions, dataset.VersionDimensions{}, "", false, []dataset.Version{}, 1, "", "", 50, false)
 		So(page.DatasetLandingPage.IsFlexible, ShouldBeTrue)
-		So(page.DatasetLandingPage.FormAction, ShouldEqual, fmt.Sprintf("/datasets/%s/editions/%s/versions/%s/filter", flexDm.ID, versionOneDetails.Edition, strconv.Itoa(versionOneDetails.Version)))
+		So(page.DatasetLandingPage.FormAction, ShouldEqual, fmt.Sprintf("/datasets/%s/editions/%s/versions/%s/filter-flex", flexDm.ID, versionOneDetails.Edition, strconv.Itoa(versionOneDetails.Version)))
 	})
 }
 

--- a/model/related/model.go
+++ b/model/related/model.go
@@ -2,6 +2,7 @@ package related
 
 // Related stores the Title and URI for any related data (eg related publications on a dataset page)
 type Related struct {
-	Title string `json:"title"`
-	URI   string `json:"uri"`
+	Title   string `json:"title"`
+	Summary string `json:"summary,omitempty"`
+	URI     string `json:"uri"`
 }


### PR DESCRIPTION
### What

- Created new handler (skeleton code) for creating filter/flex id and redirect logic
  - The endpoint is likely to change as extra parameters are needed. This work is ongoing
- Created new route to POST
- Updated unit tests
- Updated `dp-api-clients-go` which resulted in change to the `Related` model

### How to review

- Sense check
- Tests pass
- 🤙 call me to see this working locally, as there are dependencies on other work it is more difficult than normal to pull this branch and see it working end-to-end

### Who can review

!me