### PR TITLE
Feature/truncate dimension options

### DIFF
--- a/assets/locales/service.cy.toml
+++ b/assets/locales/service.cy.toml
@@ -310,3 +310,11 @@ one = "Copied"
 [CopyLinkFailureMessage]
 description = "Copying failed"
 one = "Copying failed"
+
+[TruncateShowAll]
+description = "Show all {{$strOptCount}} categories"
+one = "Show all {{.arg0}} categories"
+
+[TruncateShowFewer]
+description = "Show less categories"
+one = "Show less categories"

--- a/assets/locales/service.en.toml
+++ b/assets/locales/service.en.toml
@@ -291,3 +291,11 @@ one = "Copied"
 [CopyLinkFailureMessage]
 description = "Copying failed"
 one = "Copying failed"
+
+[TruncateShowAll]
+description = "Show all {{$strOptCount}} categories"
+one = "Show all {{.arg0}} categories"
+
+[TruncateShowFewer]
+description = "Show less categories"
+one = "Show less categories"

--- a/assets/templates/partials/census/variables-table.tmpl
+++ b/assets/templates/partials/census/variables-table.tmpl
@@ -35,8 +35,8 @@
                                     {{ end }}
                                 </div>
                             {{else}}
+                                {{ $strOptCount := intToString $dim.TotalItems }}
                                 <div>
-                                    {{ $strOptCount := intToString $dim.TotalItems }}
                                     {{ $dim.TotalItems }}
                                     {{ if gt $dim.TotalItems 1 }}
                                         {{ localise "Category" $language 4 }}

--- a/assets/templates/partials/census/variables-table.tmpl
+++ b/assets/templates/partials/census/variables-table.tmpl
@@ -4,66 +4,80 @@
 <section id="variables" aria-label="{{ localise "Variables" .Language 4}}">
     <h2 class="ons-u-mt-xl">{{ localise "Variables" .Language 4}}</h2>
     {{ if $flexible }}
-    <form action="{{.DatasetLandingPage.FormAction}}" method="post">
-    {{ end }}
-    <table class="ons-table">
-        <tbody class="ons-table__body">
-            {{range $i, $dim := $dims}}
-                <tr class="ons-table__row ons-u-bb ons-grid--flex@xxs@s ons-grid--between@xxs@s{{ if eq $i 0 }} ons-u-bt{{ end }}">
-                    <th scope="col" class="ons-table__header ons-table__cell ons-col-4@s ons-u-pb-s ons-u-pt-s ons-u-pl-no ons-u-order--1 ons-u-bb-no@xxs@s {{if $flexible}}ons-u-flex--2@xxs@s{{end}}">
-                        <span>
-                        {{ if $dim.IsAreaType }}
-                            {{- localise "AreaTypeDescription" $language 1 -}}
-                        {{ else if $dim.IsCoverage }}
-                             {{- localise "AreaTypeCoverageTitle" $language 1 -}}
-                        {{ else }}
-                            {{ $dim.Title }}
-                        {{ end }}
-                        </span>
-                    </th>
-                    <td class="ons-table__cell ons-u-pb-s ons-u-pt-s ons-u-pl-no@xxs@s ons-u-order--3 ons-u-fw@xxs@s ons-u-pt-no@xxs@s ons-u-bb-no@xxs@s">
-                        {{ if or ($dim.IsAreaType) ($dim.IsCoverage) }}
-                            <div>
-                                {{ if $dim.IsCoverage }}
-                                    {{- localise "AreaTypeDefaultCoverage" $language 1 -}}
+        <form action="{{.DatasetLandingPage.FormAction}}" method="post">
+        {{ end }}
+        <table class="ons-table">
+            <tbody class="ons-table__body">
+                {{range $i, $dim := $dims}}
+                    <tr class="ons-table__row ons-u-bb ons-grid--flex@xxs@s ons-grid--between@xxs@s{{ if eq $i 0 }} ons-u-bt{{ end }}" id="{{- .ID -}}">
+                        <th
+                            scope="col"
+                            class="ons-table__header ons-table__cell ons-col-4@s ons-u-pb-s ons-u-pt-s ons-u-pl-no ons-u-order--1 ons-u-bb-no@xxs@s
+                                {{if $flexible}}ons-u-flex--2@xxs@s{{end}}">
+                            <span>
+                                {{ if $dim.IsAreaType }}
+                                    {{- localise "AreaTypeDescription" $language 1 -}}
+                                {{ else if $dim.IsCoverage }}
+                                    {{- localise "AreaTypeCoverageTitle" $language 1 -}}
                                 {{ else }}
-                                    {{- $dim.Title }} 
-                                    ({{ $dim.TotalItems -}})
+                                    {{ $dim.Title }}
                                 {{ end }}
-                            </div>
-                        {{else}}
-                            <div>
-                                {{ $length := len $dim.Values }}
-                                {{ $length }}
-                                {{ if gt $length 1 }}
-                                    {{ localise "Category" $language 4 }}
-                                {{else}}
-                                    {{ localise "Category" $language 1 }}
-                                {{end}}
-                            </div>
-                            <div class="ons-u-mt-s ons-u-fs-s ons-list--container">
-                                <ul class="ons-list--truncated ons-u-m-no">
-                                    {{ range $j, $val := $dim.Values}}
-                                        <li class="ons-list__item ons-u-mb-no">{{ $val }}</li>
+                            </span>
+                        </th>
+                        <td class="ons-table__cell ons-u-pb-s ons-u-pt-s ons-u-pl-no@xxs@s ons-u-order--3 ons-u-fw@xxs@s ons-u-pt-no@xxs@s
+                                ons-u-bb-no@xxs@s">
+                            {{ if or ($dim.IsAreaType) ($dim.IsCoverage) }}
+                                <div>
+                                    {{ if $dim.IsCoverage }}
+                                        {{- localise "AreaTypeDefaultCoverage" $language 1 -}}
+                                    {{ else }}
+                                        {{- $dim.Title }} ({{ $dim.TotalItems -}})
                                     {{ end }}
