### PR TITLE
Fix/add missing value

### DIFF
--- a/mapper/census.go
+++ b/mapper/census.go
@@ -375,6 +375,7 @@ func mapFilterOutputDims(dims []sharedModel.FilterDimension, queryStrValues []st
 		pDim := sharedModel.Dimension{}
 		pDim.Title = dim.Label
 		pDim.ID = dim.ID
+		pDim.Name = dim.Name
 		pDim.IsAreaType = isAreaType
 		pDim.ShowChange = isAreaType
 		pDim.TotalItems = dim.OptionsCount

--- a/mapper/census_test.go
+++ b/mapper/census_test.go
@@ -192,6 +192,7 @@ func TestCreateCensusDatasetLandingPage(t *testing.T) {
 		So(page.DatasetLandingPage.Dimensions[0].Title, ShouldEqual, fDims[0].Label)
 		So(page.DatasetLandingPage.Dimensions[0].Values, ShouldResemble, fDims[0].Options)
 		So(page.DatasetLandingPage.Dimensions[0].ShowChange, ShouldBeTrue)
+		So(page.DatasetLandingPage.Dimensions[0].Name, ShouldEqual, fDims[0].Name)
 		So(page.DatasetLandingPage.Dimensions[1].IsCoverage, ShouldBeTrue)
 		So(page.DatasetLandingPage.Dimensions[1].Values, ShouldResemble, fDims[0].Options)
 		So(page.DatasetLandingPage.Dimensions[1].ShowChange, ShouldBeTrue)


### PR DESCRIPTION
### What

Mapped `name` field. This is required to ensure that the user is redirected to the change `area type` page when creating a new filter record

### How to review

- Sense check
- Tests pass

### Who can review

!me
