### PR TITLE
Fix/remove options from filter creation

### DIFF
--- a/handlers/create_filter_id.go
+++ b/handlers/create_filter_id.go
@@ -3,15 +3,16 @@ package handlers
 import (
 	"errors"
 	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+
 	"github.com/ONSdigital/dp-api-clients-go/v2/dataset"
 	"github.com/ONSdigital/dp-api-clients-go/v2/filter"
 	"github.com/ONSdigital/dp-frontend-dataset-controller/config"
 	"github.com/ONSdigital/dp-net/v2/handlers"
 	"github.com/ONSdigital/log.go/v2/log"
 	"github.com/gorilla/mux"
-	"net/http"
-	"net/url"
-	"strings"
 )
 
 // CreateFilterID controls the creating of a filter idea when a new user journey is requested
@@ -88,19 +89,6 @@ func CreateFilterFlexID(fc FilterClient, dc DatasetClient, cfg config.Config) ht
 			dim.Name = verDim.Name
 			dim.URI = verDim.URL
 			dim.IsAreaType = verDim.IsAreaType
-			q := dataset.QueryParams{Offset: 0, Limit: 1000}
-			opts, err := dc.GetOptions(ctx, userAccessToken, "", collectionID, datasetID, edition, version, dim.Name, &q)
-			if err != nil {
-				setStatusCode(ctx, w, err)
-				return
-			}
-			var labels, options []string
-			for _, opt := range opts.Items {
-				labels = append(labels, opt.Label)
-				options = append(options, opt.Option)
-			}
-			dim.Options = options
-			dim.Values = labels
 			dims = append(dims, dim)
 		}
 

--- a/handlers/create_filter_id_test.go
+++ b/handlers/create_filter_id_test.go
@@ -19,7 +19,6 @@ func TestCreateFilterID(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
 	ctx := gomock.Any()
-	//cfg := initialiseMockConfig()
 
 	Convey("test CreateFilterID", t, func() {
 		mockCfg := config.Config{}
@@ -86,7 +85,6 @@ func TestCreateFilterID(t *testing.T) {
 		}
 
 		Convey("test CreateFilterFlexID handler, creates a filter id and redirect includes dimension name", func() {
-			q := dataset.QueryParams{Offset: 0, Limit: 1000}
 			mockDims := []filter.ModelDimension{
 				{
 					Name: "aggregate",
@@ -102,10 +100,6 @@ func TestCreateFilterID(t *testing.T) {
 			mockDatasetClient := NewMockDatasetClient(mockCtrl)
 			mockDatasetClient.EXPECT().GetVersion(ctx, userAuthToken, serviceAuthToken, "", collectionID, "1234", "2021", "1").
 				Return(mockVersions.Items[1], nil)
-			mockDatasetClient.EXPECT().GetOptions(ctx, userAuthToken, serviceAuthToken, collectionID, "1234", "2021", "1", "aggregate", &q).
-				Return(datasetOptions(0, 0), nil)
-			mockDatasetClient.EXPECT().GetOptions(ctx, userAuthToken, serviceAuthToken, collectionID, "1234", "2021", "1", "time", &q).
-				Return(datasetOptions(0, 0), nil)
 			mockDatasetClient.EXPECT().Get(ctx, userAuthToken, serviceAuthToken, collectionID, "1234").
 				Return(dataset.DatasetDetails{IsBasedOn: &dataset.IsBasedOn{ID: "Example"}}, nil)
 


### PR DESCRIPTION
### What

Removed options being added to the dimensions on filter creation, which are then stored within the `filters` table in mongo

**Resolves** trello ticket [5715 - Fix where we add all options to the dimension selected in filter collection](https://trello.com/c/uESwlPYU/5715-fix-where-we-add-all-options-to-the-dimension-selected-in-filter-collection)

### How to review

- Sense check
- Tests pass
- _Optionally_ run the stack locally; using the [cantabular-import](https://github.com/ONSdigital/dp-compose/tree/main/cantabular-import) docker container. 
  - Create a flexible dataset
  - Go to a [dataset landing page](http://localhost:8081/datasets/cantabular-flexible-example/editions/2021/versions/1)
  - Click 'change'
  - Check that the filter is still created in the database and that the `dimensions[i].options` are null (example json below ⬇️ 
  - **OR** call me 🤙 and I'll show you 

```json 
{
    "_id" : "f9e8972c-d706-4e28-ae67-de44cbdb7d62",
    "dataset" : {
        "id" : "cantabular-flexible-default",
        "edition" : "2021",
        "version" : 1
    },
    "dimensions" : [ 
        {
            "name" : "geography",
            "id" : "city",
            "label" : "City",
            "options" : null,
            "is_area_type" : true
        }, 
        {
            "name" : "siblings",
            "id" : "siblings_3",
            "label" : "Number of siblings (3 mappings)",
            "options" : null,
            "is_area_type" : false
        }
    ],
    "etag" : "e024ce62a41cfa25e6108ccbd7fa36231bb47022",
    "filter_id" : "f9e8972c-d706-4e28-ae67-de44cbdb7d62",
    "instance_id" : "c7f2b593-5927-4efb-afeb-3037949f06f2",
    "last_updated" : ISODate("2022-06-17T09:12:08.876Z"),
    "links" : {
        "version" : {
            "href" : "http://dp-dataset-api:22000/datasets/cantabular-flexible-default/editions/2021/version/1",
            "id" : "1"
        },
        "self" : {
            "href" : ":27100/filters/f9e8972c-d706-4e28-ae67-de44cbdb7d62"
        },
        "dimensions" : {
            "href" : ":27100/filters/f9e8972c-d706-4e28-ae67-de44cbdb7d62/dimensions"
        }
    },
    "population_type" : "Example",
    "published" : true,
    "type" : "flexible",
    "unique_timestamp" : Timestamp(1655457128, 1)
}
```
### Who can review

!me
