### PR TITLE
Added census branding to dataset landing page

### DIFF
--- a/assets/templates/static.tmpl
+++ b/assets/templates/static.tmpl
@@ -76,6 +76,9 @@
 
 <div class="meta-wrap">
     <div class="wrapper">
+        {{ if eq .DatasetLandingPage.Survey "census" }}
+            <img class="margin-bottom--2" src="/img/logo-census-2021-purple-landscape.png" alt="Census"/> 
+        {{ end }}
         <ul class="col-wrap meta__list">
             <li class="col col--md-12 col--lg-15 meta__item">
                 {{ if .DatasetLandingPage.IsNationalStatistic}}

--- a/mapper/legacy.go
+++ b/mapper/legacy.go
@@ -73,6 +73,7 @@ func CreateLegacyDatasetLanding(basePage coreModel.Page, ctx context.Context, re
 
 	sdlp.DatasetLandingPage.IsNationalStatistic = dlp.Description.NationalStatistic
 	sdlp.DatasetLandingPage.IsTimeseries = dlp.Timeseries
+	sdlp.DatasetLandingPage.Survey = dlp.Description.Survey
 	sdlp.ContactDetails = contactDetails.ContactDetails(dlp.Description.Contact)
 
 	// HACK FIX TODO REMOVE WHEN TIME IS SAVED CORRECTLY (GMT/UTC Issue)

--- a/model/datasetLandingPageStatic/model.go
+++ b/model/datasetLandingPageStatic/model.go
@@ -23,6 +23,7 @@ type DatasetLandingPage struct {
 	Notes               string    `json:"markdown"`
 	MetaDescription     string    `json:"meta_description"`
 	IsNationalStatistic bool      `json:"national_statistic"`
+	Survey              string    `json:"survey"`
 	ReleaseDate         string    `json:"release_date"`
 	NextRelease         string    `json:"next_release"`
 	IsTimeseries        bool      `json:"is_timeseries"`


### PR DESCRIPTION
### What

Added census branding to dataset landing page

### How to review

LGTM / Create/Edit a dataset landing page in Florence, in Edit pane check Census tickbox, branding should appear in preview.

### Who can review

Anyone.