### PR TITLE
Feature/display coverage options

### DIFF
--- a/assets/templates/partials/census/variables-table.tmpl
+++ b/assets/templates/partials/census/variables-table.tmpl
@@ -35,17 +35,15 @@
                                     {{ end }}
                                 </div>
                             {{else}}
-                                {{ if .IsCoverage }}
-                                    {{ if $dim.Values }}
-                                        {{ if gt (len $dim.Values) 1 }}
-                                            <ul class="ons-list ons-u-mb-no">
-                                                {{ range $dim.Values }}
-                                                    <li class="ons-list__item">{{- . -}}</li>
-                                                {{ end }}
-                                            </ul>
-                                        {{ else }}
-                                            {{- index $dim.Values 0 -}}
-                                        {{ end }}
+                                {{ if and (.IsCoverage) ($dim.Values) }}
+                                    {{ if gt (len $dim.Values) 1 }}
+                                        <ul class="ons-list ons-u-mb-no">
+                                            {{ range $dim.Values }}
+                                                <li class="ons-list__item">{{- . -}}</li>
+                                            {{ end }}
+                                        </ul>
+                                    {{ else }}
+                                        {{- index $dim.Values 0 -}}
                                     {{ end }}
                                 {{ else }}
                                     {{ $strOptCount := intToString $dim.TotalItems }}

--- a/assets/templates/partials/census/variables-table.tmpl
+++ b/assets/templates/partials/census/variables-table.tmpl
@@ -26,39 +26,53 @@
                         </th>
                         <td class="ons-table__cell ons-u-pb-s ons-u-pt-s ons-u-pl-no@xxs@s ons-u-order--3 ons-u-fw@xxs@s ons-u-pt-no@xxs@s
                                 ons-u-bb-no@xxs@s">
-                            {{ if or ($dim.IsAreaType) ($dim.IsCoverage) }}
+                            {{ if or ($dim.IsAreaType) ($dim.IsDefaultCoverage) }}
                                 <div>
-                                    {{ if $dim.IsCoverage }}
+                                    {{ if $dim.IsDefaultCoverage }}
                                         {{- localise "AreaTypeDefaultCoverage" $language 1 -}}
                                     {{ else }}
                                         {{- $dim.Title }} ({{ $dim.TotalItems -}})
                                     {{ end }}
                                 </div>
                             {{else}}
-                                {{ $strOptCount := intToString $dim.TotalItems }}
-                                <div>
-                                    {{ $dim.TotalItems }}
-                                    {{ if gt $dim.TotalItems 1 }}
-                                        {{ localise "Category" $language 4 }}
-                                    {{else}}
-                                        {{ localise "Category" $language 1 }}
-                                    {{end}}
-                                </div>
-                                <div class="ons-u-mt-s ons-u-fs-s ons-list--container">
-                                    <ul class="ons-list{{ if $dim.IsTruncated }}--truncated{{end}}{{ if or (gt $dim.TotalItems 9) ($dim.IsTruncated) }}
-                                            ons-u-mb-xs{{else}} ons-u-m-no{{end}}">
-                                        {{ range $j, $val := $dim.Values}}
-                                            <li class="ons-list__item{{ if $dim.IsTruncated }}--truncated{{end}} ons-u-mb-no">
-                                                {{- $val -}}
-                                            </li>
+                                {{ if .IsCoverage }}
+                                    {{ if $dim.Values }}
+                                        {{ if gt (len $dim.Values) 1 }}
+                                            <ul class="ons-list ons-u-mb-no">
+                                                {{ range $dim.Values }}
+                                                    <li class="ons-list__item">{{- . -}}</li>
+                                                {{ end }}
+                                            </ul>
+                                        {{ else }}
+                                            {{- index $dim.Values 0 -}}
                                         {{ end }}
-                                    </ul>
-                                    {{ if $dim.IsTruncated }}
-                                        <a href="{{$dim.TruncateLink}}">{{- localise "TruncateShowAll" $language 1 $strOptCount -}}</a>
-                                    {{ else if gt $dim.TotalItems 9 }}
-                                        <a href="{{.TruncateLink}}">{{- localise "TruncateShowFewer" $language 1 -}}</a>
                                     {{ end }}
-                                </div>
+                                {{ else }}
+                                    {{ $strOptCount := intToString $dim.TotalItems }}
+                                    <div>
+                                        {{ $dim.TotalItems }}
+                                        {{ if gt $dim.TotalItems 1 }}
+                                            {{ localise "Category" $language 4 }}
+                                        {{else}}
+                                            {{ localise "Category" $language 1 }}
+                                        {{end}}
+                                    </div>
+                                    <div class="ons-u-mt-s ons-u-fs-s ons-list--container">
+                                        <ul class="ons-list{{ if $dim.IsTruncated }}--truncated{{end}}{{ if or (gt $dim.TotalItems 9) ($dim.IsTruncated) }}
+                                                ons-u-mb-xs{{else}} ons-u-m-no{{end}}">
+                                            {{ range $j, $val := $dim.Values}}
+                                                <li class="ons-list__item{{ if $dim.IsTruncated }}--truncated{{end}} ons-u-mb-no">
+                                                    {{- $val -}}
+                                                </li>
+                                            {{ end }}
+                                        </ul>
+                                        {{ if $dim.IsTruncated }}
+                                            <a href="{{$dim.TruncateLink}}">{{- localise "TruncateShowAll" $language 1 $strOptCount -}}</a>
+                                        {{ else if gt $dim.TotalItems 9 }}
+                                            <a href="{{.TruncateLink}}">{{- localise "TruncateShowFewer" $language 1 -}}</a>
+                                        {{ end }}
+                                    </div>
+                                {{ end }}
                             {{end}}
                         </td>
                         <td class="ons-table__cell ons-u-pb-s ons-u-pt-s ons-u-ta-right ons-u-pl-no@xxs@s ons-u-ml-xs@xxs@s ons-u-order--2

