### PR TITLE
Feature/back-to UI component on mobile

### DIFF
--- a/assets/templates/census-landing.tmpl
+++ b/assets/templates/census-landing.tmpl
@@ -11,7 +11,7 @@
                 {{ template "partials/census/other-versions-panel" . }}
             {{ end }}
         </section>
-        <div class="ons-grid__col ons-col-4@m ons-u-pl-no ons-grid__col--sticky@m">
+        <div class="ons-grid__col ons-col-4@m ons-u-pl-no ons-grid__col--sticky@m" id="toc">
             {{ template "partials/table-of-contents" . }}
         </div>
         <div class="ons-grid__col ons-col-8@m ons-u-pl-no">

--- a/assets/templates/partials/census/back-to-contents.tmpl
+++ b/assets/templates/partials/census/back-to-contents.tmpl
@@ -1,0 +1,1 @@
+<div class="ons-u-mt-l ons-u-d-no@m">{{ template "partials/back-to" . }}</div>

--- a/assets/templates/partials/census/contact-details.tmpl
+++ b/assets/templates/partials/census/contact-details.tmpl
@@ -1,5 +1,5 @@
 <section id="contact" aria-label="{{ localise "RelatedLinksForCensus" .Language 1 }}">
-    <h2 class="ons-u-mt-l ons-u-pb-no ons-u-pt-no" id="contact-details">{{ localise "ContactDetails" .Language 1 }}</h2>
+    <h2 class="ons-u-mt-xl ons-u-pb-no ons-u-pt-no" id="contact-details">{{ localise "ContactDetails" .Language 1 }}</h2>
     <nav class="ons-related-content__navigation" aria-labelledby="contact-details">
         <ul class="ons-list ons-list--bare ons-u-fs-r">
             {{ if .ContactDetails.Email }}
@@ -16,4 +16,5 @@
             {{ end }}
         </ul>
     </nav>
+    {{ template "partials/census/back-to-contents" . }}
 </section>

--- a/assets/templates/partials/census/get-data.tmpl
+++ b/assets/templates/partials/census/get-data.tmpl
@@ -41,7 +41,7 @@
                 {{ end }}
             </div>
         </fieldset>
-        <button type="submit" class="ons-btn ons-u-mt-s ons-u-mb-s">
+        <button type="submit" class="ons-btn ons-u-mt-s">
             <span class="ons-btn__inner">
                 {{ template "icons/download" }} Download
             </span>
@@ -51,4 +51,5 @@
         </div>
     </div>
     {{ end }}
+    {{ template "partials/census/back-to-contents" . }}
 </section>

--- a/assets/templates/partials/census/methodologies.tmpl
+++ b/assets/templates/partials/census/methodologies.tmpl
@@ -3,4 +3,5 @@
     {{ range .DatasetLandingPage.Methodologies }}
         <p>{{ .Description }}</p>
     {{ end }}
+    {{ template "partials/census/back-to-contents" . }}
 </section>

--- a/assets/templates/partials/census/stats-disclosure.tmpl
+++ b/assets/templates/partials/census/stats-disclosure.tmpl
@@ -2,4 +2,5 @@
     <h2 class="ons-u-mt-xl ons-u-pb-no ons-u-pt-no">{{ localise "StatsDisclosureTitle" .Language 1 }}</h2>
     <p>{{ localise "StatsDisclosureReasoning" .Language 1 }}</p>
     <p>{{ localise "StatsDisclosureEffect" .Language 1 }}</p>
+    {{ template "partials/census/back-to-contents" . }}
 </section>

--- a/assets/templates/partials/census/summary.tmpl
+++ b/assets/templates/partials/census/summary.tmpl
@@ -1,9 +1,10 @@
 <section id="summary" aria-label="{{ localise "Summary" .Language 1 }}">
-    <h2>{{ localise "Summary" .Language 1 }}</h2>
+    <h2 class="ons-u-mt-m@xxs@m">{{ localise "Summary" .Language 1 }}</h2>
     {{ range .DatasetLandingPage.Description }}
         <p>{{ . }}</p>
     {{ end }}
     {{ if .Collapsible.CollapsibleItems }}
         {{ template "partials/collapsible" . }}
     {{ end }}
+    {{ template "partials/census/back-to-contents" . }}
 </section>

--- a/assets/templates/partials/census/variables-table.tmpl
+++ b/assets/templates/partials/census/variables-table.tmpl
@@ -52,4 +52,5 @@
     {{ if $flexible }}
     </form>
     {{ end }}
+    {{ template "partials/census/back-to-contents" . }}
 </section>

--- a/assets/templates/partials/census/version-history.tmpl
+++ b/assets/templates/partials/census/version-history.tmpl
@@ -18,7 +18,9 @@
                         {{ if .IsCurrentPage }}
                             <time datetime="{{ $version.ReleaseDate }}">{{ dateFormat $version.ReleaseDate }}</time>
                         {{ else }}
-                            <a href="{{ $version.VersionURL }}"><time datetime="{{ $version.ReleaseDate }}">{{ dateFormat $version.ReleaseDate }}</time></a>
+                            <a href="{{ $version.VersionURL }}">
+                                <time datetime="{{ $version.ReleaseDate }}">{{ dateFormat $version.ReleaseDate }}</time>
+                            </a>
                         {{ end }}
                     </td>
                     <td class="ons-table__cell ons-u-pb-s ons-u-pt-s">
