### PR TITLE
feature/parent area count

### DIFF
--- a/assets/templates/partials/census/variables-table.tmpl
+++ b/assets/templates/partials/census/variables-table.tmpl
@@ -75,21 +75,13 @@
                         </td>
                         <td class="ons-table__cell ons-u-pb-s ons-u-pt-s ons-u-ta-right ons-u-pl-no@xxs@s ons-u-ml-xs@xxs@s ons-u-order--2
                                 ons-u-bb-no@xxs@s">
-                            {{ if $dim.ShowChange }}
-                                {{ if $isFlexibleForm }}
-                                    <button type="submit" class="ons-btn ons-btn__btn--link" name="dimension" value="{{ $dim.Name }}" role="link">
-                                        {{ localise "Change" $language 1 }}
-                                        <span class="ons-u-vh">{{ localise "Variables" $language 1 }}
-                                            {{ $dim.Title }}
-                                        </span>
-                                    </button>
-                                {{ else }}
-                                    <a href="{{$dim.ChangeURL}}">{{ localise "Change" $language 1 }}
-                                        <span class="ons-u-vh">{{ localise "Variables" $language 1 }}
-                                            {{ $dim.Title }}
-                                        </span>
-                                    </a>
-                                {{ end }}
+                            {{ if and $dim.ShowChange $isFlexibleForm}}
+                                <button type="submit" class="ons-btn ons-btn__btn--link" name="dimension" value="{{ $dim.Name }}" role="link">
+                                    {{ localise "Change" $language 1 }}
+                                    <span class="ons-u-vh">{{ localise "Variables" $language 1 }}
+                                        {{ $dim.Title }}
+                                    </span>
+                                </button>
                             {{ end }}
                         </td>
                     </tr>

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/ONSdigital/dp-frontend-dataset-controller
 go 1.18
 
 require (
-	github.com/ONSdigital/dp-api-clients-go/v2 v2.180.1
+	github.com/ONSdigital/dp-api-clients-go/v2 v2.181.1
 	github.com/ONSdigital/dp-cache v0.1.0
 	github.com/ONSdigital/dp-cookies v0.3.3
 	github.com/ONSdigital/dp-healthcheck v1.4.0-beta
@@ -22,17 +22,12 @@ require (
 )
 
 require (
-	github.com/ONSdigital/dp-api-clients-go v1.43.0 // indirect
-	github.com/aws/aws-sdk-go v1.44.76 // indirect
-	github.com/jmespath/go-jmespath v0.4.0 // indirect
 	github.com/kevinburke/go-bindata v3.24.0+incompatible // indirect
-	github.com/shurcooL/graphql v0.0.0-20220606043923-3cf50f8a0a29 // indirect
-)
-
-require (
 	github.com/BurntSushi/toml v1.1.0 // indirect
+	github.com/ONSdigital/dp-api-clients-go v1.43.0 // indirect
 	github.com/ONSdigital/dp-topic-api v0.13.1
 	github.com/andybalholm/cascadia v1.3.1 // indirect
+	github.com/aws/aws-sdk-go v1.44.76 // indirect
 	github.com/c2h5oh/datasize v0.0.0-20220606134207-859f65c6625b // indirect
 	github.com/fatih/color v1.13.0 // indirect
 	github.com/fsnotify/fsnotify v1.5.4 // indirect
@@ -40,11 +35,13 @@ require (
 	github.com/gosimple/slug v1.12.0 // indirect
 	github.com/gosimple/unidecode v1.0.1 // indirect
 	github.com/hokaccha/go-prettyjson v0.0.0-20211117102719-0474bc63780f // indirect
+	github.com/jmespath/go-jmespath v0.4.0 // indirect
 	github.com/jtolds/gls v4.20.0+incompatible // indirect
 	github.com/mattn/go-colorable v0.1.12 // indirect
 	github.com/mattn/go-isatty v0.0.16 // indirect
 	github.com/nicksnyder/go-i18n/v2 v2.2.0 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
+	github.com/shurcooL/graphql v0.0.0-20220606043923-3cf50f8a0a29 // indirect
 	github.com/smartystreets/assertions v1.13.0 // indirect
 	github.com/unrolled/render v1.5.0 // indirect
 	golang.org/x/net v0.0.0-20220812174116-3211cb980234 // indirect

--- a/go.sum
+++ b/go.sum
@@ -7,8 +7,8 @@ github.com/ONSdigital/dp-api-clients-go v1.34.3/go.mod h1:kX+YKuoLYLfkeLHMvQKRRy
 github.com/ONSdigital/dp-api-clients-go v1.41.1/go.mod h1:Ga1+ANjviu21NFJI9wp5NctJIdB4TJLDGbpQFl2V8Wc=
 github.com/ONSdigital/dp-api-clients-go v1.43.0 h1:0982P/YxnYXvba1RhEcFmwF3xywC4eXokWQ8YH3Mm24=
 github.com/ONSdigital/dp-api-clients-go v1.43.0/go.mod h1:V5MfINik+o3OAF985UXUoMjXIfrZe3JKYa5AhZn5jts=
-github.com/ONSdigital/dp-api-clients-go/v2 v2.180.1 h1:TN4EF2HCY1IKtCdGeoASUHHNdoAp+l+qemCv3y1dyn0=
-github.com/ONSdigital/dp-api-clients-go/v2 v2.180.1/go.mod h1:2IF90BHkQjNBzs3El66r0qOPFQ0kJq+zPfHUwCk5rgo=
+github.com/ONSdigital/dp-api-clients-go/v2 v2.181.1 h1:793aKAnL2KnddDeIs3KHkxdsESi9WWD6mJSgPtn85nM=
+github.com/ONSdigital/dp-api-clients-go/v2 v2.181.1/go.mod h1:2IF90BHkQjNBzs3El66r0qOPFQ0kJq+zPfHUwCk5rgo=
 github.com/ONSdigital/dp-cache v0.1.0 h1:qA/iqVe+vBpQPbvkwW/OU3bdJUjcerSjU29fix53JcM=
 github.com/ONSdigital/dp-cache v0.1.0/go.mod h1:Vz9L0Dj7arGo8cYOOs/xHqT0rxOmVLZtfBZfZT87E14=
 github.com/ONSdigital/dp-cookies v0.3.3 h1:KXX4swf+OnljIYbsTYICIBjuRJoxQukGWKBTvBaISlA=

--- a/handlers/clients.go
+++ b/handlers/clients.go
@@ -51,6 +51,8 @@ type FilesAPIClient interface {
 // PopulationClient is an interface with methods required for a population client
 type PopulationClient interface {
 	GetAreas(ctx context.Context, input population.GetAreasInput) (population.GetAreasResponse, error)
+	GetArea(ctx context.Context, input population.GetAreaInput) (population.GetAreaResponse, error)
+	GetParentAreaCount(ctx context.Context, input population.GetParentAreaCountInput) (int, error)
 }
 
 // ClientError is an interface that can be used to retrieve the status code if a client has errored

--- a/handlers/filterable_landing_page.go
+++ b/handlers/filterable_landing_page.go
@@ -214,7 +214,7 @@ func censusLanding(ctx context.Context, w http.ResponseWriter, req *http.Request
 
 	showAll := req.URL.Query()[queryStrKey]
 	basePage := rend.NewBasePageModel()
-	m := mapper.CreateCensusDatasetLandingPage(ctx, req, basePage, datasetModel, version, opts, initialVersionReleaseDate, hasOtherVersions, allVersions, latestVersionNumber, latestVersionURL, lang, showAll, numOptsSummary, isValidationError, false, false, filter.Model{})
+	m := mapper.CreateCensusDatasetLandingPage(ctx, req, basePage, datasetModel, version, opts, initialVersionReleaseDate, hasOtherVersions, allVersions, latestVersionNumber, latestVersionURL, lang, showAll, numOptsSummary, isValidationError, false, false, map[string]filter.Download{}, []model.FilterDimension{})
 	rend.BuildPage(w, m, "census-landing")
 }
 

--- a/handlers/mock_clients.go
+++ b/handlers/mock_clients.go
@@ -371,6 +371,21 @@ func (m *MockPopulationClient) EXPECT() *MockPopulationClientMockRecorder {
 	return m.recorder
 }
 
+// GetArea mocks base method.
+func (m *MockPopulationClient) GetArea(ctx context.Context, input population.GetAreaInput) (population.GetAreaResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetArea", ctx, input)
+	ret0, _ := ret[0].(population.GetAreaResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetArea indicates an expected call of GetArea.
+func (mr *MockPopulationClientMockRecorder) GetArea(ctx, input interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetArea", reflect.TypeOf((*MockPopulationClient)(nil).GetArea), ctx, input)
+}
+
 // GetAreas mocks base method.
 func (m *MockPopulationClient) GetAreas(ctx context.Context, input population.GetAreasInput) (population.GetAreasResponse, error) {
 	m.ctrl.T.Helper()
@@ -384,6 +399,21 @@ func (m *MockPopulationClient) GetAreas(ctx context.Context, input population.Ge
 func (mr *MockPopulationClientMockRecorder) GetAreas(ctx, input interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAreas", reflect.TypeOf((*MockPopulationClient)(nil).GetAreas), ctx, input)
+}
+
+// GetParentAreaCount mocks base method.
+func (m *MockPopulationClient) GetParentAreaCount(ctx context.Context, input population.GetParentAreaCountInput) (int, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetParentAreaCount", ctx, input)
+	ret0, _ := ret[0].(int)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetParentAreaCount indicates an expected call of GetParentAreaCount.
+func (mr *MockPopulationClientMockRecorder) GetParentAreaCount(ctx, input interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetParentAreaCount", reflect.TypeOf((*MockPopulationClient)(nil).GetParentAreaCount), ctx, input)
 }
 
 // MockClientError is a mock of ClientError interface.

--- a/model/dimension.go
+++ b/model/dimension.go
@@ -1,5 +1,7 @@
 package model
 
+import "github.com/ONSdigital/dp-api-clients-go/v2/filter"
+
 // Dimension represents the data for a single dimension
 type Dimension struct {
 	Title             string   `json:"title"`
@@ -12,8 +14,13 @@ type Dimension struct {
 	IsCoverage        bool     `json:"is_coverage"`
 	IsDefaultCoverage bool     `json:"is_default_coverage"`
 	ShowChange        bool     `json:"show_change"`
-	ChangeURL         string   `json:"change_url"`
 	IsTruncated       bool     `json:"is_truncated"`
 	TruncateLink      string   `json:"truncate_link"`
 	ID                string   `json:"id"`
+}
+
+// FilterDimension represents a DTO for filter.Dimension with the additional OptionsCount field
+type FilterDimension struct {
+	filter.ModelDimension
+	OptionsCount int
 }


### PR DESCRIPTION
### What

- Implemented `pc.GetParentAreaCount` 
- Used `total_count` field to remove need to measure lengths of arrays
- Replaced `pc.GetAreas` with `pc.GetArea` where necessary
- Removed 'changeURL' functionality (missed from [previous PR](https://github.com/ONSdigital/dp-frontend-dataset-controller/pull/317) 😊 )  
- ✅ resolves [trello ticket - Fix count on pages that GetArea(s)](https://trello.com/c/cKGTgs1o/5843-fix-count-on-pages-that-getareas)

### How to review

- Sense check
- Tests pass
- Media review

Image shows when the use add a parent area of England the count in brackets equals 2 ✅
<img width="1032" alt="image" src="https://user-images.githubusercontent.com/19624419/191982509-9dac354c-a795-4189-8f43-c9125f866c0b.png">

### Who can review

Frontend go dev
