### PR TITLE
Feature/enable access to filter record from filter output page

### DIFF
--- a/assets/templates/partials/census/variables-table.tmpl
+++ b/assets/templates/partials/census/variables-table.tmpl
@@ -1,9 +1,9 @@
 {{$dims := .DatasetLandingPage.Dimensions}}
 {{$language := .Language }}
-{{$flexible := .DatasetLandingPage.IsFlexible}}
+{{$isFlexibleForm := .DatasetLandingPage.IsFlexibleForm}}
 <section id="variables" aria-label="{{ localise "Variables" .Language 4}}">
     <h2 class="ons-u-mt-xl">{{ localise "Variables" .Language 4}}</h2>
-    {{ if $flexible }}
+    {{ if $isFlexibleForm }}
         <form action="{{.DatasetLandingPage.FormAction}}" method="post">
         {{ end }}
         <table class="ons-table">
@@ -13,7 +13,7 @@
                         <th
                             scope="col"
                             class="ons-table__header ons-table__cell ons-col-4@s ons-u-pb-s ons-u-pt-s ons-u-pl-no ons-u-order--1 ons-u-bb-no@xxs@s
-                                {{if $flexible}}ons-u-flex--2@xxs@s{{end}}">
+                                ons-u-flex--2@xxs@s">
                             <span>
                                 {{ if $dim.IsAreaType }}
                                     {{- localise "AreaTypeDescription" $language 1 -}}
@@ -76,19 +76,27 @@
                         <td class="ons-table__cell ons-u-pb-s ons-u-pt-s ons-u-ta-right ons-u-pl-no@xxs@s ons-u-ml-xs@xxs@s ons-u-order--2
                                 ons-u-bb-no@xxs@s">
                             {{ if $dim.ShowChange }}
-                                <button type="submit" class="ons-btn ons-btn__btn--link" name="dimension" value="{{ $dim.Name }}" role="link">
-                                    {{ localise "Change" $language 1 }}
-                                    <span class="ons-u-vh">{{ localise "Variables" $language 1 }}
-                                        {{ $dim.Title }}
-                                    </span>
-                                </button>
+                                {{ if $isFlexibleForm }}
+                                    <button type="submit" class="ons-btn ons-btn__btn--link" name="dimension" value="{{ $dim.Name }}" role="link">
+                                        {{ localise "Change" $language 1 }}
+                                        <span class="ons-u-vh">{{ localise "Variables" $language 1 }}
+                                            {{ $dim.Title }}
+                                        </span>
+                                    </button>
+                                {{ else }}
+                                    <a href="{{$dim.ChangeURL}}">{{ localise "Change" $language 1 }}
+                                        <span class="ons-u-vh">{{ localise "Variables" $language 1 }}
+                                            {{ $dim.Title }}
+                                        </span>
+                                    </a>
+                                {{ end }}
                             {{ end }}
                         </td>
                     </tr>
                 {{ end }}
             </tbody>
         </table>
-        {{ if $flexible }}
+        {{ if $isFlexibleForm }}
         </form>
     {{ end }}
     {{ template "partials/census/back-to-contents" . }}

