### PR TITLE
Feature/consume flex blueprint

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/ONSdigital/dp-frontend-dataset-controller
 go 1.15
 
 require (
-	github.com/ONSdigital/dp-api-clients-go/v2 v2.92.5
+	github.com/ONSdigital/dp-api-clients-go/v2 v2.98.0
 	github.com/ONSdigital/dp-cookies v0.2.0
 	github.com/ONSdigital/dp-healthcheck v1.1.0
 	github.com/ONSdigital/dp-net v1.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -11,6 +11,8 @@ github.com/ONSdigital/dp-api-clients-go/v2 v2.92.2 h1:KlxSi4kRz9nO5j5OjCgnjQsyoR
 github.com/ONSdigital/dp-api-clients-go/v2 v2.92.2/go.mod h1:P3GYyqqXnbp4RjWhz0oYpUFjHPT6Ca4fEoh4huNkxHU=
 github.com/ONSdigital/dp-api-clients-go/v2 v2.92.5 h1:UbJj/eeHvJ33Th8f3LnqVPwvSQn8a3Qk4VuXhPD+lhg=
 github.com/ONSdigital/dp-api-clients-go/v2 v2.92.5/go.mod h1:P3GYyqqXnbp4RjWhz0oYpUFjHPT6Ca4fEoh4huNkxHU=
+github.com/ONSdigital/dp-api-clients-go/v2 v2.98.0 h1:mLoj5N7Q8ve/MKR56+S9vyuC1S1Yp/DKqII/jngcygo=
+github.com/ONSdigital/dp-api-clients-go/v2 v2.98.0/go.mod h1:P3GYyqqXnbp4RjWhz0oYpUFjHPT6Ca4fEoh4huNkxHU=
 github.com/ONSdigital/dp-cookies v0.2.0 h1:x+B7ka1VCS8lS5A8cA0hKVZCvf5ZYYXIMk8HAk1qUDo=
 github.com/ONSdigital/dp-cookies v0.2.0/go.mod h1:DG82eMupUGBO+/y514swhhYva1YnzxhWqfG6RnRQXIA=
 github.com/ONSdigital/dp-healthcheck v1.0.5/go.mod h1:2wbVAUHMl9+4tWhUlxYUuA1dnf2+NrwzC+So5f5BMLk=

--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -44,6 +44,7 @@ const (
 // FilterClient is an interface with the methods required for a filter client
 type FilterClient interface {
 	CreateBlueprint(ctx context.Context, userAuthToken, serviceAuthToken, downloadServiceToken, collectionID, datasetID, edition, version string, names []string) (filterID, eTag string, err error)
+	CreateFlexibleBlueprint(ctx context.Context, userAuthToken, serviceAuthToken, downloadServiceToken, collectionID, datasetID, edition, version string, names []string, population_type string) (filterID, eTag string, err error)
 }
 
 // DatasetClient is an interface with methods required for a dataset client
@@ -172,8 +173,14 @@ func CreateFilterFlexID(fc FilterClient, dc DatasetClient, cfg config.Config) ht
 			}
 		}
 
