### PR TITLE
feature/separate thousands with a comma

### DIFF
--- a/assets/templates/partials/census/variables-table.tmpl
+++ b/assets/templates/partials/census/variables-table.tmpl
@@ -31,7 +31,7 @@
                                     {{ if $dim.IsDefaultCoverage }}
                                         {{- localise "AreaTypeDefaultCoverage" $language 1 -}}
                                     {{ else }}
-                                        {{- $dim.Title }} ({{ $dim.TotalItems -}})
+                                        {{- $dim.Title }} ({{ thousandsSeparator $dim.TotalItems -}})
                                     {{ end }}
                                 </div>
                             {{else}}

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/ONSdigital/dp-healthcheck v1.4.0-beta
 	github.com/ONSdigital/dp-net v1.5.0
 	github.com/ONSdigital/dp-net/v2 v2.5.0-beta
-	github.com/ONSdigital/dp-renderer v1.48.0
+	github.com/ONSdigital/dp-renderer v1.51.0
 	github.com/ONSdigital/log.go/v2 v2.3.0-beta
 	github.com/PuerkitoBio/goquery v1.8.0
 	github.com/golang/mock v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -30,8 +30,8 @@ github.com/ONSdigital/dp-net v1.5.0 h1:H47O5N+eXyXCYqPoQGWwuK12uLds3pCgzxpYwepg+
 github.com/ONSdigital/dp-net v1.5.0/go.mod h1:d/S4n6FJlQwmVIa2rnVt1HnAUgM8XsG0QEJBQp48uGg=
 github.com/ONSdigital/dp-net/v2 v2.5.0-beta h1:be/sM3nEXy5ejU/bvpO/KigUXcfED9o6c+zAh/V2K74=
 github.com/ONSdigital/dp-net/v2 v2.5.0-beta/go.mod h1:QJK9K2N8qwjMS5nZEzxSVALxJ/72KHAFDyFLj/mdLtw=
-github.com/ONSdigital/dp-renderer v1.48.0 h1:bdlCYYY/cSOFLUbyHyr0XA9L0EsKIk9KTeQmKvq7K3I=
-github.com/ONSdigital/dp-renderer v1.48.0/go.mod h1:q/zlK9Qc7b95w7XPfgS7RPLID++CZgaAn0q51QCqZew=
+github.com/ONSdigital/dp-renderer v1.51.0 h1:UVhmDKsancu5Ism54wH83w+JRG3urGWgm7pd5EihTW8=
+github.com/ONSdigital/dp-renderer v1.51.0/go.mod h1:q/zlK9Qc7b95w7XPfgS7RPLID++CZgaAn0q51QCqZew=
 github.com/ONSdigital/dp-topic-api v0.13.1 h1:3D+COy0REDTIBx76bfOoJi7M6pBmZNeXwiqx4wOoL3k=
 github.com/ONSdigital/dp-topic-api v0.13.1/go.mod h1:MipguYB6NVmJtzcdvmQ2DDpVY31PPPOiSFiWDzV5bWw=
 github.com/ONSdigital/go-ns v0.0.0-20191104121206-f144c4ec2e58/go.mod h1:iWos35il+NjbvDEqwtB736pyHru0MPFE/LqcwkV1wDc=


### PR DESCRIPTION
### What

- Used template helper function to convert `int` to a `string` with 1000s separated by a comma, as per the [style guide](https://style.ons.gov.uk/category/house-style/numbers/).
- ✅ resolves [trello ticket - Display commas to separate thousands in total count displayed to the user](https://trello.com/c/BBxlqgjq/5868-display-commas-to-separate-thousands-in-total-count-displayed-to-the-user)

### How to review

Sense check

### Who can review

Frontend go dev