--- a/handlers/clients.go
+++ b/handlers/clients.go
@@ -21,6 +21,7 @@ type FilterClient interface {
 	CreateBlueprint(ctx context.Context, userAuthToken, serviceAuthToken, downloadServiceToken, collectionID, datasetID, edition, version string, names []string) (filterID, eTag string, err error)
 	CreateFlexibleBlueprint(ctx context.Context, userAuthToken, serviceAuthToken, downloadServiceToken, collectionID, datasetID, edition, version string, dimensions []filter.ModelDimension, population_type string) (filterID, eTag string, err error)
 	GetOutput(ctx context.Context, userAuthToken, serviceAuthToken, downloadServiceToken, collectionID, filterOutputID string) (m filter.Model, err error)
+	GetDimensionOptions(ctx context.Context, userAuthToken, serviceAuthToken, collectionID, filterID, name string, q *filter.QueryParams) (opts filter.DimensionOptions, eTag string, err error)
 }
 
 // DatasetClient is an interface with methods required for a dataset client

--- a/handlers/filter_output.go
+++ b/handlers/filter_output.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
+	"sync"
 
 	"github.com/ONSdigital/dp-api-clients-go/v2/dataset"
 	"github.com/ONSdigital/dp-api-clients-go/v2/filter"
@@ -31,6 +32,11 @@ func filterOutput(w http.ResponseWriter, req *http.Request, dc DatasetClient, fc
 	var form = req.URL.Query().Get("f")
 	var format = req.URL.Query().Get("format")
 	var isValidationError bool
+	var datasetModel dataset.DatasetDetails
+	var allVers dataset.VersionsList
+	var ver dataset.Version
+	var filterOutput filter.Model
+	var dmErr, versErr, verErr, fErr error
 
 	vars := mux.Vars(req)
 	datasetID := vars["datasetID"]
@@ -39,21 +45,61 @@ func filterOutput(w http.ResponseWriter, req *http.Request, dc DatasetClient, fc
 	filterOutputID := vars["filterOutputID"]
 	ctx := req.Context()
 
-	datasetModel, err := dc.Get(ctx, userAccessToken, "", collectionID, datasetID)
-	if err != nil {
-		log.Error(ctx, "failed to get dataset", err, log.Data{"dataset": datasetID})
-		setStatusCode(ctx, w, err)
+	var wg sync.WaitGroup
+	wg.Add(4)
+
+	go func() {
+		defer wg.Done()
+		datasetModel, dmErr = dc.Get(ctx, userAccessToken, "", collectionID, datasetID)
+	}()
+
+	go func() {
+		defer wg.Done()
+		q := dataset.QueryParams{Offset: 0, Limit: 1000}
+		allVers, versErr = dc.GetVersions(ctx, userAccessToken, "", "", collectionID, datasetID, edition, &q)
+	}()
+
+	go func() {
+		defer wg.Done()
+		ver, verErr = dc.GetVersion(ctx, userAccessToken, "", "", collectionID, datasetID, edition, version)
+		if ver.Version != 1 {
+			initialVersion, verErr = dc.GetVersion(ctx, userAccessToken, "", "", collectionID, datasetID, edition, "1")
+			initialVersionReleaseDate = initialVersion.ReleaseDate
+		}
+	}()
+
+	go func() {
+		defer wg.Done()
+		filterOutput, fErr = fc.GetOutput(ctx, userAccessToken, "", "", collectionID, filterOutputID)
+	}()
+
+	wg.Wait()
+
+	if dmErr != nil {
+		log.Error(ctx, "failed to get dataset", dmErr, log.Data{"dataset": datasetID})
+		setStatusCode(ctx, w, dmErr)
 		return
 	}
-
-	q := dataset.QueryParams{Offset: 0, Limit: 1000}
-	allVers, err := dc.GetVersions(ctx, userAccessToken, "", "", collectionID, datasetID, edition, &q)
-	if err != nil {
-		log.Error(ctx, "failed to get dataset versions", err, log.Data{
+	if versErr != nil {
+		log.Error(ctx, "failed to get dataset versions", versErr, log.Data{
 			"dataset": datasetID,
 			"edition": edition,
 		})
-		setStatusCode(ctx, w, err)
+		setStatusCode(ctx, w, versErr)
+		return
+	}
+	if verErr != nil {
+		log.Error(ctx, "failed to get dataset version", verErr, log.Data{
+			"dataset": datasetID,
+			"edition": edition,
+			"version": version,
+		})
+		setStatusCode(ctx, w, verErr)
+		return
+	}
+	if fErr != nil {
+		log.Error(ctx, "failed to get filter output", fErr, log.Data{"filter_output_id": filterOutputID})
+		setStatusCode(ctx, w, fErr)
 		return
 	}
 
@@ -71,29 +117,6 @@ func filterOutput(w http.ResponseWriter, req *http.Request, dc DatasetClient, fc
 	}
 
 	latestVersionURL := helpers.DatasetVersionUrl(datasetID, edition, strconv.Itoa(latestVersionNumber))
-
-	ver, err := dc.GetVersion(ctx, userAccessToken, "", "", collectionID, datasetID, edition, version)
-	if err != nil {
-		log.Error(ctx, "failed to get dataset version", err, log.Data{
-			"dataset": datasetID,
-			"edition": edition,
-			"version": version,
-		})
-		setStatusCode(ctx, w, err)
-		return
-	}
-
-	// TODO: inherited from censusLanding handler refactor to get initial release date in the mapper
-	if ver.Version != 1 {
-		initialVersion, err = dc.GetVersion(ctx, userAccessToken, "", "", collectionID, datasetID, edition, "1")
-		if err != nil {
-			setStatusCode(ctx, w, err)
-			return
-		}
-		initialVersionReleaseDate = initialVersion.ReleaseDate
-	}
-
-	filterOutput := filter.Model{}
 
 	getDimensionOptions := func(dim filter.ModelDimension) ([]string, error) {
 		q := dataset.QueryParams{Offset: 0, Limit: 1000}
@@ -136,25 +159,22 @@ func filterOutput(w http.ResponseWriter, req *http.Request, dc DatasetClient, fc
 		return getDimensionOptions(dim)
 	}
 
-	filterOutput, err = fc.GetOutput(ctx, userAccessToken, "", "", collectionID, filterOutputID)
-	if err != nil {
-		log.Error(ctx, "failed to get filter output", err, log.Data{"filter_output_id": filterOutputID})
-		setStatusCode(ctx, w, err)
-		return
-	}
-
 	for i, dim := range filterOutput.Dimensions {
-		options, err := getOptions(dim)
-		if err != nil {
-			log.Error(ctx, "failed to get options for dimension", err, log.Data{"dimension_name": dim.Name})
-			setStatusCode(ctx, w, err)
-			return
-		}
+		wg.Add(1)
+		go func(i int, dim filter.ModelDimension) {
+			defer wg.Done()
+			options, err := getOptions(dim)
+			if err != nil {
+				log.Error(ctx, "failed to get options for dimension", err, log.Data{"dimension_name": dim.Name})
+				setStatusCode(ctx, w, err)
+				return
+			}
 
-		dim.Options = options
-		filterOutput.Dimensions[i] = dim
-
+			dim.Options = options
+			filterOutput.Dimensions[i] = dim
+		}(i, dim)
 	}
+	wg.Wait()
 
 	if filterOutput.Downloads == nil {
 		log.Warn(ctx, "filter output downloads are nil", log.Data{"filter_output_id": filterOutputID})

--- a/handlers/filter_output_test.go
+++ b/handlers/filter_output_test.go
@@ -713,6 +713,77 @@ func TestFilterOutputHandler(t *testing.T) {
 				So(w.Code, ShouldEqual, http.StatusInternalServerError)
 			})
 		})
+
+		Convey("When the fc.GetDimensionOptions is called", func() {
+			Convey("and the additional call to pc.GetAreas fails", func() {
+				mockDc := NewMockDatasetClient(mockCtrl)
+				mockDc.
+					EXPECT().
+					Get(ctx, userAuthToken, serviceAuthToken, collectionID, "12345").
+					Return(dataset.DatasetDetails{
+						Contacts: &[]dataset.Contact{{Name: "Nick"}},
+						Type:     "flexible",
+						URI:      "/economy/grossdomesticproduct/datasets/gdpjanuary2018",
+						Links: dataset.Links{
+							LatestVersion: dataset.Link{
+								URL: "/datasets/12345/editions/2021/versions/1",
+							},
+						},
+						ID: "12345",
+					}, nil)
+				mockDc.
+					EXPECT().
+					GetVersions(ctx, userAuthToken, serviceAuthToken, collectionID, "", "12345", "2021", &dataset.QueryParams{Offset: 0, Limit: 1000}).
+					Return(versions, nil)
+				mockDc.
+					EXPECT().
+					GetVersion(ctx, userAuthToken, serviceAuthToken, collectionID, "", "12345", "2021", "1").
+					Return(versions.Items[0], nil)
+
+				mockFc := NewMockFilterClient(mockCtrl)
+				mockFc.
+					EXPECT().
+					GetOutput(ctx, gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(filterModels[1], nil)
+				mockFc.
+					EXPECT().
+					GetDimensionOptions(ctx, gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(filter.DimensionOptions{
+						Items: []filter.DimensionOption{
+							{
+								Option: "area 1",
+							},
+						},
+						TotalCount: 1,
+					}, "", nil)
+
+				mockPc := NewMockPopulationClient(mockCtrl)
+				mockPc.
+					EXPECT().
+					GetAreas(gomock.Any(), gomock.Any()).
+					Return(population.GetAreasResponse{}, errors.New("area client error"))
+
+				mockRend := NewMockRenderClient(mockCtrl)
+				mockRend.
+					EXPECT().
+					NewBasePageModel().
+					Return(coreModel.NewPage(cfg.PatternLibraryAssetsPath, cfg.SiteDomain))
+				mockRend.
+					EXPECT().
+					BuildPage(gomock.Any(), gomock.Any(), "census-landing")
+
+				w := httptest.NewRecorder()
+				req := httptest.NewRequest("GET", "/datasets/12345/editions/2021/versions/1/filter-outputs/67890", nil)
+
+				router := mux.NewRouter()
+				router.HandleFunc("/datasets/{datasetID}/editions/{editionID}/versions/{versionID}/filter-outputs/{filterOutputID}", FilterOutput(mockFc, mockPc, mockDc, mockRend, cfg, ""))
+
+				router.ServeHTTP(w, req)
+				Convey("Then the status code is 500", func() {
+					So(w.Code, ShouldEqual, http.StatusInternalServerError)
+				})
+			})
+		})
 	})
 }
 

--- a/handlers/filterable_landing_page.go
+++ b/handlers/filterable_landing_page.go
@@ -214,7 +214,7 @@ func censusLanding(ctx context.Context, w http.ResponseWriter, req *http.Request
 
 	showAll := req.URL.Query()[queryStrKey]
 	basePage := rend.NewBasePageModel()
-	m := mapper.CreateCensusDatasetLandingPage(ctx, req, basePage, datasetModel, version, opts, initialVersionReleaseDate, hasOtherVersions, allVersions, latestVersionNumber, latestVersionURL, lang, showAll, numOptsSummary, isValidationError, false, filter.Model{})
+	m := mapper.CreateCensusDatasetLandingPage(ctx, req, basePage, datasetModel, version, opts, initialVersionReleaseDate, hasOtherVersions, allVersions, latestVersionNumber, latestVersionURL, lang, showAll, numOptsSummary, isValidationError, false, false, filter.Model{})
 	rend.BuildPage(w, m, "census-landing")
 }
 

--- a/handlers/mock_clients.go
+++ b/handlers/mock_clients.go
@@ -72,6 +72,22 @@ func (mr *MockFilterClientMockRecorder) CreateFlexibleBlueprint(ctx, userAuthTok
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateFlexibleBlueprint", reflect.TypeOf((*MockFilterClient)(nil).CreateFlexibleBlueprint), ctx, userAuthToken, serviceAuthToken, downloadServiceToken, collectionID, datasetID, edition, version, dimensions, population_type)
 }
 
+// GetDimensionOptions mocks base method.
+func (m *MockFilterClient) GetDimensionOptions(ctx context.Context, userAuthToken, serviceAuthToken, collectionID, filterID, name string, q *filter.QueryParams) (filter.DimensionOptions, string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetDimensionOptions", ctx, userAuthToken, serviceAuthToken, collectionID, filterID, name, q)
+	ret0, _ := ret[0].(filter.DimensionOptions)
+	ret1, _ := ret[1].(string)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// GetDimensionOptions indicates an expected call of GetDimensionOptions.
+func (mr *MockFilterClientMockRecorder) GetDimensionOptions(ctx, userAuthToken, serviceAuthToken, collectionID, filterID, name, q interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDimensionOptions", reflect.TypeOf((*MockFilterClient)(nil).GetDimensionOptions), ctx, userAuthToken, serviceAuthToken, collectionID, filterID, name, q)
+}
+
 // GetOutput mocks base method.
 func (m *MockFilterClient) GetOutput(ctx context.Context, userAuthToken, serviceAuthToken, downloadServiceToken, collectionID, filterOutputID string) (filter.Model, error) {
 	m.ctrl.T.Helper()

--- a/mapper/mapper.go
+++ b/mapper/mapper.go
@@ -39,6 +39,7 @@ const (
 	SixteensVersion     = "77f1d9b"
 	CorrectionAlertType = "correction"
 	queryStrKey         = "showAll"
+	Coverage            = "Coverage"
 )
 
 func (p TimeSlice) Len() int {
@@ -344,7 +345,7 @@ func CreateEditionsList(basePage coreModel.Page, ctx context.Context, req *http.
 }
 
 // CreateCensusDatasetLandingPage creates a census-landing page based on api model responses
-func CreateCensusDatasetLandingPage(ctx context.Context, req *http.Request, basePage coreModel.Page, d dataset.DatasetDetails, version dataset.Version, opts []dataset.Options, initialVersionReleaseDate string, hasOtherVersions bool, allVersions []dataset.Version, latestVersionNumber int, latestVersionURL, lang string, queryStrValues []string, maxNumberOfOptions int, isValidationError, hasFilterOutput bool, filter filter.Model) datasetLandingPageCensus.Page {
+func CreateCensusDatasetLandingPage(ctx context.Context, req *http.Request, basePage coreModel.Page, d dataset.DatasetDetails, version dataset.Version, opts []dataset.Options, initialVersionReleaseDate string, hasOtherVersions bool, allVersions []dataset.Version, latestVersionNumber int, latestVersionURL, lang string, queryStrValues []string, maxNumberOfOptions int, isValidationError, hasFilterOutput, hasNoAreaOptions bool, filter filter.Model) datasetLandingPageCensus.Page {
 	p := datasetLandingPageCensus.Page{
 		Page: basePage,
 	}
@@ -592,11 +593,12 @@ func CreateCensusDatasetLandingPage(ctx context.Context, req *http.Request, base
 		p.DatasetLandingPage.Dimensions = mapCensusOptionsToDimensions(version.Dimensions, opts, queryStrValues, req.URL.Path, isFlex)
 		coverage := []sharedModel.Dimension{
 			{
-				IsCoverage: true,
-				Title:      "Coverage",
-				Name:       "coverage",
-				ShowChange: isFlex,
-				ID:         "coverage",
+				IsCoverage:        true,
+				IsDefaultCoverage: true,
+				Title:             Coverage,
+				Name:              strings.ToLower(Coverage),
+				ShowChange:        isFlex,
+				ID:                strings.ToLower(Coverage),
 			},
 		}
 		temp := append(coverage, p.DatasetLandingPage.Dimensions[1:]...)
@@ -605,6 +607,18 @@ func CreateCensusDatasetLandingPage(ctx context.Context, req *http.Request, base
 
 	if hasFilterOutput {
 		p.DatasetLandingPage.Dimensions = mapFilterOutputDims(filter, queryStrValues, req.URL.Path)
+		coverage := []sharedModel.Dimension{
+			{
+				IsCoverage:        true,
+				IsDefaultCoverage: hasNoAreaOptions,
+				Title:             Coverage,
+				Name:              strings.ToLower(Coverage),
+				ID:                strings.ToLower(Coverage),
+				Values:            filter.Dimensions[0].Options,
+			},
+		}
+		temp := append(coverage, p.DatasetLandingPage.Dimensions[1:]...)
+		p.DatasetLandingPage.Dimensions = append(p.DatasetLandingPage.Dimensions[:1], temp...)
 	}
 
 	if isValidationError {
@@ -633,7 +647,7 @@ func mapFilterOutputDims(filter filter.Model, queryStrValues []string, path stri
 		midFloor, midCeiling := getTruncationMidRange(pDim.TotalItems)
 
 		var displayedOptions []string
-		if pDim.TotalItems > 9 && !helpers.HasStringInSlice(pDim.ID, queryStrValues) {
+		if pDim.TotalItems > 9 && !helpers.HasStringInSlice(pDim.ID, queryStrValues) && !pDim.IsAreaType {
 			displayedOptions = dim.Options[:3]
 			displayedOptions = append(displayedOptions, dim.Options[midFloor:midCeiling]...)
 			displayedOptions = append(displayedOptions, dim.Options[len(dim.Options)-3:]...)

--- a/mapper/mapper_test.go
+++ b/mapper/mapper_test.go
@@ -701,7 +701,7 @@ func TestCreateCensusDatasetLandingPage(t *testing.T) {
 	}
 
 	Convey("Census dataset landing page maps correctly as version 1", t, func() {
-		page := CreateCensusDatasetLandingPage(context.Background(), req, pageModel, datasetModel, versionOneDetails, datasetOptions, "", false, []dataset.Version{versionOneDetails}, 1, "/a/version/1", "", []string{}, 50, false, false, filter.Model{})
+		page := CreateCensusDatasetLandingPage(context.Background(), req, pageModel, datasetModel, versionOneDetails, datasetOptions, "", false, []dataset.Version{versionOneDetails}, 1, "/a/version/1", "", []string{}, 50, false, false, false, filter.Model{})
 		So(page.Type, ShouldEqual, datasetModel.Type)
 		So(page.ID, ShouldEqual, datasetModel.ID)
 		So(page.Version.ReleaseDate, ShouldEqual, versionOneDetails.ReleaseDate)
@@ -738,7 +738,7 @@ func TestCreateCensusDatasetLandingPage(t *testing.T) {
 
 	Convey("Census dataset landing page maps correctly with filter output", t, func() {
 		datasetModel.Type = "flexible"
-		page := CreateCensusDatasetLandingPage(context.Background(), req, pageModel, datasetModel, versionOneDetails, datasetOptions, "", false, []dataset.Version{versionOneDetails}, 1, "/a/version/1", "", []string{}, 50, false, true, filterOutput)
+		page := CreateCensusDatasetLandingPage(context.Background(), req, pageModel, datasetModel, versionOneDetails, datasetOptions, "", false, []dataset.Version{versionOneDetails}, 1, "/a/version/1", "", []string{}, 50, false, true, true, filterOutput)
 		So(page.Type, ShouldEqual, datasetModel.Type)
 		So(page.ID, ShouldEqual, datasetModel.ID)
 		So(page.Version.ReleaseDate, ShouldEqual, versionOneDetails.ReleaseDate)
@@ -768,11 +768,13 @@ func TestCreateCensusDatasetLandingPage(t *testing.T) {
 		So(page.DatasetLandingPage.IsFlexible, ShouldBeTrue)
 		So(page.DatasetLandingPage.Dimensions[0].Title, ShouldEqual, filterOutput.Dimensions[0].Label)
 		So(page.DatasetLandingPage.Dimensions[0].Values, ShouldResemble, filterOutput.Dimensions[0].Options)
+		So(page.DatasetLandingPage.Dimensions[1].IsCoverage, ShouldBeTrue)
+		So(page.DatasetLandingPage.Dimensions[1].Values, ShouldResemble, filterOutput.Dimensions[0].Options)
 	})
 
 	Convey("Release date and hasOtherVersions is mapped correctly when v2 of Census DLP dataset is loaded", t, func() {
 		req := httptest.NewRequest("", "/datasets/cantabular-1/editions/2021/versions/2", nil)
-		page := CreateCensusDatasetLandingPage(context.Background(), req, pageModel, datasetModel, versionTwoDetails, datasetOptions, versionOneDetails.ReleaseDate, true, []dataset.Version{versionOneDetails, versionTwoDetails}, 2, "/a/version/123", "", []string{}, 50, false, false, filter.Model{})
+		page := CreateCensusDatasetLandingPage(context.Background(), req, pageModel, datasetModel, versionTwoDetails, datasetOptions, versionOneDetails.ReleaseDate, true, []dataset.Version{versionOneDetails, versionTwoDetails}, 2, "/a/version/123", "", []string{}, 50, false, false, false, filter.Model{})
 		So(page.InitialReleaseDate, ShouldEqual, versionOneDetails.ReleaseDate)
 		So(page.Version.ReleaseDate, ShouldEqual, versionTwoDetails.ReleaseDate)
 		So(page.DatasetLandingPage.HasOtherVersions, ShouldBeTrue)
@@ -786,13 +788,13 @@ func TestCreateCensusDatasetLandingPage(t *testing.T) {
 
 	Convey("IsCurrent returns false when request is for a different page", t, func() {
 		req := httptest.NewRequest("", "/datasets/cantabular-1/editions/2021/versions/1", nil)
-		page := CreateCensusDatasetLandingPage(context.Background(), req, pageModel, datasetModel, versionTwoDetails, datasetOptions, versionOneDetails.ReleaseDate, true, []dataset.Version{versionOneDetails, versionTwoDetails}, 2, "", "", []string{}, 50, false, false, filter.Model{})
+		page := CreateCensusDatasetLandingPage(context.Background(), req, pageModel, datasetModel, versionTwoDetails, datasetOptions, versionOneDetails.ReleaseDate, true, []dataset.Version{versionOneDetails, versionTwoDetails}, 2, "", "", []string{}, 50, false, false, false, filter.Model{})
 		So(page.Versions[0].VersionURL, ShouldEqual, "/datasets/cantabular-1/editions/2021/versions/2")
 		So(page.Versions[0].IsCurrentPage, ShouldBeFalse)
 	})
 
 	Convey("Versions history is in descending order", t, func() {
-		page := CreateCensusDatasetLandingPage(context.Background(), req, pageModel, datasetModel, versionTwoDetails, datasetOptions, versionOneDetails.ReleaseDate, true, []dataset.Version{versionOneDetails, versionTwoDetails, versionThreeDetails}, 3, "", "", []string{}, 50, false, false, filter.Model{})
+		page := CreateCensusDatasetLandingPage(context.Background(), req, pageModel, datasetModel, versionTwoDetails, datasetOptions, versionOneDetails.ReleaseDate, true, []dataset.Version{versionOneDetails, versionTwoDetails, versionThreeDetails}, 3, "", "", []string{}, 50, false, false, false, filter.Model{})
 		So(page.Versions[0].VersionNumber, ShouldEqual, 3)
 		So(page.Versions[1].VersionNumber, ShouldEqual, 2)
 		So(page.Versions[2].VersionNumber, ShouldEqual, 1)
@@ -800,15 +802,15 @@ func TestCreateCensusDatasetLandingPage(t *testing.T) {
 
 	Convey("ShowOtherVersionsPanel is set correctly", t, func() {
 		// Landed on version 1, more than one version available = panel displays
-		page := CreateCensusDatasetLandingPage(context.Background(), req, pageModel, datasetModel, versionOneDetails, datasetOptions, versionOneDetails.ReleaseDate, true, []dataset.Version{versionOneDetails, versionTwoDetails, versionThreeDetails}, 3, "", "", []string{}, 50, false, false, filter.Model{})
+		page := CreateCensusDatasetLandingPage(context.Background(), req, pageModel, datasetModel, versionOneDetails, datasetOptions, versionOneDetails.ReleaseDate, true, []dataset.Version{versionOneDetails, versionTwoDetails, versionThreeDetails}, 3, "", "", []string{}, 50, false, false, false, filter.Model{})
 		So(page.DatasetLandingPage.ShowOtherVersionsPanel, ShouldBeTrue)
 
 		// Only one version = panel hidden
-		page = CreateCensusDatasetLandingPage(context.Background(), req, pageModel, datasetModel, versionOneDetails, datasetOptions, versionOneDetails.ReleaseDate, false, []dataset.Version{versionOneDetails}, 1, "", "", []string{}, 50, false, false, filter.Model{})
+		page = CreateCensusDatasetLandingPage(context.Background(), req, pageModel, datasetModel, versionOneDetails, datasetOptions, versionOneDetails.ReleaseDate, false, []dataset.Version{versionOneDetails}, 1, "", "", []string{}, 50, false, false, false, filter.Model{})
 		So(page.DatasetLandingPage.ShowOtherVersionsPanel, ShouldBeFalse)
 
 		// More than one version, landed on latest version (3) = panel hidden
-		page = CreateCensusDatasetLandingPage(context.Background(), req, pageModel, datasetModel, versionThreeDetails, datasetOptions, versionThreeDetails.ReleaseDate, true, []dataset.Version{versionOneDetails, versionTwoDetails, versionThreeDetails}, 3, "", "", []string{}, 50, false, false, filter.Model{})
+		page = CreateCensusDatasetLandingPage(context.Background(), req, pageModel, datasetModel, versionThreeDetails, datasetOptions, versionThreeDetails.ReleaseDate, true, []dataset.Version{versionOneDetails, versionTwoDetails, versionThreeDetails}, 3, "", "", []string{}, 50, false, false, false, filter.Model{})
 		So(page.DatasetLandingPage.ShowOtherVersionsPanel, ShouldBeFalse)
 	})
 
@@ -822,7 +824,7 @@ func TestCreateCensusDatasetLandingPage(t *testing.T) {
 				},
 			},
 		}
-		page := CreateCensusDatasetLandingPage(context.Background(), req, pageModel, datasetModel, versionDetails, datasetOptions, versionOneDetails.ReleaseDate, false, []dataset.Version{}, 1, "", "", []string{}, 50, true, false, filter.Model{})
+		page := CreateCensusDatasetLandingPage(context.Background(), req, pageModel, datasetModel, versionDetails, datasetOptions, versionOneDetails.ReleaseDate, false, []dataset.Version{}, 1, "", "", []string{}, 50, true, false, false, filter.Model{})
 		So(page.Error.Title, ShouldEqual, fmt.Sprintf("Error: %s", datasetModel.Title))
 	})
 
@@ -836,7 +838,7 @@ func TestCreateCensusDatasetLandingPage(t *testing.T) {
 				},
 			},
 		}
-		page := CreateCensusDatasetLandingPage(context.Background(), req, pageModel, datasetModel, versionDetails, datasetOptions, versionOneDetails.ReleaseDate, false, []dataset.Version{}, 1, "", "", []string{}, 50, false, false, filter.Model{})
+		page := CreateCensusDatasetLandingPage(context.Background(), req, pageModel, datasetModel, versionDetails, datasetOptions, versionOneDetails.ReleaseDate, false, []dataset.Version{}, 1, "", "", []string{}, 50, false, false, false, filter.Model{})
 		So(page.Error.Title, ShouldBeBlank)
 	})
 
@@ -850,7 +852,7 @@ func TestCreateCensusDatasetLandingPage(t *testing.T) {
 				},
 			},
 		}
-		page := CreateCensusDatasetLandingPage(context.Background(), req, pageModel, datasetModel, versionDetails, datasetOptions, versionOneDetails.ReleaseDate, false, []dataset.Version{}, 1, "", "", []string{}, 50, false, false, filter.Model{})
+		page := CreateCensusDatasetLandingPage(context.Background(), req, pageModel, datasetModel, versionDetails, datasetOptions, versionOneDetails.ReleaseDate, false, []dataset.Version{}, 1, "", "", []string{}, 50, false, false, false, filter.Model{})
 		So(page.Error.Title, ShouldBeBlank)
 	})
 
@@ -865,7 +867,7 @@ func TestCreateCensusDatasetLandingPage(t *testing.T) {
 	}
 
 	Convey("No contacts provided, contact section is not displayed", t, func() {
-		page := CreateCensusDatasetLandingPage(context.Background(), req, pageModel, noContactDM, versionOneDetails, datasetOptions, "", false, []dataset.Version{}, 1, "", "", []string{}, 50, false, false, filter.Model{})
+		page := CreateCensusDatasetLandingPage(context.Background(), req, pageModel, noContactDM, versionOneDetails, datasetOptions, "", false, []dataset.Version{}, 1, "", "", []string{}, 50, false, false, false, filter.Model{})
 		So(page.ContactDetails.Email, ShouldEqual, noContact.Email)
 		So(page.ContactDetails.Telephone, ShouldEqual, noContact.Telephone)
 		So(page.HasContactDetails, ShouldBeFalse)
@@ -882,7 +884,7 @@ func TestCreateCensusDatasetLandingPage(t *testing.T) {
 	}
 
 	Convey("One contact detail provided, contact section is displayed", t, func() {
-		page := CreateCensusDatasetLandingPage(context.Background(), req, pageModel, oneContactDetailDM, versionOneDetails, datasetOptions, "", false, []dataset.Version{}, 1, "", "", []string{}, 50, false, false, filter.Model{})
+		page := CreateCensusDatasetLandingPage(context.Background(), req, pageModel, oneContactDetailDM, versionOneDetails, datasetOptions, "", false, []dataset.Version{}, 1, "", "", []string{}, 50, false, false, false, filter.Model{})
 		So(page.ContactDetails.Email, ShouldEqual, oneContactDetail.Email)
 		So(page.ContactDetails.Telephone, ShouldEqual, oneContactDetail.Telephone)
 		So(page.HasContactDetails, ShouldBeTrue)
@@ -893,7 +895,7 @@ func TestCreateCensusDatasetLandingPage(t *testing.T) {
 			Type: "cantabular_flexible_table",
 			ID:   "test-flex",
 		}
-		page := CreateCensusDatasetLandingPage(context.Background(), req, pageModel, flexDm, versionOneDetails, datasetOptions, "", false, []dataset.Version{}, 1, "", "", []string{}, 50, false, false, filter.Model{})
+		page := CreateCensusDatasetLandingPage(context.Background(), req, pageModel, flexDm, versionOneDetails, datasetOptions, "", false, []dataset.Version{}, 1, "", "", []string{}, 50, false, false, false, filter.Model{})
 		So(page.DatasetLandingPage.IsFlexible, ShouldBeTrue)
 		So(page.DatasetLandingPage.FormAction, ShouldEqual, fmt.Sprintf("/datasets/%s/editions/%s/versions/%s/filter-flex", flexDm.ID, versionOneDetails.Edition, strconv.Itoa(versionOneDetails.Version)))
 	})
@@ -906,26 +908,77 @@ func TestCreateCensusDatasetLandingPage(t *testing.T) {
 						Size: "1234",
 						URL:  "https://mydomain.com/my-request.xlsx",
 					},
-				}}, datasetOptions, "", false, []dataset.Version{}, 1, "", "", []string{}, 50, false, false, filter.Model{})
+				}}, datasetOptions, "", false, []dataset.Version{}, 1, "", "", []string{}, 50, false, false, false, filter.Model{})
 				So(page.DatasetLandingPage.HasDownloads, ShouldBeTrue)
 			})
 			Convey("HasDownloads set to false when downloads are zero", func() {
-				page := CreateCensusDatasetLandingPage(context.Background(), req, pageModel, oneContactDetailDM, dataset.Version{Downloads: nil}, datasetOptions, "", false, []dataset.Version{}, 1, "", "", []string{}, 50, false, false, filter.Model{})
+				page := CreateCensusDatasetLandingPage(context.Background(), req, pageModel, oneContactDetailDM, dataset.Version{Downloads: nil}, datasetOptions, "", false, []dataset.Version{}, 1, "", "", []string{}, 50, false, false, false, filter.Model{})
 				So(page.DatasetLandingPage.HasDownloads, ShouldBeFalse)
 			})
 		})
 		Convey("On filterOutput", func() {
 			Convey("HasDownloads set to true when downloads are greater than zero", func() {
-				page := CreateCensusDatasetLandingPage(context.Background(), req, pageModel, oneContactDetailDM, dataset.Version{}, datasetOptions, "", false, []dataset.Version{}, 1, "", "", []string{}, 50, false, true, filter.Model{Downloads: map[string]filter.Download{
-					"XLSX": {
-						Size: "1234",
-						URL:  "https://mydomain.com/my-request.xlsx",
-					},
-				}})
+				page := CreateCensusDatasetLandingPage(context.Background(),
+					req,
+					pageModel,
+					oneContactDetailDM,
+					dataset.Version{},
+					datasetOptions,
+					"",
+					false,
+					[]dataset.Version{},
+					1,
+					"",
+					"",
+					[]string{},
+					50,
+					false,
+					true,
+					false,
+					filter.Model{
+						Dimensions: []filter.ModelDimension{
+							{
+								Name:       "Area 1",
+								IsAreaType: helpers.ToBoolPtr(true),
+								Options:    []string{"one", "two", "three"},
+							},
+						},
+						Downloads: map[string]filter.Download{
+							"XLSX": {
+								Size: "1234",
+								URL:  "https://mydomain.com/my-request.xlsx",
+							},
+						}})
 				So(page.DatasetLandingPage.HasDownloads, ShouldBeTrue)
 			})
 			Convey("HasDownloads set to false when downloads are zero", func() {
-				page := CreateCensusDatasetLandingPage(context.Background(), req, pageModel, oneContactDetailDM, dataset.Version{}, datasetOptions, "", false, []dataset.Version{}, 1, "", "", []string{}, 50, false, true, filter.Model{Downloads: nil})
+				page := CreateCensusDatasetLandingPage(context.Background(),
+					req,
+					pageModel,
+					oneContactDetailDM,
+					dataset.Version{},
+					datasetOptions,
+					"",
+					false,
+					[]dataset.Version{},
+					1,
+					"",
+					"",
+					[]string{},
+					50,
+					false,
+					true,
+					false,
+					filter.Model{
+						Dimensions: []filter.ModelDimension{
+							{
+								Name:       "Area 1",
+								IsAreaType: helpers.ToBoolPtr(true),
+								Options:    []string{"one", "two", "three"},
+							},
+						},
+						Downloads: nil,
+					})
 				So(page.DatasetLandingPage.HasDownloads, ShouldBeFalse)
 			})
 		})
@@ -1127,6 +1180,7 @@ func TestCreateCensusDatasetLandingPage(t *testing.T) {
 				50,
 				false,
 				false,
+				false,
 				filter.Model{Downloads: nil})
 			Convey("then the list should be truncated to show the first, middle, and last three values", func() {
 				So(p.DatasetLandingPage.Dimensions[0].TotalItems, ShouldEqual, datasetOptions[0].TotalCount)
@@ -1157,6 +1211,7 @@ func TestCreateCensusDatasetLandingPage(t *testing.T) {
 				"",
 				[]string{"dim_1"},
 				50,
+				false,
 				false,
 				false,
 				filter.Model{Downloads: nil})
@@ -1242,6 +1297,7 @@ func TestCreateCensusDatasetLandingPage(t *testing.T) {
 				50,
 				false,
 				true,
+				false,
 				filterDims)
 			Convey("then the list should be truncated to show the first, middle, and last three values", func() {
 				So(p.DatasetLandingPage.Dimensions[0].TotalItems, ShouldEqual, 21)
@@ -1274,6 +1330,7 @@ func TestCreateCensusDatasetLandingPage(t *testing.T) {
 				50,
 				false,
 				true,
+				false,
 				filterDims)
 
 			Convey("then the dimension is no longer truncated", func() {
@@ -1300,15 +1357,15 @@ func TestCreateCensusDatasetLandingPage(t *testing.T) {
 					"Label 21",
 				})
 				So(p.DatasetLandingPage.Dimensions[0].TruncateLink, ShouldEqual, "/#dim_1")
-				So(p.DatasetLandingPage.Dimensions[1].TotalItems, ShouldEqual, 12)
-				So(p.DatasetLandingPage.Dimensions[1].Values, ShouldHaveLength, 9)
-				So(p.DatasetLandingPage.Dimensions[1].Values, ShouldResemble, []string{
+				So(p.DatasetLandingPage.Dimensions[2].TotalItems, ShouldEqual, 12)
+				So(p.DatasetLandingPage.Dimensions[2].Values, ShouldHaveLength, 9)
+				So(p.DatasetLandingPage.Dimensions[2].Values, ShouldResemble, []string{
 					"Label 1", "Label 2", "Label 3",
 					"Label 5", "Label 6", "Label 7",
 					"Label 10", "Label 11", "Label 12",
 				})
-				So(p.DatasetLandingPage.Dimensions[1].IsTruncated, ShouldBeTrue)
-				So(p.DatasetLandingPage.Dimensions[1].TruncateLink, ShouldEqual, "/?showAll=dim_2#dim_2")
+				So(p.DatasetLandingPage.Dimensions[2].IsTruncated, ShouldBeTrue)
+				So(p.DatasetLandingPage.Dimensions[2].TruncateLink, ShouldEqual, "/?showAll=dim_2#dim_2")
 			})
 		})
 	})

--- a/model/dimension.go
+++ b/model/dimension.go
@@ -2,16 +2,17 @@ package model
 
 // Dimension represents the data for a single dimension
 type Dimension struct {
-	Title        string   `json:"title"`
-	Name         string   `json:"name"`
-	Values       []string `json:"values"`
-	OptionsURL   string   `json:"options_url"`
-	TotalItems   int      `json:"total_items"`
-	Description  string   `json:"description"`
-	IsAreaType   bool     `json:"is_area_type"`
-	IsCoverage   bool     `json:"is_coverage"`
-	ShowChange   bool     `json:"show_change"`
-	IsTruncated  bool     `json:"is_truncated"`
-	TruncateLink string   `json:"truncate_link"`
-	ID           string   `json:"id"`
+	Title             string   `json:"title"`
+	Name              string   `json:"name"`
+	Values            []string `json:"values"`
+	OptionsURL        string   `json:"options_url"`
+	TotalItems        int      `json:"total_items"`
+	Description       string   `json:"description"`
+	IsAreaType        bool     `json:"is_area_type"`
+	IsCoverage        bool     `json:"is_coverage"`
+	IsDefaultCoverage bool     `json:"is_default_coverage"`
+	ShowChange        bool     `json:"show_change"`
+	IsTruncated       bool     `json:"is_truncated"`
+	TruncateLink      string   `json:"truncate_link"`
+	ID                string   `json:"id"`
 }


### PR DESCRIPTION
### What

- Display coverage selection on filter output page
- Made API calls concurrent 

✅ **Resolves** [trello ticket](https://trello.com/c/DoG2nyPO/5786-display-coverage-selection-on-data-set-landing-page) Display Coverage selection on data set landing page

### How to review

- Sense check
- Tests pass
- [Compare concurrent APIs commit](https://github.com/ONSdigital/dp-frontend-dataset-controller/commit/bb4f758b5ab8835953e0ec5721a3d24078adad0f) with develop (might be easier 🤷‍♂️)
- Media review

https://user-images.githubusercontent.com/19624419/185090093-fd8cda9e-31e0-473e-a00f-c24118346aab.mov

### Who can review

Frontend go dev
