### PR TITLE
Feature/share dataset link

### DIFF
--- a/assets/locales/service.cy.toml
+++ b/assets/locales/service.cy.toml
@@ -278,3 +278,27 @@ one = "There is a new version of this dataset. View the <a href=\"{{.arg0}}\">la
 [Change]
 description = "Change"
 one = "Change"
+
+[CopyLinkTitle]
+description = "Dataset link"
+one = "Dataset link"
+
+[CopyLinkLeadText]
+description = "Bookmark or copy the link to return to this dataset"
+one = "Bookmark or copy the link to return to this dataset"
+
+[CopyLinkButtonText]
+description = "Copy link"
+one = "Copy link"
+
+[CopyLinkButtonAssistiveText]
+description = "to clipboard"
+one = "to clipboard"
+
+[CopyLinkSuccessMessage]
+description = "Copied"
+one = "Copied"
+
+[CopyLinkFailureMessage]
+description = "Copying failed"
+one = "Copying failed"

--- a/assets/locales/service.en.toml
+++ b/assets/locales/service.en.toml
@@ -259,3 +259,27 @@ one = "There is a new version of this dataset. View the <a href=\"{{.arg0}}\">la
 [Change]
 description = "Change"
 one = "Change"
+
+[CopyLinkTitle]
+description = "Dataset link"
+one = "Dataset link"
+
+[CopyLinkLeadText]
+description = "Bookmark or copy the link to return to this dataset"
+one = "Bookmark or copy the link to return to this dataset"
+
+[CopyLinkButtonText]
+description = "Copy link"
+one = "Copy link"
+
+[CopyLinkButtonAssistiveText]
+description = "to clipboard"
+one = "to clipboard"
+
+[CopyLinkSuccessMessage]
+description = "Copied"
+one = "Copied"
+
+[CopyLinkFailureMessage]
+description = "Copying failed"
+one = "Copying failed"

--- a/assets/templates/census-landing.tmpl
+++ b/assets/templates/census-landing.tmpl
@@ -30,9 +30,5 @@
             {{ end }}
         </div>
     </div>
-    <div class="ons-grid ons-u-ml-no ons-u-mb-xl">
-        {{ if .DatasetLandingPage.ShareDetails }}
-            {{ template "partials/share-dataset/share-this-dataset" .DatasetLandingPage.ShareDetails }}
-        {{ end }}
-    </div>
+   {{ template "partials/share-dataset/share-section" . }}
 </div>

--- a/assets/templates/partials/census/variables-table.tmpl
+++ b/assets/templates/partials/census/variables-table.tmpl
@@ -38,20 +38,20 @@
                             <div class="ons-u-mt-s ons-u-fs-s ons-list--container">
                                 <ul class="ons-list--truncated ons-u-m-no">
                                     {{ range $j, $val := $dim.Values}}
-                                        <li class="ons-list__item">{{ $val }}</li>
+                                        <li class="ons-list__item ons-u-mb-no">{{ $val }}</li>
                                     {{ end }}
                                 </ul>
                             </div>
                         {{end}}
                     </td>
-                    {{ if and $flexible $dim.IsAreaType }}
                     <td class="ons-table__cell ons-u-pb-s ons-u-pt-s ons-u-ta-right ons-u-pl-no@xxs@s ons-u-ml-xs@xxs@s ons-u-order--2 ons-u-bb-no@xxs@s">
+                        {{ if and $flexible $dim.IsAreaType }}
                         <button type="submit" class="ons-btn ons-btn__btn--link" name="dimension" value="{{ $dim.Name }}" role="link">
                             {{ localise "Change" $language 1 }} 
                             <span class="ons-u-vh">{{ localise "Variables" $language 1 }} {{ $dim.Title }}</span>
                         </button>
+                        {{ end }}
                     </td>
-                    {{ end }}
                 </tr>
             {{ end }}
         </tbody>

