### PR TITLE
Update landing page to use ID rather than title (#5664)

### DIFF
--- a/assets/templates/partials/census/variables-table.tmpl
+++ b/assets/templates/partials/census/variables-table.tmpl
@@ -39,7 +39,7 @@
                     </td>
                     {{ if $flexible }}
                     <td class="ons-table__cell ons-u-pb-s ons-u-pt-s ons-u-ta-right ons-u-pl-no@xxs@s ons-u-ml-xs@xxs@s ons-u-order--2 ons-u-bb-no@xxs@s">
-                        <button type="submit" class="ons-btn ons-btn__btn--link" name="dimension" value="{{ $dim.Title }}" role="link">
+                        <button type="submit" class="ons-btn ons-btn__btn--link" name="dimension" value="{{ $dim.Name }}" role="link">
                             {{ localise "Change" $language 1 }} 
                             <span class="ons-u-vh">{{ localise "Variables" $language 1 }} {{ $dim.Title }}</span>
                         </button>

--- a/mapper/mapper.go
+++ b/mapper/mapper.go
@@ -610,6 +610,7 @@ func mapOptionsToDimensions(ctx context.Context, datasetType string, dims datase
 			}
 			for _, dimension := range dims.Items {
 				if dimension.Name == opt.Items[0].DimensionID {
+					pDim.Name = dimension.Name
 					pDim.Description = dimension.Description
 					if len(dimension.Label) > 0 {
 						pDim.Title = dimension.Label

--- a/mapper/mapper_test.go
+++ b/mapper/mapper_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/ONSdigital/dp-api-clients-go/v2/dataset"
 	"github.com/ONSdigital/dp-api-clients-go/v2/zebedee"
+	sharedModel "github.com/ONSdigital/dp-frontend-dataset-controller/model"
 	"github.com/ONSdigital/dp-renderer/model"
 	. "github.com/smartystreets/goconvey/convey"
 )
@@ -85,6 +86,13 @@ func TestUnitMapper(t *testing.T) {
 			Links: dataset.Links{
 				Self: dataset.Link{
 					URL: "/datasets/83jd98fkflg/editions/124/versions/1",
+				},
+			},
+			Dimensions: []dataset.VersionDimension{
+				{
+					ID:    "city",
+					Name:  "geography",
+					Label: "City",
 				},
 			},
 			ReleaseDate: "11-11-2017",
@@ -327,6 +335,51 @@ func TestUnitMapper(t *testing.T) {
 		So(v0.Edition, ShouldEqual, v[0].Edition)
 		So(v0.Version, ShouldEqual, strconv.Itoa(v[0].Version))
 		So(p.ReleaseDate, ShouldEqual, v[0].ReleaseDate)
+	})
+
+	Convey("test CreateFilterableLandingPage dimension options are mapped into landing page dimensions", t, func() {
+		const (
+			dimensionName        = "geography"
+			dimensionID          = "city"
+			dimensionLabel       = "City"
+			dimensionOptionLabel = "London"
+		)
+
+		dims := dataset.VersionDimensions{
+			Items: []dataset.VersionDimension{
+				{
+					ID:    dimensionID,
+					Name:  dimensionName,
+					Label: dimensionLabel,
+				},
+			},
+		}
+		opts := []dataset.Options{
+			{
+				Items: []dataset.Option{
+					{
+						DimensionID: dimensionName,
+						Label:       dimensionOptionLabel,
+						Option:      "0",
+					},
+				},
+				Count:      1,
+				TotalCount: 1,
+			},
+		}
+
+		p := CreateFilterableLandingPage(mdl, ctx, req, d, v[0], datasetID, opts, dims, false, []zebedee.Breadcrumb{},
+			1, "", "en", "/v1", 50, serviceMessage, emergencyBanner)
+
+		So(p.DatasetLandingPage.Dimensions, ShouldResemble, []sharedModel.Dimension{
+			{
+				Title:      dimensionLabel,
+				Name:       dimensionName,
+				Values:     []string{dimensionOptionLabel},
+				OptionsURL: "/dimensions/geography/options",
+				TotalItems: 1,
+			},
+		})
 	})
 
 	Convey("test time dimensions when parsing Jan-06 format for CreateFilterableLandingPage ", t, func() {

--- a/model/dimension.go
+++ b/model/dimension.go
@@ -3,6 +3,7 @@ package model
 // Dimension represents the data for a single dimension
 type Dimension struct {
 	Title       string   `json:"title"`
+	Name        string   `json:"name"`
 	Values      []string `json:"values"`
 	OptionsURL  string   `json:"options_url"`
 	TotalItems  int      `json:"total_items"`


### PR DESCRIPTION
### What

We now have a consistent, machine-readable ID and name for dimensions, so we no longer have to use the label.

(Changes will also need to be made to the [filter-flex frontend](https://github.com/ONSdigital/dp-frontend-filter-flex-dataset/pull/20))

Resolves: [5664](https://trello.com/c/3TbBPTvY) (partial)

### How to review

Sense check.

### Who can review

Anyone, but probably Team B.
