### PR TITLE
Feature/adding coverage to variables table

### DIFF
--- a/assets/locales/service.cy.toml
+++ b/assets/locales/service.cy.toml
@@ -234,6 +234,14 @@ one = "Dataset ID and release date information"
 description = "Area type"
 one = "Area type"
 
+[AreaTypeCoverageTitle]
+description = "Coverage"
+one = "Coverage"
+
+[AreaTypeDefaultCoverage]
+description = "England and Wales"
+one = "England and Wales"
+
 [PageProblem]
 description = "There is a problem with this page"
 one = "There is a problem with this page"

--- a/assets/locales/service.en.toml
+++ b/assets/locales/service.en.toml
@@ -215,6 +215,14 @@ one = "Dataset ID and release date information"
 description = "Area type"
 one = "Area type"
 
+[AreaTypeCoverageTitle]
+description = "Coverage"
+one = "Coverage"
+
+[AreaTypeDefaultCoverage]
+description = "England and Wales"
+one = "England and Wales"
+
 [PageProblem]
 description = "There is a problem with this page"
 one = "There is a problem with this page"

--- a/assets/templates/partials/census/variables-table.tmpl
+++ b/assets/templates/partials/census/variables-table.tmpl
@@ -13,17 +13,23 @@
                     <th scope="col" class="ons-table__header ons-table__cell ons-col-4@s ons-u-pb-s ons-u-pt-s ons-u-pl-no ons-u-order--1 ons-u-bb-no@xxs@s {{if $flexible}}ons-u-flex--2@xxs@s{{end}}">
                         <span>
                         {{ if $dim.IsAreaType }}
-                            {{ localise "AreaTypeDescription" $language 1 }}
+                            {{- localise "AreaTypeDescription" $language 1 -}}
+                        {{ else if $dim.IsCoverage }}
+                             {{- localise "AreaTypeCoverageTitle" $language 1 -}}
                         {{ else }}
                             {{ $dim.Title }}
                         {{ end }}
                         </span>
                     </th>
                     <td class="ons-table__cell ons-u-pb-s ons-u-pt-s ons-u-pl-no@xxs@s ons-u-order--3 ons-u-fw@xxs@s ons-u-pt-no@xxs@s ons-u-bb-no@xxs@s">
-                        {{ if $dim.IsAreaType }}
+                        {{ if or ($dim.IsAreaType) ($dim.IsCoverage) }}
                             <div>
-                                {{- $dim.Title }} 
-                                ({{ $dim.TotalItems -}})
+                                {{ if $dim.IsCoverage }}
+                                    {{- localise "AreaTypeDefaultCoverage" $language 1 -}}
+                                {{ else }}
+                                    {{- $dim.Title }} 
+                                    ({{ $dim.TotalItems -}})
+                                {{ end }}
                             </div>
                         {{else}}
                             <div>
@@ -45,7 +51,7 @@
                         {{end}}
                     </td>
                     <td class="ons-table__cell ons-u-pb-s ons-u-pt-s ons-u-ta-right ons-u-pl-no@xxs@s ons-u-ml-xs@xxs@s ons-u-order--2 ons-u-bb-no@xxs@s">
-                        {{ if and $flexible $dim.IsAreaType }}
+                        {{ if $dim.ShowChange }}
                         <button type="submit" class="ons-btn ons-btn__btn--link" name="dimension" value="{{ $dim.Name }}" role="link">
                             {{ localise "Change" $language 1 }} 
                             <span class="ons-u-vh">{{ localise "Variables" $language 1 }} {{ $dim.Title }}</span>

--- a/handlers/create_filter_id.go
+++ b/handlers/create_filter_id.go
@@ -106,9 +106,13 @@ func CreateFilterFlexID(fc FilterClient, dc DatasetClient, cfg config.Config) ht
 		}
 
 		filterPath := fmt.Sprintf("/filters/%s/dimensions", fid)