--- a/assets/templates/partials/share-dataset/copy-link.tmpl
+++ b/assets/templates/partials/share-dataset/copy-link.tmpl
@@ -1,0 +1,13 @@
+<h2 class="ons-u-fw-b ons-u-mb-xs ons-u-mt-s">{{- localise "CopyLinkTitle" .Language 1 -}}</h2>
+<p class="ons-u-fs-r ons-u-mb-xs">{{- localise "CopyLinkLeadText" .Language 1 -}}</p>
+<div class="ons-copy-link">
+    <a href="{{- .URI -}}" class="ons-copy-link__link ons-u-fs-r">{{- .DatasetLandingPage.DatasetURL -}}</a>
+    <button type="button" class="ons-btn ons-btn--secondary ons-btn--small ons-copy-link__btn ons-u-d-no">
+        <span class="ons-btn__inner" data-copy-link-success="{{- localise "CopyLinkSuccessMessage" .Language 1 -}}" data-copy-link-failure="{{- localise "CopyLinkFailureMessage" .Language 1 -}}">
+            {{- localise "CopyLinkButtonText" .Language 1 }}
+        </span>
+        <span class="ons-u-vh">
+            {{- localise "CopyLinkButtonAssistiveText" .Language 1 }}
+        </span>
+    </button>
+</div>

--- a/assets/templates/partials/share-dataset/share-section.tmpl
+++ b/assets/templates/partials/share-dataset/share-section.tmpl
@@ -1,0 +1,6 @@
+<section class="ons-grid ons-u-ml-no ons-u-mb-xl" aria-label="{{- localise "ShareDataset" .Language 1 -}}">
+   {{ template "partials/share-dataset/copy-link" . }}
+    {{ if .DatasetLandingPage.ShareDetails }}
+        {{ template "partials/share-dataset/share-this-dataset" .DatasetLandingPage.ShareDetails }}
+    {{ end }}
+</section>

--- a/assets/templates/partials/share-dataset/share-this-dataset.tmpl
+++ b/assets/templates/partials/share-dataset/share-this-dataset.tmpl
@@ -1,12 +1,13 @@
 {{ $shareDetails := . }}
-<hr />
-<h2 class="ons-u-fw-b ons-u-mb-xxs ons-u-mt-s">{{ localise "ShareDataset" .Language 1 }}</h2>
+<h2 class="ons-u-fw-b ons-u-mt-l">{{ localise "ShareDataset" .Language 1 }}</h2>
 <ul class="ons-list ons-list--inline ons-list--bare ons-list--icons">
   {{ range .ShareLocations }}
-  <li class="ons-list__item ons-u-pl-no ons-u-pr-xs">
-    <span class="ons-list__prefix">
-    {{ template "partials/share-dataset/icon-handler" .Icon }}
-    </span><a href="{{.Link}}" class="ons-list__link ons-u-fs-r ons-u-pt-xxs" target="_blank" rel="noreferrer external">{{ .Title }}<span class="ons-u-vh">{{ localise "ShareLinkA11yText" $shareDetails.Language 1 }}</span></a>
-  </li>
+    <li class="ons-list__item ons-u-pl-no ons-u-pr-xs">
+      <span class="ons-list__prefix">
+        {{ template "partials/share-dataset/icon-handler" .Icon }}
+      </span>
+      <a href="{{.Link}}" class="ons-list__link ons-u-fs-r ons-u-pt-xxs" target="_blank" rel="noreferrer external">{{ .Title }}<span class="ons-u-vh">{{ localise "ShareLinkA11yText" $shareDetails.Language 1 }}</span>
+      </a>
+    </li>
   {{ end }}
 </ul>

