### PR TITLE
Feature/create filter based on filter output

### DIFF
--- a/assets/templates/partials/census/variables-table.tmpl
+++ b/assets/templates/partials/census/variables-table.tmpl
@@ -4,7 +4,7 @@
 <section id="variables" aria-label="{{ localise "Variables" .Language 4}}">
     <h2 class="ons-u-mt-xl">{{ localise "Variables" .Language 4}}</h2>
     {{ if $isFlexibleForm }}
-        <form action="{{.DatasetLandingPage.FormAction}}" method="post">
+        <form method="post">
         {{ end }}
         <table class="ons-table">
             <tbody class="ons-table__body">

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/ONSdigital/dp-frontend-dataset-controller
 go 1.18
 
 require (
-	github.com/ONSdigital/dp-api-clients-go/v2 v2.170.0
+	github.com/ONSdigital/dp-api-clients-go/v2 v2.180.1
 	github.com/ONSdigital/dp-cache v0.1.0
 	github.com/ONSdigital/dp-cookies v0.3.3
 	github.com/ONSdigital/dp-healthcheck v1.4.0-beta

--- a/go.sum
+++ b/go.sum
@@ -7,8 +7,8 @@ github.com/ONSdigital/dp-api-clients-go v1.34.3/go.mod h1:kX+YKuoLYLfkeLHMvQKRRy
 github.com/ONSdigital/dp-api-clients-go v1.41.1/go.mod h1:Ga1+ANjviu21NFJI9wp5NctJIdB4TJLDGbpQFl2V8Wc=
 github.com/ONSdigital/dp-api-clients-go v1.43.0 h1:0982P/YxnYXvba1RhEcFmwF3xywC4eXokWQ8YH3Mm24=
 github.com/ONSdigital/dp-api-clients-go v1.43.0/go.mod h1:V5MfINik+o3OAF985UXUoMjXIfrZe3JKYa5AhZn5jts=
-github.com/ONSdigital/dp-api-clients-go/v2 v2.170.0 h1:xHj6HSzPTpjxSsS0SNMI7XX/+1vqaThdFQBsOADFpJI=
-github.com/ONSdigital/dp-api-clients-go/v2 v2.170.0/go.mod h1:2IF90BHkQjNBzs3El66r0qOPFQ0kJq+zPfHUwCk5rgo=
+github.com/ONSdigital/dp-api-clients-go/v2 v2.180.1 h1:TN4EF2HCY1IKtCdGeoASUHHNdoAp+l+qemCv3y1dyn0=
+github.com/ONSdigital/dp-api-clients-go/v2 v2.180.1/go.mod h1:2IF90BHkQjNBzs3El66r0qOPFQ0kJq+zPfHUwCk5rgo=
 github.com/ONSdigital/dp-cache v0.1.0 h1:qA/iqVe+vBpQPbvkwW/OU3bdJUjcerSjU29fix53JcM=
 github.com/ONSdigital/dp-cache v0.1.0/go.mod h1:Vz9L0Dj7arGo8cYOOs/xHqT0rxOmVLZtfBZfZT87E14=
 github.com/ONSdigital/dp-cookies v0.3.3 h1:KXX4swf+OnljIYbsTYICIBjuRJoxQukGWKBTvBaISlA=

--- a/handlers/create_filter_id.go
+++ b/handlers/create_filter_id.go
@@ -1,15 +1,14 @@
 package handlers
 
 import (
-	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
+	"strconv"
 	"strings"
 
 	"github.com/ONSdigital/dp-api-clients-go/v2/dataset"
 	"github.com/ONSdigital/dp-api-clients-go/v2/filter"
-	"github.com/ONSdigital/dp-frontend-dataset-controller/config"
 	"github.com/ONSdigital/dp-net/v2/handlers"
 	"github.com/ONSdigital/log.go/v2/log"
 	"github.com/gorilla/mux"
@@ -56,20 +55,13 @@ func CreateFilterID(c FilterClient, dc DatasetClient) http.HandlerFunc {
 }
 
 // CreateFilterFlexID creates a new filter ID for filter flex journeys
-func CreateFilterFlexID(fc FilterClient, dc DatasetClient, cfg config.Config) http.HandlerFunc {
+func CreateFilterFlexID(fc FilterClient, dc DatasetClient) http.HandlerFunc {
 	return handlers.ControllerHandler(func(w http.ResponseWriter, req *http.Request, lang, collectionID, userAccessToken string) {
 		vars := mux.Vars(req)
 		datasetID := vars["datasetID"]
 		edition := vars["editionID"]
 		version := vars["versionID"]
 		ctx := req.Context()
-
-		if !cfg.EnableCensusPages {
-			err := errors.New("not implemented")
-			log.Error(ctx, "route not implemented", err)
-			setStatusCode(ctx, w, err)
-			return
-		}
 
 		if err := req.ParseForm(); err != nil {
 			log.Error(ctx, "unable to parse request form", err)
@@ -105,17 +97,66 @@ func CreateFilterFlexID(fc FilterClient, dc DatasetClient, cfg config.Config) ht
 			return
 		}
 
-		filterPath := fmt.Sprintf("/filters/%s/dimensions", fid)
 		dimensionName := url.QueryEscape(strings.ToLower(req.FormValue("dimension")))
-		if dimensionName != "" {
-			if dimensionName == "coverage" {
-				filterPath += fmt.Sprintf("/geography/%s", dimensionName)
-			} else {
-				filterPath += fmt.Sprintf("/%s", dimensionName)
-			}
-		}
+		filterPath := createFilterPath(fid, dimensionName)
 
 		log.Info(ctx, "created filter id", log.Data{"filter_id": fid})
 		http.Redirect(w, req, filterPath, http.StatusMovedPermanently)
 	})
+}
+
+// CreateFilterFlexIDFromOutput creates a new filter ID for filter flex journeys from the user's filter output
+func CreateFilterFlexIDFromOutput(fc FilterClient) http.HandlerFunc {
+	return handlers.ControllerHandler(func(w http.ResponseWriter, req *http.Request, lang, collectionID, userAccessToken string) {
+		vars := mux.Vars(req)
+		filterOutputID := vars["filterOutputID"]
+		ctx := req.Context()
+
+		if err := req.ParseForm(); err != nil {
+			log.Error(ctx, "unable to parse request form", err)
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+
+		fo, err := fc.GetOutput(ctx, userAccessToken, "", "", collectionID, filterOutputID)
+		if err != nil {
+			setStatusCode(ctx, w, err)
+			return
+		}
+
+		dims := []filter.ModelDimension{}
+		for _, verDim := range fo.Dimensions {
+			var dim = filter.ModelDimension{}
+			dim.Name = verDim.Name
+			dim.URI = verDim.URI
+			dim.IsAreaType = verDim.IsAreaType
+			dim.Options = verDim.Options
+			dim.FilterByParent = verDim.FilterByParent
+			dims = append(dims, dim)
+		}
+
+		fid, _, err := fc.CreateFlexibleBlueprint(ctx, userAccessToken, "", "", collectionID, fo.Dataset.DatasetID, fo.Dataset.Edition, strconv.Itoa(fo.Dataset.Version), dims, fo.PopulationType)
+		if err != nil {
+			setStatusCode(ctx, w, err)
+			return
+		}
+
+		dimensionName := url.QueryEscape(strings.ToLower(req.FormValue("dimension")))
+		filterPath := createFilterPath(fid, dimensionName)
+
+		log.Info(ctx, "created filter id", log.Data{"filter_id": fid})
+		http.Redirect(w, req, filterPath, http.StatusMovedPermanently)
+	})
+}
+
+func createFilterPath(fid, dimensionName string) string {
+	filterPath := fmt.Sprintf("/filters/%s/dimensions", fid)
+	if dimensionName != "" {
+		if dimensionName == "coverage" {
+			filterPath += fmt.Sprintf("/geography/%s", dimensionName)
+		} else {
+			filterPath += fmt.Sprintf("/%s", dimensionName)
+		}
+	}
+	return filterPath
 }

--- a/main.go
+++ b/main.go
@@ -152,8 +152,9 @@ func run(ctx context.Context) error {
 
 	router.Path("/datasets/{datasetID}/editions/{editionID}/versions/{versionID}/filter").Methods("POST").HandlerFunc(handlers.CreateFilterID(f, dc))
 	if cfg.EnableCensusPages {
-		router.Path("/datasets/{datasetID}/editions/{editionID}/versions/{versionID}/filter-flex").Methods("POST").HandlerFunc(handlers.CreateFilterFlexID(f, dc, *cfg))
+		router.Path("/datasets/{datasetID}/editions/{editionID}/versions/{versionID}").Methods("POST").HandlerFunc(handlers.CreateFilterFlexID(f, dc))
 		router.Path("/datasets/{datasetID}/editions/{editionID}/versions/{versionID}/filter-outputs/{filterOutputID}").Methods("GET").HandlerFunc(handlers.FilterOutput(f, pc, dc, rend, *cfg, apiRouterVersion))
+		router.Path("/datasets/{datasetID}/editions/{editionID}/versions/{versionID}/filter-outputs/{filterOutputID}").Methods("POST").HandlerFunc(handlers.CreateFilterFlexIDFromOutput(f))
 	}
 
 	router.PathPrefix("/dataset/").Methods("GET").Handler(http.StripPrefix("/dataset/", handlers.DatasetPage(zc, rend, fc, cacheList)))

--- a/mapper/census.go
+++ b/mapper/census.go
@@ -64,7 +64,6 @@ func CreateCensusDatasetLandingPage(ctx context.Context, req *http.Request, base
 	if strings.Contains(d.Type, "flex") {
 		isFlex = true
 		p.DatasetLandingPage.IsFlexibleForm = true
-		p.DatasetLandingPage.FormAction = fmt.Sprintf("/datasets/%s/editions/%s/versions/%s/filter-flex", d.ID, version.Edition, strconv.Itoa(version.Version))
 	}
 
 	if isFilterOutput {
@@ -294,7 +293,7 @@ func CreateCensusDatasetLandingPage(ctx context.Context, req *http.Request, base
 		}
 		temp := append(coverage, p.DatasetLandingPage.Dimensions[1:]...)
 		p.DatasetLandingPage.Dimensions = append(p.DatasetLandingPage.Dimensions[:1], temp...)
-		p.DatasetLandingPage.IsFlexibleForm = false
+		p.DatasetLandingPage.IsFlexibleForm = true
 	}
 
 	if isValidationError {

--- a/mapper/census_test.go
+++ b/mapper/census_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"net/http/httptest"
-	"strconv"
 	"strings"
 	"testing"
 
@@ -184,7 +183,7 @@ func TestCreateCensusDatasetLandingPage(t *testing.T) {
 		So(page.Collapsible.CollapsibleItems[1].Subheading, ShouldEqual, versionOneDetails.Dimensions[1].Name)
 		So(page.Collapsible.CollapsibleItems[1].Content, ShouldResemble, strings.Split(versionOneDetails.Dimensions[1].Description, "\n"))
 		So(page.Collapsible.CollapsibleItems, ShouldHaveLength, 2)
-		So(page.DatasetLandingPage.IsFlexibleForm, ShouldBeFalse)
+		So(page.DatasetLandingPage.IsFlexibleForm, ShouldBeTrue)
 		So(page.DatasetLandingPage.Dimensions[0].Title, ShouldEqual, filterOutput.Dimensions[0].Label)
 		So(page.DatasetLandingPage.Dimensions[0].Values, ShouldResemble, filterOutput.Dimensions[0].Options)
 		So(page.DatasetLandingPage.Dimensions[0].ShowChange, ShouldBeTrue)
@@ -376,7 +375,6 @@ func TestCreateCensusDatasetLandingPage(t *testing.T) {
 		}
 		page := CreateCensusDatasetLandingPage(context.Background(), req, pageModel, flexDm, versionOneDetails, datasetOptions, "", false, []dataset.Version{}, 1, "", "", []string{}, 50, false, false, false, filter.Model{})
 		So(page.DatasetLandingPage.IsFlexibleForm, ShouldBeTrue)
-		So(page.DatasetLandingPage.FormAction, ShouldEqual, fmt.Sprintf("/datasets/%s/editions/%s/versions/%s/filter-flex", flexDm.ID, versionOneDetails.Edition, strconv.Itoa(versionOneDetails.Version)))
 	})
 
 	Convey("Test HasDownloads", t, func() {

--- a/model/datasetLandingPageCensus/model.go
+++ b/model/datasetLandingPageCensus/model.go
@@ -27,7 +27,6 @@ type DatasetLandingPage struct {
 	ShareDetails     ShareDetails
 	Description      []string `json:"description"`
 	IsFlexibleForm   bool     `json:"is_flexible_form"`
-	FormAction       string   `json:"form_action"`
 	DatasetURL       string   `json:"dataset_url"`
 	Panels           []Panel  `json:"panels"`
 }


### PR DESCRIPTION
### What

Requirements have changed that when the user click 'change' from the filter output page, instead of going to their existing filter record a new one is created based on their current selection. This change addresses that functionality and resolves trello ticket [Create new filter from custom dataset landing page](https://trello.com/c/G5CGwNc9/5859-create-new-filter-from-custom-dataset-landing-page).

### How to review

- Sense check
- Tests pass
- Media review

https://user-images.githubusercontent.com/19624419/191511090-13f89e53-f4db-4b5d-a010-ff4dbc2bfaa0.mov

### Who can review

Frontend go dev