@@ -38,4 +40,5 @@
             {{ end }}
         </tbody>
     </table>
+    {{ template "partials/census/back-to-contents" . }}
 </section>

--- a/config/config.go
+++ b/config/config.go
@@ -36,7 +36,7 @@ func Get() (*Config, error) {
 	if cfg.Debug {
 		cfg.PatternLibraryAssetsPath = "http://localhost:9002/dist/assets"
 	} else {
-		cfg.PatternLibraryAssetsPath = "//cdn.ons.gov.uk/dp-design-system/d081822"
+		cfg.PatternLibraryAssetsPath = "//cdn.ons.gov.uk/dp-design-system/778ac19"
 	}
 	return cfg, nil
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -31,7 +31,7 @@ func TestConfig(t *testing.T) {
 				So(cfg.HealthCheckInterval, ShouldEqual, 30*time.Second)
 				So(cfg.HealthCheckCriticalTimeout, ShouldEqual, 90*time.Second)
 				So(cfg.EnableProfiler, ShouldBeFalse)
-				So(cfg.PatternLibraryAssetsPath, ShouldEqual, "//cdn.ons.gov.uk/dp-design-system/d081822")
+				So(cfg.PatternLibraryAssetsPath, ShouldEqual, "//cdn.ons.gov.uk/dp-design-system/778ac19")
 			})
 		})
 	})

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/ONSdigital/dp-cookies v0.2.0
 	github.com/ONSdigital/dp-healthcheck v1.2.3
 	github.com/ONSdigital/dp-net/v2 v2.2.0
-	github.com/ONSdigital/dp-renderer v1.25.3
+	github.com/ONSdigital/dp-renderer v1.27.0
 	github.com/ONSdigital/log.go/v2 v2.1.0
 	github.com/golang/mock v1.6.0
 	github.com/gorilla/mux v1.8.0

--- a/go.sum
+++ b/go.sum
@@ -67,6 +67,8 @@ github.com/ONSdigital/dp-net/v2 v2.2.0 h1:EHh7n6pdI82F7Ejmbt30d47NC+hzA/RgD9g8i3
 github.com/ONSdigital/dp-net/v2 v2.2.0/go.mod h1:Pv/35rM5tCLYdVdIZ5KoGu2EUXv/87fWTptlVTlS5MY=
 github.com/ONSdigital/dp-renderer v1.25.3 h1:EpBsfXKknYqGVTeYtH9/JYbpYglb76ZztB7IFM2eHHo=
 github.com/ONSdigital/dp-renderer v1.25.3/go.mod h1:Z5sbyS0ApY6D8ikGDt2KIl5bt2p5kk73PeeMxGs1pEM=
+github.com/ONSdigital/dp-renderer v1.27.0 h1:DE7cZM1lzhv2Bt57BCouX6M8f8jJJThZB3yUXAnr60Y=
+github.com/ONSdigital/dp-renderer v1.27.0/go.mod h1:Z5sbyS0ApY6D8ikGDt2KIl5bt2p5kk73PeeMxGs1pEM=
 github.com/ONSdigital/go-ns v0.0.0-20191104121206-f144c4ec2e58/go.mod h1:iWos35il+NjbvDEqwtB736pyHru0MPFE/LqcwkV1wDc=
 github.com/ONSdigital/log.go v1.0.0/go.mod h1:UnGu9Q14gNC+kz0DOkdnLYGoqugCvnokHBRBxFRpVoQ=
 github.com/ONSdigital/log.go v1.0.1-0.20200805084515-ee61165ea36a/go.mod h1:dDnQATFXCBOknvj6ZQuKfmDhbOWf3e8mtV+dPEfWJqs=

--- a/mapper/mapper.go
+++ b/mapper/mapper.go
@@ -575,6 +575,14 @@ func CreateCensusDatasetLandingPage(ctx context.Context, req *http.Request, base
 		p.DatasetLandingPage.FormAction = fmt.Sprintf("/datasets/%s/editions/%s/versions/%s/filter-flex", d.ID, version.Edition, strconv.Itoa(version.Version))
 	}
 
+	p.BackTo = coreModel.BackTo{
+		Text: coreModel.Localisation{
+			LocaleKey: "BackToContents",
+			Plural:    4,
+		},
+		AnchorFragment: "toc",
+	}
+
 	return p
 }
 


### PR DESCRIPTION
### What

Enabled 'back-to' UI component anchored to the table of contents
Updated `dp-renderer` and `dp-design-system`

### How to review

- Sense check
- Compare images
- _Optionally_ run the stack locally; using the [cantabular-import](https://github.com/ONSdigital/dp-compose/tree/main/cantabular-import) docker container. Go to a [dataset landing page](http://localhost:8081/datasets/cantabular-flexible-example/editions/2021/versions/1) and resize the window to less than 740px, you should see the 'back to' component **OR** call me 🤙 and I'll show you 

#### Images
##### In frontend service
<img width="213" alt="back to component" src="https://user-images.githubusercontent.com/19624419/167872924-7e7da419-772b-4a13-a109-6a97628d1c16.png">

![image](https://user-images.githubusercontent.com/19624419/168084167-51c40429-6faf-466e-868f-ad402ae67302.png)

##### From design
![image](https://user-images.githubusercontent.com/19624419/167874403-b1580694-6070-46c8-aae0-cf59a5c8d54d.png)

### Who can review

Frontend dev