--- a/config/config.go
+++ b/config/config.go
@@ -36,7 +36,7 @@ func Get() (*Config, error) {
 	if cfg.Debug {
 		cfg.PatternLibraryAssetsPath = "http://localhost:9002/dist/assets"
 	} else {
-		cfg.PatternLibraryAssetsPath = "//cdn.ons.gov.uk/dp-design-system/778ac19"
+		cfg.PatternLibraryAssetsPath = "//cdn.ons.gov.uk/dp-design-system/6ee63c5"
 	}
 
 	return cfg, nil

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -31,7 +31,7 @@ func TestConfig(t *testing.T) {
 				So(cfg.HealthCheckInterval, ShouldEqual, 30*time.Second)
 				So(cfg.HealthCheckCriticalTimeout, ShouldEqual, 90*time.Second)
 				So(cfg.EnableProfiler, ShouldBeFalse)
-				So(cfg.PatternLibraryAssetsPath, ShouldEqual, "//cdn.ons.gov.uk/dp-design-system/778ac19")
+				So(cfg.PatternLibraryAssetsPath, ShouldEqual, "//cdn.ons.gov.uk/dp-design-system/6ee63c5")
 			})
 		})
 	})

--- a/mapper/mapper.go
+++ b/mapper/mapper.go
@@ -553,6 +553,7 @@ func CreateCensusDatasetLandingPage(ctx context.Context, req *http.Request, base
 
 	p.DatasetLandingPage.ShareDetails.Language = lang
 	currentUrl := helpers.GetCurrentUrl(lang, p.SiteDomain, req.URL.Path)
+	p.DatasetLandingPage.DatasetURL = currentUrl
 
 	p.DatasetLandingPage.ShareDetails.ShareLocations = []datasetLandingPageCensus.Share{
 		{

--- a/model/datasetLandingPageCensus/model.go
+++ b/model/datasetLandingPageCensus/model.go
@@ -31,6 +31,7 @@ type DatasetLandingPage struct {
 	Description            []string      `json:"description"`
 	IsFlexible             bool          `json:"is_flexible"`
 	FormAction             string        `json:"form_action"`
+	DatasetURL             string        `json:"dataset_url"`
 }
 
 // ShareDetails contains the locations the page can be shared to, as well as the language attribute for localisation


### PR DESCRIPTION
### What

- Created functionality to share the dataset by copying the dataset link to the clipboard; resolves ticket [5695 - share link](https://trello.com/c/m9lMxENK/5695-share-link-on-landing-page-enhanced)
- Removed margin bottom on `ons-list__item` with utility class `ons-u-mb-no`; resolves ticket [5694 - Remove margin-bottom on list-items](https://trello.com/c/QmUn00eQ/5694-remove-margin-bottom-on-list-items)
- Bug fix on the variables table where a `<td>` element was being omitted

### How to review

- Sense check
- Review media
- _Optionally_ run the stack locally; using the [cantabular-import](https://github.com/ONSdigital/dp-compose/tree/main/cantabular-import) docker container. 
  - Create a flexible dataset
  - Go to a [dataset landing page](http://localhost:8081/datasets/cantabular-flexible-example/editions/2021/versions/1)
  - Verify that the 'copy-link' component is displayed
  - Click the 'copy link' button and confirm the dataset url is copied to your clipboard
  - This component is also displayed as part of the 'flex' journey so 'change' the geography, 'get the data' and verify that the copy link component now contains the custom dataset link 
  - **OR** call me 🤙 and I'll show you 

### Media
#### Copy-link
<img width="1046" alt="share this dataset section" src="https://user-images.githubusercontent.com/19624419/172823200-6bc30fe7-b08b-455e-bde3-f88c33509987.png">

https://user-images.githubusercontent.com/19624419/172637493-9270502e-e2b7-49f7-b526-6230f0743927.mov

#### Before (with margin bottom)
<img width="362" alt="before with margin" src="https://user-images.githubusercontent.com/19624419/172651119-57726257-b885-4cf8-af90-a731af32ac64.png">

#### After (without margin bottom)
<img width="362" alt="after without margin" src="https://user-images.githubusercontent.com/19624419/172651260-bc885673-b045-4339-a26f-7110c32cc5d5.png">

### Who can review

Frontend dev