-		// TODO: This endpoint is likely to change; awaiting change to be implemented
-		fid, _, err := fc.CreateBlueprint(ctx, userAccessToken, "", "", collectionID, datasetID, edition, version, names)
+		datasetModel, err := dc.Get(ctx, userAccessToken, "", collectionID, datasetID)
+		if err != nil {
+			setStatusCode(req, w, err)
+			return
+		}
+
+		popType := datasetModel.IsBasedOn.ID
+		fid, _, err := fc.CreateFlexibleBlueprint(ctx, userAccessToken, "", "", collectionID, datasetID, edition, version, names, popType)
 		if err != nil {
 			setStatusCode(req, w, err)
 			return

--- a/handlers/handlers_test.go
+++ b/handlers/handlers_test.go
@@ -158,7 +158,7 @@ func TestUnitHandlers(t *testing.T) {
 
 		Convey("test CreateFilterFlexID handler, creates a filter id and redirect includes dimension name", func() {
 			mockClient := NewMockFilterClient(mockCtrl)
-			mockClient.EXPECT().CreateBlueprint(ctx, userAuthToken, serviceAuthToken, "", collectionID, "1234", "2021", "1", []string{"aggregate", "time"}).Return("12345", "testETag", nil)
+			mockClient.EXPECT().CreateFlexibleBlueprint(ctx, userAuthToken, serviceAuthToken, "", collectionID, "1234", "2021", "1", []string{"aggregate", "time"}, "Example").Return("12345", "testETag", nil)
 
 			mockDatasetClient := NewMockDatasetClient(mockCtrl)
 			mockDatasetClient.EXPECT().GetVersion(ctx, userAuthToken, serviceAuthToken, "", collectionID, "1234", "2021", "1").Return(mockVersions.Items[1], nil)
@@ -166,6 +166,7 @@ func TestUnitHandlers(t *testing.T) {
 				&dataset.QueryParams{Offset: 0, Limit: 0}).Return(datasetOptions(0, 0), nil)
 			mockDatasetClient.EXPECT().GetOptions(ctx, userAuthToken, serviceAuthToken, collectionID, "1234", "2021", "1", "time",
 				&dataset.QueryParams{Offset: 0, Limit: 0}).Return(datasetOptions(0, 0), nil)
+			mockDatasetClient.EXPECT().Get(ctx, userAuthToken, serviceAuthToken, collectionID, "1234").Return(dataset.DatasetDetails{IsBasedOn: &dataset.IsBasedOn{ID: "Example"}}, nil)
 
 			body := strings.NewReader("dimension=aggregate")
 			w := testResponse(301, body, "/datasets/1234/editions/2021/versions/1/filter-flex", mockClient, mockDatasetClient, true, mockCfg)
@@ -188,8 +189,9 @@ func TestUnitHandlers(t *testing.T) {
 		Convey("test CreateFilterFlexID returns 500 if unable to create a blueprint on filter api", func() {
 			mockDatasetClient := NewMockDatasetClient(mockCtrl)
 			mockDatasetClient.EXPECT().GetVersion(ctx, userAuthToken, serviceAuthToken, "", collectionID, "1234", "2021", "1").Return(mockVersions.Items[0], nil)
+			mockDatasetClient.EXPECT().Get(ctx, userAuthToken, serviceAuthToken, collectionID, "1234").Return(dataset.DatasetDetails{IsBasedOn: &dataset.IsBasedOn{}}, nil)
 			mockFilterClient := NewMockFilterClient(mockCtrl)
-			mockFilterClient.EXPECT().CreateBlueprint(ctx, userAuthToken, serviceAuthToken, "", collectionID, "1234", "2021", "1", gomock.Any()).Return("", "", errors.New("unable to create filter blueprint"))
+			mockFilterClient.EXPECT().CreateFlexibleBlueprint(ctx, userAuthToken, serviceAuthToken, "", collectionID, "1234", "2021", "1", gomock.Any(), "").Return("", "", errors.New("unable to create filter blueprint"))
 			body := strings.NewReader("")
 
 			testResponse(500, body, "/datasets/1234/editions/2021/versions/1/filter-flex", mockFilterClient, mockDatasetClient, true, mockCfg)

--- a/handlers/mock_handlers.go
+++ b/handlers/mock_handlers.go
@@ -53,6 +53,22 @@ func (mr *MockFilterClientMockRecorder) CreateBlueprint(ctx, userAuthToken, serv
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateBlueprint", reflect.TypeOf((*MockFilterClient)(nil).CreateBlueprint), ctx, userAuthToken, serviceAuthToken, downloadServiceToken, collectionID, datasetID, edition, version, names)
 }
 
+// CreateFlexibleBlueprint mocks base method.
+func (m *MockFilterClient) CreateFlexibleBlueprint(ctx context.Context, userAuthToken, serviceAuthToken, downloadServiceToken, collectionID, datasetID, edition, version string, names []string, population_type string) (string, string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateFlexibleBlueprint", ctx, userAuthToken, serviceAuthToken, downloadServiceToken, collectionID, datasetID, edition, version, names, population_type)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(string)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// CreateFlexibleBlueprint indicates an expected call of CreateFlexibleBlueprint.
+func (mr *MockFilterClientMockRecorder) CreateFlexibleBlueprint(ctx, userAuthToken, serviceAuthToken, downloadServiceToken, collectionID, datasetID, edition, version, names, population_type interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateFlexibleBlueprint", reflect.TypeOf((*MockFilterClient)(nil).CreateFlexibleBlueprint), ctx, userAuthToken, serviceAuthToken, downloadServiceToken, collectionID, datasetID, edition, version, names, population_type)
+}
+
 // MockDatasetClient is a mock of DatasetClient interface.
 type MockDatasetClient struct {
 	ctrl     *gomock.Controller


### PR DESCRIPTION
### What

- Consuming new `CreateFlexibleBlueprint` for the start of filter/flex journeys
- Updated unit tests

### How to review

- Sense check
- Tests pass
- _Optional_ you can pull this branch and run the [cantabular import journey](https://github.com/ONSdigital/dp-compose/tree/main/cantabular-import) docker container OR 🤙 and I'll show you it working locally

### Who can review

!me