--- a/mapper/mapper_test.go
+++ b/mapper/mapper_test.go
@@ -688,8 +688,10 @@ func TestCreateCensusDatasetLandingPage(t *testing.T) {
 	filterOutput := filter.Model{
 		Dimensions: []filter.ModelDimension{
 			{
-				Label:   "A label",
-				Options: []string{"An option", "and another"},
+				Label:      "A label",
+				Options:    []string{"An option", "and another"},
+				IsAreaType: helpers.ToBoolPtr(true),
+				Name:       "Geography",
 			},
 		},
 		Downloads: map[string]filter.Download{
@@ -698,6 +700,7 @@ func TestCreateCensusDatasetLandingPage(t *testing.T) {
 				URL:  "https://mydomain.com/my-request",
 			},
 		},
+		FilterID: "1234-5678",
 	}
 
 	Convey("Census dataset landing page maps correctly as version 1", t, func() {
@@ -727,7 +730,7 @@ func TestCreateCensusDatasetLandingPage(t *testing.T) {
 		So(page.Collapsible.CollapsibleItems[1].Subheading, ShouldEqual, versionOneDetails.Dimensions[1].Name)
 		So(page.Collapsible.CollapsibleItems[1].Content, ShouldResemble, strings.Split(versionOneDetails.Dimensions[1].Description, "\n"))
 		So(page.Collapsible.CollapsibleItems, ShouldHaveLength, 2)
-		So(page.DatasetLandingPage.IsFlexible, ShouldBeFalse)
+		So(page.DatasetLandingPage.IsFlexibleForm, ShouldBeFalse)
 		So(page.DatasetLandingPage.Dimensions, ShouldHaveLength, 2) // coverage is inserted
 		So(page.DatasetLandingPage.Dimensions[1].IsCoverage, ShouldBeTrue)
 		So(page.DatasetLandingPage.Dimensions[1].Title, ShouldEqual, "Coverage")
@@ -765,11 +768,15 @@ func TestCreateCensusDatasetLandingPage(t *testing.T) {
 		So(page.Collapsible.CollapsibleItems[1].Subheading, ShouldEqual, versionOneDetails.Dimensions[1].Name)
 		So(page.Collapsible.CollapsibleItems[1].Content, ShouldResemble, strings.Split(versionOneDetails.Dimensions[1].Description, "\n"))
 		So(page.Collapsible.CollapsibleItems, ShouldHaveLength, 2)
-		So(page.DatasetLandingPage.IsFlexible, ShouldBeTrue)
+		So(page.DatasetLandingPage.IsFlexibleForm, ShouldBeFalse)
 		So(page.DatasetLandingPage.Dimensions[0].Title, ShouldEqual, filterOutput.Dimensions[0].Label)
 		So(page.DatasetLandingPage.Dimensions[0].Values, ShouldResemble, filterOutput.Dimensions[0].Options)
+		So(page.DatasetLandingPage.Dimensions[0].ShowChange, ShouldBeTrue)
+		So(page.DatasetLandingPage.Dimensions[0].ChangeURL, ShouldEqual, "/filters/1234-5678/dimensions/geography")
 		So(page.DatasetLandingPage.Dimensions[1].IsCoverage, ShouldBeTrue)
 		So(page.DatasetLandingPage.Dimensions[1].Values, ShouldResemble, filterOutput.Dimensions[0].Options)
+		So(page.DatasetLandingPage.Dimensions[1].ShowChange, ShouldBeTrue)
+		So(page.DatasetLandingPage.Dimensions[1].ChangeURL, ShouldEqual, "/filters/1234-5678/dimensions/geography/coverage")
 	})
 
 	Convey("Release date and hasOtherVersions is mapped correctly when v2 of Census DLP dataset is loaded", t, func() {
@@ -896,7 +903,7 @@ func TestCreateCensusDatasetLandingPage(t *testing.T) {
 			ID:   "test-flex",
 		}
 		page := CreateCensusDatasetLandingPage(context.Background(), req, pageModel, flexDm, versionOneDetails, datasetOptions, "", false, []dataset.Version{}, 1, "", "", []string{}, 50, false, false, false, filter.Model{})
-		So(page.DatasetLandingPage.IsFlexible, ShouldBeTrue)
+		So(page.DatasetLandingPage.IsFlexibleForm, ShouldBeTrue)
 		So(page.DatasetLandingPage.FormAction, ShouldEqual, fmt.Sprintf("/datasets/%s/editions/%s/versions/%s/filter-flex", flexDm.ID, versionOneDetails.Edition, strconv.Itoa(versionOneDetails.Version)))
 	})
 

--- a/model/datasetLandingPageCensus/model.go
+++ b/model/datasetLandingPageCensus/model.go
@@ -29,7 +29,7 @@ type DatasetLandingPage struct {
 	ShareDetails           ShareDetails
 	Methodologies          []Methodology `json:"methodology"`
 	Description            []string      `json:"description"`
-	IsFlexible             bool          `json:"is_flexible"`
+	IsFlexibleForm         bool          `json:"is_flexible_form"`
 	FormAction             string        `json:"form_action"`
 	DatasetURL             string        `json:"dataset_url"`
 }

--- a/model/dimension.go
+++ b/model/dimension.go
@@ -12,6 +12,7 @@ type Dimension struct {
 	IsCoverage        bool     `json:"is_coverage"`
 	IsDefaultCoverage bool     `json:"is_default_coverage"`
 	ShowChange        bool     `json:"show_change"`
+	ChangeURL         string   `json:"change_url"`
 	IsTruncated       bool     `json:"is_truncated"`
 	TruncateLink      string   `json:"truncate_link"`
 	ID                string   `json:"id"`


### PR DESCRIPTION
### What

- [x] [5788 - As a user I want to access my existing filter record from the custom data set landing page](https://trello.com/c/GwdGLwZJ/5788-as-a-user-i-want-to-access-my-existing-filter-record-from-the-custom-data-set-landing-page)
- Enabling access to existing filter record means that the 'change' button is now a link, all form elements should be removed that are part of creating a new filter record.

### How to review

- Sense check
- Tests pass
- Media review

https://user-images.githubusercontent.com/19624419/188920466-ca9b4910-fe9d-437c-a9b4-5cbcd939e3ab.mov

### Who can review

Frontend go dev