-                                </ul>
-                            </div>
-                        {{end}}
-                    </td>
-                    <td class="ons-table__cell ons-u-pb-s ons-u-pt-s ons-u-ta-right ons-u-pl-no@xxs@s ons-u-ml-xs@xxs@s ons-u-order--2 ons-u-bb-no@xxs@s">
-                        {{ if $dim.ShowChange }}
-                        <button type="submit" class="ons-btn ons-btn__btn--link" name="dimension" value="{{ $dim.Name }}" role="link">
-                            {{ localise "Change" $language 1 }} 
-                            <span class="ons-u-vh">{{ localise "Variables" $language 1 }} {{ $dim.Title }}</span>
-                        </button>
-                        {{ end }}
-                    </td>
-                </tr>
-            {{ end }}
-        </tbody>
-    </table>
-    {{ if $flexible }}
-    </form>
+                                </div>
+                            {{else}}
+                                <div>
+                                    {{ $strOptCount := intToString $dim.TotalItems }}
+                                    {{ $dim.TotalItems }}
+                                    {{ if gt $dim.TotalItems 1 }}
+                                        {{ localise "Category" $language 4 }}
+                                    {{else}}
+                                        {{ localise "Category" $language 1 }}
+                                    {{end}}
+                                </div>
+                                <div class="ons-u-mt-s ons-u-fs-s ons-list--container">
+                                    <ul class="ons-list{{ if $dim.IsTruncated }}--truncated{{end}}{{ if or (gt $dim.TotalItems 9) ($dim.IsTruncated) }}
+                                            ons-u-mb-xs{{else}} ons-u-m-no{{end}}">
+                                        {{ range $j, $val := $dim.Values}}
+                                            <li class="ons-list__item{{ if $dim.IsTruncated }}--truncated{{end}} ons-u-mb-no">
+                                                {{- $val -}}
+                                            </li>
+                                        {{ end }}
+                                    </ul>
+                                    {{ if $dim.IsTruncated }}
+                                        <a href="{{$dim.TruncateLink}}">{{- localise "TruncateShowAll" $language 1 $strOptCount -}}</a>
+                                    {{ else if gt $dim.TotalItems 9 }}
+                                        <a href="{{.TruncateLink}}">{{- localise "TruncateShowFewer" $language 1 -}}</a>
+                                    {{ end }}
+                                </div>
+                            {{end}}
+                        </td>
+                        <td class="ons-table__cell ons-u-pb-s ons-u-pt-s ons-u-ta-right ons-u-pl-no@xxs@s ons-u-ml-xs@xxs@s ons-u-order--2
+                                ons-u-bb-no@xxs@s">
+                            {{ if $dim.ShowChange }}
+                                <button type="submit" class="ons-btn ons-btn__btn--link" name="dimension" value="{{ $dim.Name }}" role="link">
+                                    {{ localise "Change" $language 1 }}
+                                    <span class="ons-u-vh">{{ localise "Variables" $language 1 }}
+                                        {{ $dim.Title }}
+                                    </span>
+                                </button>
+                            {{ end }}
+                        </td>
+                    </tr>
+                {{ end }}
+            </tbody>
+        </table>
+        {{ if $flexible }}
+        </form>
     {{ end }}
     {{ template "partials/census/back-to-contents" . }}
 </section>

--- a/handlers/filter_output.go
+++ b/handlers/filter_output.go
@@ -173,7 +173,8 @@ func filterOutput(w http.ResponseWriter, req *http.Request, dc DatasetClient, fc
 		}
 	}
 
+	showAll := req.URL.Query()[queryStrKey]
 	basePage := rend.NewBasePageModel()
-	m := mapper.CreateCensusDatasetLandingPage(ctx, req, basePage, datasetModel, ver, []dataset.Options{}, initialVersionReleaseDate, hasOtherVersions, allVers.Items, latestVersionNumber, latestVersionURL, lang, numOptsSummary, isValidationError, true, filterOutput)
+	m := mapper.CreateCensusDatasetLandingPage(ctx, req, basePage, datasetModel, ver, []dataset.Options{}, initialVersionReleaseDate, hasOtherVersions, allVers.Items, latestVersionNumber, latestVersionURL, lang, showAll, numOptsSummary, isValidationError, true, filterOutput)
 	rend.BuildPage(w, m, "census-landing")
 }

--- a/handlers/filterable_landing_page.go
+++ b/handlers/filterable_landing_page.go
@@ -212,8 +212,9 @@ func censusLanding(ctx context.Context, w http.ResponseWriter, req *http.Request
 		getDownloadFile(version.Downloads, format, w, req)
 	}
 
+	showAll := req.URL.Query()[queryStrKey]
 	basePage := rend.NewBasePageModel()
-	m := mapper.CreateCensusDatasetLandingPage(ctx, req, basePage, datasetModel, version, opts, initialVersionReleaseDate, hasOtherVersions, allVersions, latestVersionNumber, latestVersionURL, lang, numOptsSummary, isValidationError, false, filter.Model{})
+	m := mapper.CreateCensusDatasetLandingPage(ctx, req, basePage, datasetModel, version, opts, initialVersionReleaseDate, hasOtherVersions, allVersions, latestVersionNumber, latestVersionURL, lang, showAll, numOptsSummary, isValidationError, false, filter.Model{})
 	rend.BuildPage(w, m, "census-landing")
 }
 

--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -3,12 +3,13 @@ package handlers
 import (
 	"bytes"
 	"context"
+	"net/http"
+	"regexp"
+
 	"github.com/ONSdigital/dp-api-clients-go/v2/dataset"
 	"github.com/ONSdigital/dp-frontend-dataset-controller/mapper"
 	"github.com/ONSdigital/log.go/v2/log"
 	"github.com/pkg/errors"
-	"net/http"
-	"regexp"
 )
 
 // Constants...
@@ -18,6 +19,7 @@ const (
 	maxMetadataOptions   = 1000
 	maxAgeAndTimeOptions = 1000
 	homepagePath         = "/"
+	queryStrKey          = "showAll"
 )
 
 var errTooManyOptions = errors.New("too many options in dimension")