-		dimensionName := req.FormValue("dimension")
+		dimensionName := url.QueryEscape(strings.ToLower(req.FormValue("dimension")))
 		if dimensionName != "" {
-			filterPath += fmt.Sprintf("/%s", strings.ToLower(url.QueryEscape(dimensionName)))
+			if dimensionName == "coverage" {
+				filterPath += fmt.Sprintf("/geography/%s", dimensionName)
+			} else {
+				filterPath += fmt.Sprintf("/%s", dimensionName)
+			}
 		}
 
 		log.Info(ctx, "created filter id", log.Data{"filter_id": fid})

--- a/mapper/mapper.go
+++ b/mapper/mapper.go
@@ -582,6 +582,16 @@ func CreateCensusDatasetLandingPage(ctx context.Context, req *http.Request, base
 
 	if len(opts) > 0 && !hasFilterOutput {
 		p.DatasetLandingPage.Dimensions = mapOptionsToDimensions(ctx, d.Type, version.Dimensions, opts, d.Links.LatestVersion.URL, maxNumberOfOptions)
+		coverage := []sharedModel.Dimension{
+			{
+				IsCoverage: true,
+				Title:      "Coverage",
+				Name:       "coverage",
+				ShowChange: true,
+			},
+		}
+		temp := append(coverage, p.DatasetLandingPage.Dimensions[1:]...)
+		p.DatasetLandingPage.Dimensions = append(p.DatasetLandingPage.Dimensions[:1], temp...)
 	}
 
 	if hasFilterOutput {
@@ -650,6 +660,7 @@ func mapOptionsToDimensions(ctx context.Context, datasetType string, dims []data
 					pDim.Name = dimension.Name
 					pDim.Description = dimension.Description
 					pDim.IsAreaType = helpers.IsBoolPtr(dimension.IsAreaType)
+					pDim.ShowChange = pDim.IsAreaType
 					if len(dimension.Label) > 0 {
 						pDim.Title = dimension.Label
 					}

--- a/mapper/mapper_test.go
+++ b/mapper/mapper_test.go
@@ -735,6 +735,12 @@ func TestCreateCensusDatasetLandingPage(t *testing.T) {
 		So(page.Collapsible.CollapsibleItems[1].Content, ShouldResemble, strings.Split(versionOneDetails.Dimensions[1].Description, "\n"))
 		So(page.Collapsible.CollapsibleItems, ShouldHaveLength, 2)
 		So(page.DatasetLandingPage.IsFlexible, ShouldBeFalse)
+		So(page.DatasetLandingPage.Dimensions, ShouldHaveLength, 2) // coverage is inserted
+		So(page.DatasetLandingPage.Dimensions[1].IsCoverage, ShouldBeTrue)
+		So(page.DatasetLandingPage.Dimensions[1].Title, ShouldEqual, "Coverage")
+		So(page.DatasetLandingPage.Dimensions[1].Name, ShouldEqual, "coverage")
+		So(page.DatasetLandingPage.Dimensions[1].ShowChange, ShouldBeTrue)
+		So(page.DatasetLandingPage.Dimensions[0].ShowChange, ShouldBeFalse)
 	})
 
 	Convey("Census dataset landing page maps correctly with filter output", t, func() {

--- a/model/dimension.go
+++ b/model/dimension.go
@@ -9,4 +9,6 @@ type Dimension struct {
 	TotalItems  int      `json:"total_items"`
 	Description string   `json:"description"`
 	IsAreaType  bool     `json:"is_area_type"`
+	IsCoverage  bool     `json:"is_coverage"`
+	ShowChange  bool     `json:"show_change"`
 }


### PR DESCRIPTION
### What

- Displaying default coverage option on area type dimension to be 'England and Wales'. This has been manually inserted into `p.DatasetLandingPage.Dimensions` as the variables table is generated from this struct. **NB** Coverage is not a dimension and will not be returned from the dimensions endpoint as its own dimension; (hopefully) it will be returned as an option on the area type dimension 🤞 
- Reworked the logic to display the 'change' button

**Resolves** trello ticket [5744 - Add coverage to variable table](https://trello.com/c/QxigbV7k/5744-add-coverage-to-variable-table)

### How to review

- Sense check
- Tests pass
- Review image

<img width="697" alt="variables table with coverage option" src="https://user-images.githubusercontent.com/19624419/175044814-e2b57cb2-d9aa-4651-b288-c7ea7e99f004.png">

### Who can review

Frontend go dev
