### PR TITLE
Use 'printf' to add build flags when generating assets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,11 +47,11 @@ endif
 .PHONY: generate-debug
 generate-debug: fetch-renderer-lib
 	cd assets; go run github.com/kevinburke/go-bindata/go-bindata -prefix $(CORE_ASSETS_PATH)/assets -debug -o data.go -pkg assets locales/... templates/... $(CORE_ASSETS_PATH)/assets/locales/... $(CORE_ASSETS_PATH)/assets/templates/...
-	{ echo "// +build debug\n"; cat assets/data.go; } > assets/debug.go.new
+	{ printf "// +build debug\n"; cat assets/data.go; } > assets/debug.go.new
 	mv assets/debug.go.new assets/data.go
 
 .PHONY: generate-prod
 generate-prod: fetch-renderer-lib 
 	cd assets; go run github.com/kevinburke/go-bindata/go-bindata -prefix $(CORE_ASSETS_PATH)/assets -o data.go -pkg assets locales/... templates/... $(CORE_ASSETS_PATH)/assets/locales/... $(CORE_ASSETS_PATH)/assets/templates/...
-	{ echo "// +build production\n"; cat assets/data.go; } > assets/data.go.new
+	{ printf "// +build production\n"; cat assets/data.go; } > assets/data.go.new
 	mv assets/data.go.new assets/data.go


### PR DESCRIPTION
### What

Running zsh on a linux machine the `\n` (newline) character was being
added to the `data.go` file when using the `echo` command.
Additionally the `echo -e` of `echo -E` options for backslash
interpretation are not available on Darwin/bsd.

This is useful when running the commands:
```
make generate-debug
make generate-prod
```

### How to review

Run locally the following commands from your local `dp-frontend-dataset-controller` repo
```
make generate-debug
make generate-prod
```

### Who can review

Anyone developer from Get Data team B