--- a/helpers/helpers.go
+++ b/helpers/helpers.go
@@ -82,11 +82,9 @@ func HasStringInSlice(a string, list []string) bool {
 
 // PersistExistingParams persists existing query string values and ignores a given value
 func PersistExistingParams(values []string, key, ignoreValue string, q url.Values) {
-	if len(values) > 0 {
-		for _, value := range values {
-			if value != ignoreValue {
-				q.Add(key, value)
-			}
+	for _, value := range values {
+		if value != ignoreValue {
+			q.Add(key, value)
 		}
 	}
 }

--- a/helpers/helpers.go
+++ b/helpers/helpers.go
@@ -69,3 +69,24 @@ func IsBoolPtr(val *bool) bool {
 
 	return *val
 }
+
+// HasStringInSlice checks for a string within in a string array
+func HasStringInSlice(a string, list []string) bool {
+	for _, b := range list {
+		if b == a {
+			return true
+		}
+	}
+	return false
+}
+
+// PersistExistingParams persists existing query string values and ignores a given value
+func PersistExistingParams(values []string, key, ignoreValue string, q url.Values) {
+	if len(values) > 0 {
+		for _, value := range values {
+			if value != ignoreValue {
+				q.Add(key, value)
+			}
+		}
+	}
+}

--- a/helpers/helpers_test.go
+++ b/helpers/helpers_test.go
@@ -105,16 +105,16 @@ func TestIsBoolPtr(t *testing.T) {
 }
 
 func TestHasStringInSlice(t *testing.T) {
-	Convey("no string given and empty array returns false", t, func() {
+	Convey("Should return false when searching an empty array for the empty string", t, func() {
 		So(HasStringInSlice("", []string{}), ShouldBeFalse)
 	})
-	Convey("no string given valid string array returns false", t, func() {
+	Convey("Should return false when searching a populated array for the empty string", t, func() {
 		So(HasStringInSlice("", []string{"hello", "world"}), ShouldBeFalse)
 	})
-	Convey("valid string given empty array returns false", t, func() {
+	Convey("Should return false when searching an empty array for a given string", t, func() {
 		So(HasStringInSlice("hello", []string{}), ShouldBeFalse)
 	})
-	Convey("valid string given with valid string array returns true", t, func() {
+	Convey("Should return true when searching a populated array known to contain the given string", t, func() {
 		So(HasStringInSlice("hello", []string{"hello", "world"}), ShouldBeTrue)
 	})
 }

--- a/helpers/helpers_test.go
+++ b/helpers/helpers_test.go
@@ -103,3 +103,51 @@ func TestIsBoolPtr(t *testing.T) {
 		})
 	})
 }
+
+func TestHasStringInSlice(t *testing.T) {
+	Convey("no string given and empty array returns false", t, func() {
+		So(HasStringInSlice("", []string{}), ShouldBeFalse)
+	})
+	Convey("no string given valid string array returns false", t, func() {
+		So(HasStringInSlice("", []string{"hello", "world"}), ShouldBeFalse)
+	})
+	Convey("valid string given empty array returns false", t, func() {
+		So(HasStringInSlice("hello", []string{}), ShouldBeFalse)
+	})
+	Convey("valid string given with valid string array returns true", t, func() {
+		So(HasStringInSlice("hello", []string{"hello", "world"}), ShouldBeTrue)
+	})
+}
+
+func TestCheckForExistingParams(t *testing.T) {
+	Convey("persist existing query string values and ignore given value", t, func() {
+		queryStrValues := []string{"Value 1", "Value 2"}
+		ignoreValue := "Value 1"
+		key := "testKey"
+		q := url.Values{}
+
+		PersistExistingParams(queryStrValues, key, ignoreValue, q)
+		So(q[key], ShouldResemble, []string{"Value 2"})
+	})
+
+	Convey("persist existing query string values no value to ignore", t, func() {
+		queryStrValues := []string{"Value 1", "Value 2"}
+		existingValue := ""
+		key := "testKey"
+		q := url.Values{}
+
+		PersistExistingParams(queryStrValues, key, existingValue, q)
+		So(q[key], ShouldResemble, queryStrValues)
+	})
+
+	Convey("invalid key given no values persisted", t, func() {
+		queryStrValues := []string{"Value 1", "Value 2"}
+		existingValue := ""
+		key := "testKey"
+		q := url.Values{}
+
+		PersistExistingParams(queryStrValues, key, existingValue, q)
+		So(q["another key"], ShouldBeNil)
+		So(q[key], ShouldResemble, queryStrValues)
+	})
+}

--- a/mapper/mapper.go
+++ b/mapper/mapper.go
@@ -38,6 +38,7 @@ const (
 	DimensionGeography  = "geography"
 	SixteensVersion     = "77f1d9b"
 	CorrectionAlertType = "correction"
+	queryStrKey         = "showAll"
 )
 
 func (p TimeSlice) Len() int {
@@ -343,7 +344,7 @@ func CreateEditionsList(basePage coreModel.Page, ctx context.Context, req *http.
 }
 
 // CreateCensusDatasetLandingPage creates a census-landing page based on api model responses
-func CreateCensusDatasetLandingPage(ctx context.Context, req *http.Request, basePage coreModel.Page, d dataset.DatasetDetails, version dataset.Version, opts []dataset.Options, initialVersionReleaseDate string, hasOtherVersions bool, allVersions []dataset.Version, latestVersionNumber int, latestVersionURL, lang string, maxNumberOfOptions int, isValidationError, hasFilterOutput bool, filter filter.Model) datasetLandingPageCensus.Page {
+func CreateCensusDatasetLandingPage(ctx context.Context, req *http.Request, basePage coreModel.Page, d dataset.DatasetDetails, version dataset.Version, opts []dataset.Options, initialVersionReleaseDate string, hasOtherVersions bool, allVersions []dataset.Version, latestVersionNumber int, latestVersionURL, lang string, queryStrValues []string, maxNumberOfOptions int, isValidationError, hasFilterOutput bool, filter filter.Model) datasetLandingPageCensus.Page {
 	p := datasetLandingPageCensus.Page{
 		Page: basePage,
 	}
@@ -581,13 +582,14 @@ func CreateCensusDatasetLandingPage(ctx context.Context, req *http.Request, base
 	p.BetaBannerEnabled = true
 
 	if len(opts) > 0 && !hasFilterOutput {
-		p.DatasetLandingPage.Dimensions = mapOptionsToDimensions(ctx, d.Type, version.Dimensions, opts, d.Links.LatestVersion.URL, maxNumberOfOptions)
+		p.DatasetLandingPage.Dimensions = mapCensusOptionsToDimensions(version.Dimensions, opts, queryStrValues, req.URL.Path)
 		coverage := []sharedModel.Dimension{
 			{
 				IsCoverage: true,
 				Title:      "Coverage",
 				Name:       "coverage",
 				ShowChange: true,
+				ID:         "coverage",
 			},
 		}
 		temp := append(coverage, p.DatasetLandingPage.Dimensions[1:]...)
@@ -595,14 +597,7 @@ func CreateCensusDatasetLandingPage(ctx context.Context, req *http.Request, base
 	}
 
 	if hasFilterOutput {
-		for _, dim := range filter.Dimensions {
-			p.DatasetLandingPage.Dimensions = append(p.DatasetLandingPage.Dimensions, sharedModel.Dimension{
-				Title:      dim.Label,
-				Values:     dim.Options,
-				IsAreaType: helpers.IsBoolPtr(dim.IsAreaType),
-				TotalItems: len(dim.Options),
-			})
-		}
+		p.DatasetLandingPage.Dimensions = mapFilterOutputDims(filter, queryStrValues, req.URL.Path)
 	}
 
 	if isValidationError {
@@ -625,6 +620,38 @@ func CreateCensusDatasetLandingPage(ctx context.Context, req *http.Request, base
 	return p
 }
 
+func mapFilterOutputDims(filter filter.Model, queryStrValues []string, path string) []sharedModel.Dimension {
+	dimensions := []sharedModel.Dimension{}
+	for _, dim := range filter.Dimensions {
+		pDim := sharedModel.Dimension{}
+		pDim.Title = dim.Label
+		pDim.ID = dim.ID
+		pDim.IsAreaType = helpers.IsBoolPtr(dim.IsAreaType)
+		pDim.TotalItems = len(dim.Options)
+		midFloor, midCeiling := getTruncationMidRange(pDim.TotalItems)
+
+		for i, opt := range dim.Options {
+			if pDim.TotalItems > 9 && !helpers.HasStringInSlice(pDim.ID, queryStrValues) {
+				if isTruncationIndex(i, midFloor, midCeiling, len(dim.Options)) {
+					pDim.Values = append(pDim.Values, opt)
+					pDim.IsTruncated = true
+				}
+			} else {
+				pDim.Values = append(pDim.Values, opt)
+				pDim.IsTruncated = false
+			}
+		}
+
+		q := url.Values{}
+		if pDim.IsTruncated {
+			q.Add(queryStrKey, pDim.ID)
+		}
+		pDim.TruncateLink = generateTruncatePath(path, pDim.ID, q)
+		dimensions = append(dimensions, pDim)
+	}
+	return dimensions
+}
+
 func mapCorrectionAlert(ver *dataset.Version, version *sharedModel.Version) {
 	if ver.Alerts != nil {
 		for _, alert := range *ver.Alerts {
@@ -636,6 +663,72 @@ func mapCorrectionAlert(ver *dataset.Version, version *sharedModel.Version) {
 			}
 		}
 	}
+}
+
+func mapCensusOptionsToDimensions(dims []dataset.VersionDimension, opts []dataset.Options, queryStrValues []string, path string) []sharedModel.Dimension {
+	dimensions := []sharedModel.Dimension{}
+	for _, opt := range opts {
+		var pDim sharedModel.Dimension
+
+		for _, dimension := range dims {
+			if dimension.Name == opt.Items[0].DimensionID {
+				pDim.Name = dimension.Name
+				pDim.Description = dimension.Description
+				pDim.IsAreaType = helpers.IsBoolPtr(dimension.IsAreaType)
+				pDim.ShowChange = pDim.IsAreaType
+				pDim.Title = dimension.Label
+				pDim.ID = dimension.ID
+			}
+		}
+
+		pDim.TotalItems = opt.TotalCount
+		midFloor, midCeiling := getTruncationMidRange(opt.TotalCount)
+
+		for i, val := range opt.Items {
+			if pDim.TotalItems > 9 && !helpers.HasStringInSlice(pDim.ID, queryStrValues) {
+				if isTruncationIndex(i, midFloor, midCeiling, len(opt.Items)) {
+					pDim.Values = append(pDim.Values, val.Label)
+				}
+				pDim.IsTruncated = true
+			} else {
+				pDim.Values = append(pDim.Values, val.Label)
+				pDim.IsTruncated = false
+			}
+		}
+
+		q := url.Values{}
+		if pDim.IsTruncated {
+			q.Add(queryStrKey, pDim.ID)
+		}
+		pDim.TruncateLink = generateTruncatePath(path, pDim.ID, q)
+		dimensions = append(dimensions, pDim)
+	}
+	return dimensions
+}
+
+// getTruncationMidRange returns ints that can be used as the truncation mid range
+func getTruncationMidRange(total int) (int, int) {
+	mid := total / 2
+	midFloor := mid - 2
+	midCeiling := midFloor + 3
+	return midFloor, midCeiling
+}
+
+// isTruncationIndex determines whether the index parameter meets the tr
+func isTruncationIndex(i, midFloor, midCeiling, ceiling int) bool {
+	return i < 3 || i >= midFloor && i < midCeiling || i >= (ceiling-3)
+}
+
+// generateTruncatePath returns the path to truncate or show all
+func generateTruncatePath(path, dimID string, q url.Values) string {
+	truncatePath := path
+	if q.Encode() != "" {
+		truncatePath += fmt.Sprintf("?%s", q.Encode())
+	}
+	if dimID != "" {
+		truncatePath += fmt.Sprintf("#%s", dimID)
+	}
+	return truncatePath
 }
 
 func mapOptionsToDimensions(ctx context.Context, datasetType string, dims []dataset.VersionDimension, opts []dataset.Options, latestVersionURL string, maxNumberOfOptions int) []sharedModel.Dimension {
@@ -659,8 +752,6 @@ func mapOptionsToDimensions(ctx context.Context, datasetType string, dims []data
 				if dimension.Name == opt.Items[0].DimensionID {
 					pDim.Name = dimension.Name
 					pDim.Description = dimension.Description
-					pDim.IsAreaType = helpers.IsBoolPtr(dimension.IsAreaType)
-					pDim.ShowChange = pDim.IsAreaType
 					if len(dimension.Label) > 0 {
 						pDim.Title = dimension.Label
 					}

--- a/mapper/mapper.go
+++ b/mapper/mapper.go
@@ -634,8 +634,10 @@ func mapFilterOutputDims(filter filter.Model, queryStrValues []string, path stri
 			if pDim.TotalItems > 9 && !helpers.HasStringInSlice(pDim.ID, queryStrValues) {
 				if isTruncationIndex(i, midFloor, midCeiling, len(dim.Options)) {
 					pDim.Values = append(pDim.Values, opt)
-					pDim.IsTruncated = true
+				} else {
+					continue
 				}
+				pDim.IsTruncated = true
 			} else {
 				pDim.Values = append(pDim.Values, opt)
 				pDim.IsTruncated = false
@@ -688,6 +690,8 @@ func mapCensusOptionsToDimensions(dims []dataset.VersionDimension, opts []datase
 			if pDim.TotalItems > 9 && !helpers.HasStringInSlice(pDim.ID, queryStrValues) {
 				if isTruncationIndex(i, midFloor, midCeiling, len(opt.Items)) {
 					pDim.Values = append(pDim.Values, val.Label)
+				} else {
+					continue
 				}
 				pDim.IsTruncated = true
 			} else {
@@ -711,10 +715,13 @@ func getTruncationMidRange(total int) (int, int) {
 	mid := total / 2
 	midFloor := mid - 2
 	midCeiling := midFloor + 3
-	return midFloor, midCeiling
+	if midFloor > 0 && midCeiling > 0 {
+		return midFloor, midCeiling
+	}
+	return 0, 0
 }
 
-// isTruncationIndex determines whether the index parameter meets the tr
+// isTruncationIndex determines whether the index parameter is a truncation index
 func isTruncationIndex(i, midFloor, midCeiling, ceiling int) bool {
 	return i < 3 || i >= midFloor && i < midCeiling || i >= (ceiling-3)
 }

--- a/mapper/mapper_test.go
+++ b/mapper/mapper_test.go
@@ -631,14 +631,17 @@ func TestCreateCensusDatasetLandingPage(t *testing.T) {
 			{
 				Description: "A description on one line",
 				Name:        "Dimension 1",
+				ID:          "dim_1",
 			},
 			{
 				Description: "A description on one line \n Then a line break",
 				Name:        "Dimension 2",
+				ID:          "dim_2",
 			},
 			{
 				Description: "",
 				Name:        "Only a name - I shouldn't map",
+				ID:          "dim_3",
 			},
 		},
 	}
@@ -708,7 +711,7 @@ func TestCreateCensusDatasetLandingPage(t *testing.T) {
 	}
 
 	Convey("Census dataset landing page maps correctly as version 1", t, func() {
-		page := CreateCensusDatasetLandingPage(context.Background(), req, pageModel, datasetModel, versionOneDetails, datasetOptions, "", false, []dataset.Version{versionOneDetails}, 1, "/a/version/1", "", 50, false, false, filter.Model{})
+		page := CreateCensusDatasetLandingPage(context.Background(), req, pageModel, datasetModel, versionOneDetails, datasetOptions, "", false, []dataset.Version{versionOneDetails}, 1, "/a/version/1", "", []string{}, 50, false, false, filter.Model{})
 		So(page.Type, ShouldEqual, datasetModel.Type)
 		So(page.ID, ShouldEqual, datasetModel.ID)
 		So(page.Version.ReleaseDate, ShouldEqual, versionOneDetails.ReleaseDate)
@@ -745,7 +748,7 @@ func TestCreateCensusDatasetLandingPage(t *testing.T) {
 
 	Convey("Census dataset landing page maps correctly with filter output", t, func() {
 		datasetModel.Type = "flexible"
-		page := CreateCensusDatasetLandingPage(context.Background(), req, pageModel, datasetModel, versionOneDetails, datasetOptions, "", false, []dataset.Version{versionOneDetails}, 1, "/a/version/1", "", 50, false, true, filterOutput)
+		page := CreateCensusDatasetLandingPage(context.Background(), req, pageModel, datasetModel, versionOneDetails, datasetOptions, "", false, []dataset.Version{versionOneDetails}, 1, "/a/version/1", "", []string{}, 50, false, true, filterOutput)
 		So(page.Type, ShouldEqual, datasetModel.Type)
 		So(page.ID, ShouldEqual, datasetModel.ID)
 		So(page.Version.ReleaseDate, ShouldEqual, versionOneDetails.ReleaseDate)
@@ -779,7 +782,7 @@ func TestCreateCensusDatasetLandingPage(t *testing.T) {
 
 	Convey("Release date and hasOtherVersions is mapped correctly when v2 of Census DLP dataset is loaded", t, func() {
 		req := httptest.NewRequest("", "/datasets/cantabular-1/editions/2021/versions/2", nil)
-		page := CreateCensusDatasetLandingPage(context.Background(), req, pageModel, datasetModel, versionTwoDetails, datasetOptions, versionOneDetails.ReleaseDate, true, []dataset.Version{versionOneDetails, versionTwoDetails}, 2, "/a/version/123", "", 50, false, false, filter.Model{})
+		page := CreateCensusDatasetLandingPage(context.Background(), req, pageModel, datasetModel, versionTwoDetails, datasetOptions, versionOneDetails.ReleaseDate, true, []dataset.Version{versionOneDetails, versionTwoDetails}, 2, "/a/version/123", "", []string{}, 50, false, false, filter.Model{})
 		So(page.InitialReleaseDate, ShouldEqual, versionOneDetails.ReleaseDate)
 		So(page.Version.ReleaseDate, ShouldEqual, versionTwoDetails.ReleaseDate)
 		So(page.DatasetLandingPage.HasOtherVersions, ShouldBeTrue)
@@ -793,13 +796,13 @@ func TestCreateCensusDatasetLandingPage(t *testing.T) {
 
 	Convey("IsCurrent returns false when request is for a different page", t, func() {
 		req := httptest.NewRequest("", "/datasets/cantabular-1/editions/2021/versions/1", nil)
-		page := CreateCensusDatasetLandingPage(context.Background(), req, pageModel, datasetModel, versionTwoDetails, datasetOptions, versionOneDetails.ReleaseDate, true, []dataset.Version{versionOneDetails, versionTwoDetails}, 2, "", "", 50, false, false, filter.Model{})
+		page := CreateCensusDatasetLandingPage(context.Background(), req, pageModel, datasetModel, versionTwoDetails, datasetOptions, versionOneDetails.ReleaseDate, true, []dataset.Version{versionOneDetails, versionTwoDetails}, 2, "", "", []string{}, 50, false, false, filter.Model{})
 		So(page.Versions[0].VersionURL, ShouldEqual, "/datasets/cantabular-1/editions/2021/versions/2")
 		So(page.Versions[0].IsCurrentPage, ShouldBeFalse)
 	})
 
 	Convey("Versions history is in descending order", t, func() {
-		page := CreateCensusDatasetLandingPage(context.Background(), req, pageModel, datasetModel, versionTwoDetails, datasetOptions, versionOneDetails.ReleaseDate, true, []dataset.Version{versionOneDetails, versionTwoDetails, versionThreeDetails}, 3, "", "", 50, false, false, filter.Model{})
+		page := CreateCensusDatasetLandingPage(context.Background(), req, pageModel, datasetModel, versionTwoDetails, datasetOptions, versionOneDetails.ReleaseDate, true, []dataset.Version{versionOneDetails, versionTwoDetails, versionThreeDetails}, 3, "", "", []string{}, 50, false, false, filter.Model{})
 		So(page.Versions[0].VersionNumber, ShouldEqual, 3)
 		So(page.Versions[1].VersionNumber, ShouldEqual, 2)
 		So(page.Versions[2].VersionNumber, ShouldEqual, 1)
@@ -807,15 +810,15 @@ func TestCreateCensusDatasetLandingPage(t *testing.T) {
 
 	Convey("ShowOtherVersionsPanel is set correctly", t, func() {
 		// Landed on version 1, more than one version available = panel displays
-		page := CreateCensusDatasetLandingPage(context.Background(), req, pageModel, datasetModel, versionOneDetails, datasetOptions, versionOneDetails.ReleaseDate, true, []dataset.Version{versionOneDetails, versionTwoDetails, versionThreeDetails}, 3, "", "", 50, false, false, filter.Model{})
+		page := CreateCensusDatasetLandingPage(context.Background(), req, pageModel, datasetModel, versionOneDetails, datasetOptions, versionOneDetails.ReleaseDate, true, []dataset.Version{versionOneDetails, versionTwoDetails, versionThreeDetails}, 3, "", "", []string{}, 50, false, false, filter.Model{})
 		So(page.DatasetLandingPage.ShowOtherVersionsPanel, ShouldBeTrue)
 
 		// Only one version = panel hidden
-		page = CreateCensusDatasetLandingPage(context.Background(), req, pageModel, datasetModel, versionOneDetails, datasetOptions, versionOneDetails.ReleaseDate, false, []dataset.Version{versionOneDetails}, 1, "", "", 50, false, false, filter.Model{})
+		page = CreateCensusDatasetLandingPage(context.Background(), req, pageModel, datasetModel, versionOneDetails, datasetOptions, versionOneDetails.ReleaseDate, false, []dataset.Version{versionOneDetails}, 1, "", "", []string{}, 50, false, false, filter.Model{})
 		So(page.DatasetLandingPage.ShowOtherVersionsPanel, ShouldBeFalse)
 
 		// More than one version, landed on latest version (3) = panel hidden
-		page = CreateCensusDatasetLandingPage(context.Background(), req, pageModel, datasetModel, versionThreeDetails, datasetOptions, versionThreeDetails.ReleaseDate, true, []dataset.Version{versionOneDetails, versionTwoDetails, versionThreeDetails}, 3, "", "", 50, false, false, filter.Model{})
+		page = CreateCensusDatasetLandingPage(context.Background(), req, pageModel, datasetModel, versionThreeDetails, datasetOptions, versionThreeDetails.ReleaseDate, true, []dataset.Version{versionOneDetails, versionTwoDetails, versionThreeDetails}, 3, "", "", []string{}, 50, false, false, filter.Model{})
 		So(page.DatasetLandingPage.ShowOtherVersionsPanel, ShouldBeFalse)
 	})
 
@@ -829,7 +832,7 @@ func TestCreateCensusDatasetLandingPage(t *testing.T) {
 				},
 			},
 		}
-		page := CreateCensusDatasetLandingPage(context.Background(), req, pageModel, datasetModel, versionDetails, datasetOptions, versionOneDetails.ReleaseDate, false, []dataset.Version{}, 1, "", "", 50, true, false, filter.Model{})
+		page := CreateCensusDatasetLandingPage(context.Background(), req, pageModel, datasetModel, versionDetails, datasetOptions, versionOneDetails.ReleaseDate, false, []dataset.Version{}, 1, "", "", []string{}, 50, true, false, filter.Model{})
 		So(page.Error.Title, ShouldEqual, fmt.Sprintf("Error: %s", datasetModel.Title))
 	})
 
@@ -843,7 +846,7 @@ func TestCreateCensusDatasetLandingPage(t *testing.T) {
 				},
 			},
 		}
-		page := CreateCensusDatasetLandingPage(context.Background(), req, pageModel, datasetModel, versionDetails, datasetOptions, versionOneDetails.ReleaseDate, false, []dataset.Version{}, 1, "", "", 50, false, false, filter.Model{})
+		page := CreateCensusDatasetLandingPage(context.Background(), req, pageModel, datasetModel, versionDetails, datasetOptions, versionOneDetails.ReleaseDate, false, []dataset.Version{}, 1, "", "", []string{}, 50, false, false, filter.Model{})
 		So(page.Error.Title, ShouldBeBlank)
 	})
 
@@ -857,7 +860,7 @@ func TestCreateCensusDatasetLandingPage(t *testing.T) {
 				},
 			},
 		}
-		page := CreateCensusDatasetLandingPage(context.Background(), req, pageModel, datasetModel, versionDetails, datasetOptions, versionOneDetails.ReleaseDate, false, []dataset.Version{}, 1, "", "", 50, false, false, filter.Model{})
+		page := CreateCensusDatasetLandingPage(context.Background(), req, pageModel, datasetModel, versionDetails, datasetOptions, versionOneDetails.ReleaseDate, false, []dataset.Version{}, 1, "", "", []string{}, 50, false, false, filter.Model{})
 		So(page.Error.Title, ShouldBeBlank)
 	})
 
@@ -872,7 +875,7 @@ func TestCreateCensusDatasetLandingPage(t *testing.T) {
 	}
 
 	Convey("No contacts provided, contact section is not displayed", t, func() {
-		page := CreateCensusDatasetLandingPage(context.Background(), req, pageModel, noContactDM, versionOneDetails, datasetOptions, "", false, []dataset.Version{}, 1, "", "", 50, false, false, filter.Model{})
+		page := CreateCensusDatasetLandingPage(context.Background(), req, pageModel, noContactDM, versionOneDetails, datasetOptions, "", false, []dataset.Version{}, 1, "", "", []string{}, 50, false, false, filter.Model{})
 		So(page.ContactDetails.Email, ShouldEqual, noContact.Email)
 		So(page.ContactDetails.Telephone, ShouldEqual, noContact.Telephone)
 		So(page.HasContactDetails, ShouldBeFalse)
@@ -889,7 +892,7 @@ func TestCreateCensusDatasetLandingPage(t *testing.T) {
 	}
 
 	Convey("One contact detail provided, contact section is displayed", t, func() {
-		page := CreateCensusDatasetLandingPage(context.Background(), req, pageModel, oneContactDetailDM, versionOneDetails, datasetOptions, "", false, []dataset.Version{}, 1, "", "", 50, false, false, filter.Model{})
+		page := CreateCensusDatasetLandingPage(context.Background(), req, pageModel, oneContactDetailDM, versionOneDetails, datasetOptions, "", false, []dataset.Version{}, 1, "", "", []string{}, 50, false, false, filter.Model{})
 		So(page.ContactDetails.Email, ShouldEqual, oneContactDetail.Email)
 		So(page.ContactDetails.Telephone, ShouldEqual, oneContactDetail.Telephone)
 		So(page.HasContactDetails, ShouldBeTrue)
@@ -900,7 +903,7 @@ func TestCreateCensusDatasetLandingPage(t *testing.T) {
 			Type: "cantabular_flexible_table",
 			ID:   "test-flex",
 		}
-		page := CreateCensusDatasetLandingPage(context.Background(), req, pageModel, flexDm, versionOneDetails, datasetOptions, "", false, []dataset.Version{}, 1, "", "", 50, false, false, filter.Model{})
+		page := CreateCensusDatasetLandingPage(context.Background(), req, pageModel, flexDm, versionOneDetails, datasetOptions, "", false, []dataset.Version{}, 1, "", "", []string{}, 50, false, false, filter.Model{})
 		So(page.DatasetLandingPage.IsFlexible, ShouldBeTrue)
 		So(page.DatasetLandingPage.FormAction, ShouldEqual, fmt.Sprintf("/datasets/%s/editions/%s/versions/%s/filter-flex", flexDm.ID, versionOneDetails.Edition, strconv.Itoa(versionOneDetails.Version)))
 	})
@@ -913,17 +916,17 @@ func TestCreateCensusDatasetLandingPage(t *testing.T) {
 						Size: "1234",
 						URL:  "https://mydomain.com/my-request.xlsx",
 					},
-				}}, datasetOptions, "", false, []dataset.Version{}, 1, "", "", 50, false, false, filter.Model{})
+				}}, datasetOptions, "", false, []dataset.Version{}, 1, "", "", []string{}, 50, false, false, filter.Model{})
 				So(page.DatasetLandingPage.HasDownloads, ShouldBeTrue)
 			})
 			Convey("HasDownloads set to false when downloads are zero", func() {
-				page := CreateCensusDatasetLandingPage(context.Background(), req, pageModel, oneContactDetailDM, dataset.Version{Downloads: nil}, datasetOptions, "", false, []dataset.Version{}, 1, "", "", 50, false, false, filter.Model{})
+				page := CreateCensusDatasetLandingPage(context.Background(), req, pageModel, oneContactDetailDM, dataset.Version{Downloads: nil}, datasetOptions, "", false, []dataset.Version{}, 1, "", "", []string{}, 50, false, false, filter.Model{})
 				So(page.DatasetLandingPage.HasDownloads, ShouldBeFalse)
 			})
 		})
 		Convey("On filterOutput", func() {
 			Convey("HasDownloads set to true when downloads are greater than zero", func() {
-				page := CreateCensusDatasetLandingPage(context.Background(), req, pageModel, oneContactDetailDM, dataset.Version{}, datasetOptions, "", false, []dataset.Version{}, 1, "", "", 50, false, true, filter.Model{Downloads: map[string]filter.Download{
+				page := CreateCensusDatasetLandingPage(context.Background(), req, pageModel, oneContactDetailDM, dataset.Version{}, datasetOptions, "", false, []dataset.Version{}, 1, "", "", []string{}, 50, false, true, filter.Model{Downloads: map[string]filter.Download{
 					"XLSX": {
 						Size: "1234",
 						URL:  "https://mydomain.com/my-request.xlsx",
@@ -932,8 +935,390 @@ func TestCreateCensusDatasetLandingPage(t *testing.T) {
 				So(page.DatasetLandingPage.HasDownloads, ShouldBeTrue)
 			})
 			Convey("HasDownloads set to false when downloads are zero", func() {
-				page := CreateCensusDatasetLandingPage(context.Background(), req, pageModel, oneContactDetailDM, dataset.Version{}, datasetOptions, "", false, []dataset.Version{}, 1, "", "", 50, false, true, filter.Model{Downloads: nil})
+				page := CreateCensusDatasetLandingPage(context.Background(), req, pageModel, oneContactDetailDM, dataset.Version{}, datasetOptions, "", false, []dataset.Version{}, 1, "", "", []string{}, 50, false, true, filter.Model{Downloads: nil})
 				So(page.DatasetLandingPage.HasDownloads, ShouldBeFalse)
+			})
+		})
+	})
+
+	Convey("given a dimension to truncate on census dataset landing page", t, func() {
+		datasetOptions := []dataset.Options{
+			{
+				Items: []dataset.Option{
+					{
+						DimensionID: "Dimension 1",
+						Label:       "Label 1",
+					},
+					{
+						DimensionID: "Dimension 1",
+						Label:       "Label 2",
+					},
+					{
+						DimensionID: "Dimension 1",
+						Label:       "Label 3",
+					},
+					{
+						DimensionID: "Dimension 1",
+						Label:       "Label 4",
+					},
+					{
+						DimensionID: "Dimension 1",
+						Label:       "Label 5",
+					},
+					{
+						DimensionID: "Dimension 1",
+						Label:       "Label 6",
+					},
+					{
+						DimensionID: "Dimension 1",
+						Label:       "Label 7",
+					},
+					{
+						DimensionID: "Dimension 1",
+						Label:       "Label 8",
+					},
+					{
+						DimensionID: "Dimension 1",
+						Label:       "Label 9",
+					},
+					{
+						DimensionID: "Dimension 1",
+						Label:       "Label 10",
+					},
+					{
+						DimensionID: "Dimension 1",
+						Label:       "Label 11",
+					},
+					{
+						DimensionID: "Dimension 1",
+						Label:       "Label 12",
+					},
+					{
+						DimensionID: "Dimension 1",
+						Label:       "Label 13",
+					},
+					{
+						DimensionID: "Dimension 1",
+						Label:       "Label 14",
+					},
+					{
+						DimensionID: "Dimension 1",
+						Label:       "Label 15",
+					},
+					{
+						DimensionID: "Dimension 1",
+						Label:       "Label 16",
+					},
+					{
+						DimensionID: "Dimension 1",
+						Label:       "Label 17",
+					},
+					{
+						DimensionID: "Dimension 1",
+						Label:       "Label 18",
+					},
+					{
+						DimensionID: "Dimension 1",
+						Label:       "Label 19",
+					},
+					{
+						DimensionID: "Dimension 1",
+						Label:       "Label 20",
+					},
+					{
+						DimensionID: "Dimension 1",
+						Label:       "Label 21",
+					},
+				},
+				TotalCount: 20,
+			},
+			{
+				Items: []dataset.Option{
+					{
+						DimensionID: "Dimension 2",
+						Label:       "Label 1",
+					},
+					{
+						DimensionID: "Dimension 2",
+						Label:       "Label 2",
+					},
+					{
+						DimensionID: "Dimension 2",
+						Label:       "Label 3",
+					},
+					{
+						DimensionID: "Dimension 2",
+						Label:       "Label 4",
+					},
+					{
+						DimensionID: "Dimension 2",
+						Label:       "Label 5",
+					},
+					{
+						DimensionID: "Dimension 2",
+						Label:       "Label 6",
+					},
+					{
+						DimensionID: "Dimension 2",
+						Label:       "Label 7",
+					},
+					{
+						DimensionID: "Dimension 2",
+						Label:       "Label 8",
+					},
+					{
+						DimensionID: "Dimension 2",
+						Label:       "Label 9",
+					},
+					{
+						DimensionID: "Dimension 2",
+						Label:       "Label 10",
+					},
+					{
+						DimensionID: "Dimension 2",
+						Label:       "Label 11",
+					},
+					{
+						DimensionID: "Dimension 2",
+						Label:       "Label 12",
+					},
+					{
+						DimensionID: "Dimension 2",
+						Label:       "Label 13",
+					},
+					{
+						DimensionID: "Dimension 2",
+						Label:       "Label 14",
+					},
+					{
+						DimensionID: "Dimension 2",
+						Label:       "Label 15",
+					},
+					{
+						DimensionID: "Dimension 2",
+						Label:       "Label 16",
+					},
+					{
+						DimensionID: "Dimension 2",
+						Label:       "Label 17",
+					},
+					{
+						DimensionID: "Dimension 2",
+						Label:       "Label 18",
+					},
+					{
+						DimensionID: "Dimension 2",
+						Label:       "Label 19",
+					},
+					{
+						DimensionID: "Dimension 2",
+						Label:       "Label 20",
+					},
+				},
+				TotalCount: 20,
+			},
+		}
+
+		Convey("when valid parameters are provided", func() {
+			p := CreateCensusDatasetLandingPage(
+				context.Background(),
+				req,
+				pageModel,
+				oneContactDetailDM,
+				versionOneDetails,
+				datasetOptions,
+				"",
+				false,
+				[]dataset.Version{},
+				1,
+				"",
+				"",
+				[]string{},
+				50,
+				false,
+				false,
+				filter.Model{Downloads: nil})
+			Convey("then truncation works as expected", func() {
+				So(p.DatasetLandingPage.Dimensions[0].TotalItems, ShouldEqual, datasetOptions[0].TotalCount)
+				So(p.DatasetLandingPage.Dimensions[0].Values, ShouldHaveLength, 9)
+				So(p.DatasetLandingPage.Dimensions[0].Values, ShouldResemble, []string{
+					"Label 1", "Label 2", "Label 3",
+					"Label 9", "Label 10", "Label 11",
+					"Label 19", "Label 20", "Label 21",
+				})
+				So(p.DatasetLandingPage.Dimensions[0].IsTruncated, ShouldBeTrue)
+				So(p.DatasetLandingPage.Dimensions[0].TruncateLink, ShouldEqual, "/?showAll=dim_1#dim_1")
+			})
+		})
+
+		Convey("when 'showAll' parameter provided", func() {
+			p := CreateCensusDatasetLandingPage(
+				context.Background(),
+				req,
+				pageModel,
+				oneContactDetailDM,
+				versionOneDetails,
+				datasetOptions,
+				"",
+				false,
+				[]dataset.Version{},
+				1,
+				"",
+				"",
+				[]string{"dim_1"},
+				50,
+				false,
+				false,
+				filter.Model{Downloads: nil})
+
+			Convey("then the dimension is no longer truncated", func() {
+				So(p.DatasetLandingPage.Dimensions[0].TotalItems, ShouldEqual, datasetOptions[0].TotalCount)
+				So(p.DatasetLandingPage.Dimensions[0].Values, ShouldHaveLength, 21)
+				So(p.DatasetLandingPage.Dimensions[0].Values, ShouldResemble, []string{
+					"Label 1", "Label 2", "Label 3", "Label 4", "Label 5",
+					"Label 6", "Label 7", "Label 8", "Label 9", "Label 10",
+					"Label 11", "Label 12", "Label 13", "Label 14", "Label 15",
+					"Label 16", "Label 17", "Label 18", "Label 19", "Label 20",
+					"Label 21",
+				})
+				So(p.DatasetLandingPage.Dimensions[0].IsTruncated, ShouldBeFalse)
+				So(p.DatasetLandingPage.Dimensions[0].TruncateLink, ShouldEqual, "/#dim_1")
+			})
+
+			Convey("then other truncated dimensions are persisted", func() {
+				So(p.DatasetLandingPage.Dimensions[0].Values, ShouldHaveLength, 21)
+				So(p.DatasetLandingPage.Dimensions[0].Values, ShouldResemble, []string{
+					"Label 1", "Label 2", "Label 3", "Label 4", "Label 5",
+					"Label 6", "Label 7", "Label 8", "Label 9", "Label 10",
+					"Label 11", "Label 12", "Label 13", "Label 14", "Label 15",
+					"Label 16", "Label 17", "Label 18", "Label 19", "Label 20",
+					"Label 21",
+				})
+				So(p.DatasetLandingPage.Dimensions[0].TruncateLink, ShouldEqual, "/#dim_1")
+				So(p.DatasetLandingPage.Dimensions[2].TotalItems, ShouldEqual, datasetOptions[1].TotalCount)
+				So(p.DatasetLandingPage.Dimensions[2].Values, ShouldHaveLength, 9)
+				So(p.DatasetLandingPage.Dimensions[2].Values, ShouldResemble, []string{
+					"Label 1", "Label 2", "Label 3",
+					"Label 9", "Label 10", "Label 11",
+					"Label 18", "Label 19", "Label 20",
+				})
+				So(p.DatasetLandingPage.Dimensions[2].IsTruncated, ShouldBeTrue)
+				So(p.DatasetLandingPage.Dimensions[2].TruncateLink, ShouldEqual, "/?showAll=dim_2#dim_2")
+			})
+		})
+	})
+
+	Convey("given a dimension to truncate on filter output landing page", t, func() {
+		filterDims := filter.Model{
+			Dimensions: []filter.ModelDimension{
+				{
+					Label: "Dimension 1",
+					ID:    "dim_1",
+					Options: []string{
+						"Label 1", "Label 2", "Label 3", "Label 4", "Label 5",
+						"Label 6", "Label 7", "Label 8", "Label 9", "Label 10",
+						"Label 11", "Label 12", "Label 13", "Label 14", "Label 15",
+						"Label 16", "Label 17", "Label 18", "Label 19", "Label 20",
+						"Label 21",
+					},
+				},
+				{
+					Label: "Dimension 2",
+					ID:    "dim_2",
+					Options: []string{
+						"Label 1", "Label 2", "Label 3", "Label 4",
+						"Label 5", "Label 6", "Label 7", "Label 8",
+						"Label 9", "Label 10", "Label 11", "Label 12",
+					},
+				},
+			},
+		}
+
+		Convey("when valid parameters are provided", func() {
+			p := CreateCensusDatasetLandingPage(
+				context.Background(),
+				req,
+				pageModel,
+				oneContactDetailDM,
+				versionOneDetails,
+				datasetOptions,
+				"",
+				false,
+				[]dataset.Version{},
+				1,
+				"",
+				"",
+				[]string{},
+				50,
+				false,
+				true,
+				filterDims)
+			Convey("then truncation works as expected", func() {
+				So(p.DatasetLandingPage.Dimensions[0].TotalItems, ShouldEqual, 21)
+				So(p.DatasetLandingPage.Dimensions[0].Values, ShouldHaveLength, 9)
+				So(p.DatasetLandingPage.Dimensions[0].Values, ShouldResemble, []string{
+					"Label 1", "Label 2", "Label 3",
+					"Label 9", "Label 10", "Label 11",
+					"Label 19", "Label 20", "Label 21",
+				})
+				So(p.DatasetLandingPage.Dimensions[0].IsTruncated, ShouldBeTrue)
+				So(p.DatasetLandingPage.Dimensions[0].TruncateLink, ShouldEqual, "/?showAll=dim_1#dim_1")
+			})
+		})
+
+		Convey("when 'showAll' parameter provided", func() {
+			p := CreateCensusDatasetLandingPage(
+				context.Background(),
+				req,
+				pageModel,
+				oneContactDetailDM,
+				versionOneDetails,
+				datasetOptions,
+				"",
+				false,
+				[]dataset.Version{},
+				1,
+				"",
+				"",
+				[]string{"dim_1"},
+				50,
+				false,
+				true,
+				filterDims)
+
+			Convey("then the dimension is no longer truncated", func() {
+				So(p.DatasetLandingPage.Dimensions[0].TotalItems, ShouldEqual, 21)
+				So(p.DatasetLandingPage.Dimensions[0].Values, ShouldHaveLength, 21)
+				So(p.DatasetLandingPage.Dimensions[0].Values, ShouldResemble, []string{
+					"Label 1", "Label 2", "Label 3", "Label 4", "Label 5",
+					"Label 6", "Label 7", "Label 8", "Label 9", "Label 10",
+					"Label 11", "Label 12", "Label 13", "Label 14", "Label 15",
+					"Label 16", "Label 17", "Label 18", "Label 19", "Label 20",
+					"Label 21",
+				})
+				So(p.DatasetLandingPage.Dimensions[0].IsTruncated, ShouldBeFalse)
+				So(p.DatasetLandingPage.Dimensions[0].TruncateLink, ShouldEqual, "/#dim_1")
+			})
+
+			Convey("then other truncated dimensions are persisted", func() {
+				So(p.DatasetLandingPage.Dimensions[0].Values, ShouldHaveLength, 21)
+				So(p.DatasetLandingPage.Dimensions[0].Values, ShouldResemble, []string{
+					"Label 1", "Label 2", "Label 3", "Label 4", "Label 5",
+					"Label 6", "Label 7", "Label 8", "Label 9", "Label 10",
+					"Label 11", "Label 12", "Label 13", "Label 14", "Label 15",
+					"Label 16", "Label 17", "Label 18", "Label 19", "Label 20",
+					"Label 21",
+				})
+				So(p.DatasetLandingPage.Dimensions[0].TruncateLink, ShouldEqual, "/#dim_1")
+				So(p.DatasetLandingPage.Dimensions[1].TotalItems, ShouldEqual, 12)
+				So(p.DatasetLandingPage.Dimensions[1].Values, ShouldHaveLength, 9)
+				So(p.DatasetLandingPage.Dimensions[1].Values, ShouldResemble, []string{
+					"Label 1", "Label 2", "Label 3",
+					"Label 5", "Label 6", "Label 7",
+					"Label 10", "Label 11", "Label 12",
+				})
+				So(p.DatasetLandingPage.Dimensions[1].IsTruncated, ShouldBeTrue)
+				So(p.DatasetLandingPage.Dimensions[1].TruncateLink, ShouldEqual, "/?showAll=dim_2#dim_2")
 			})
 		})
 	})
@@ -943,7 +1328,7 @@ func getTestEmergencyBanner() zebedee.EmergencyBanner {
 	return zebedee.EmergencyBanner{
 		Type:        "notable_death",
 		Title:       "This is not not an emergency",
-		Description: "Something has go wrong",
+		Description: "Something has gone wrong",
 		URI:         "google.com",
 		LinkText:    "More info",
 	}

--- a/mapper/mapper_test.go
+++ b/mapper/mapper_test.go
@@ -1138,7 +1138,7 @@ func TestCreateCensusDatasetLandingPage(t *testing.T) {
 				false,
 				false,
 				filter.Model{Downloads: nil})
-			Convey("then truncation works as expected", func() {
+			Convey("then the list should be truncated to show the first, middle, and last three values", func() {
 				So(p.DatasetLandingPage.Dimensions[0].TotalItems, ShouldEqual, datasetOptions[0].TotalCount)
 				So(p.DatasetLandingPage.Dimensions[0].Values, ShouldHaveLength, 9)
 				So(p.DatasetLandingPage.Dimensions[0].Values, ShouldResemble, []string{
@@ -1253,7 +1253,7 @@ func TestCreateCensusDatasetLandingPage(t *testing.T) {
 				false,
 				true,
 				filterDims)
-			Convey("then truncation works as expected", func() {
+			Convey("then the list should be truncated to show the first, middle, and last three values", func() {
 				So(p.DatasetLandingPage.Dimensions[0].TotalItems, ShouldEqual, 21)
 				So(p.DatasetLandingPage.Dimensions[0].Values, ShouldHaveLength, 9)
 				So(p.DatasetLandingPage.Dimensions[0].Values, ShouldResemble, []string{

--- a/model/dimension.go
+++ b/model/dimension.go
@@ -2,13 +2,16 @@ package model
 
 // Dimension represents the data for a single dimension
 type Dimension struct {
-	Title       string   `json:"title"`
-	Name        string   `json:"name"`
-	Values      []string `json:"values"`
-	OptionsURL  string   `json:"options_url"`
-	TotalItems  int      `json:"total_items"`
-	Description string   `json:"description"`
-	IsAreaType  bool     `json:"is_area_type"`
-	IsCoverage  bool     `json:"is_coverage"`
-	ShowChange  bool     `json:"show_change"`
+	Title        string   `json:"title"`
+	Name         string   `json:"name"`
+	Values       []string `json:"values"`
+	OptionsURL   string   `json:"options_url"`
+	TotalItems   int      `json:"total_items"`
+	Description  string   `json:"description"`
+	IsAreaType   bool     `json:"is_area_type"`
+	IsCoverage   bool     `json:"is_coverage"`
+	ShowChange   bool     `json:"show_change"`
+	IsTruncated  bool     `json:"is_truncated"`
+	TruncateLink string   `json:"truncate_link"`
+	ID           string   `json:"id"`
 }


### PR DESCRIPTION
### What

Applied truncation to dimension options on dataset landing page and filter output landing page (same template) following principles set out in the [spike document](https://docs.google.com/document/d/1T7bYht3deJ_stBzO70_1G7ZTWSC5fxO7bh34JyGXxvY/) and the [dp-frontend-filter-flex-dataset](https://github.com/ONSdigital/dp-frontend-filter-flex-dataset/blob/cd5544cf0573dc965b1725acde6b12d4422c9922/mapper/mapper.go#L59). 

### How to review

- Sense check
- Tests pass
- Media review

https://user-images.githubusercontent.com/19624419/183074888-c70e7be5-ee02-4d8f-8f98-8c70e9489a9b.mov

### Who can review

Frontend go dev
