### PR TITLE
Fix/hide spinner when polling has finished

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -38,7 +38,7 @@ func Get() (*Config, error) {
 	if cfg.Debug {
 		cfg.PatternLibraryAssetsPath = "http://localhost:9002/dist/assets"
 	} else {
-		cfg.PatternLibraryAssetsPath = "//cdn.ons.gov.uk/dp-design-system/a5fd7d0"
+		cfg.PatternLibraryAssetsPath = "//cdn.ons.gov.uk/dp-design-system/51a7546"
 	}
 
 	return cfg, nil

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -31,7 +31,7 @@ func TestConfig(t *testing.T) {
 				So(cfg.HealthCheckInterval, ShouldEqual, 30*time.Second)
 				So(cfg.HealthCheckCriticalTimeout, ShouldEqual, 90*time.Second)
 				So(cfg.EnableProfiler, ShouldBeFalse)
-				So(cfg.PatternLibraryAssetsPath, ShouldEqual, "//cdn.ons.gov.uk/dp-design-system/a5fd7d0")
+				So(cfg.PatternLibraryAssetsPath, ShouldEqual, "//cdn.ons.gov.uk/dp-design-system/51a7546")
 			})
 		})
 	})


### PR DESCRIPTION
### What

Hide spinner when polling has finished := update to dp-design-system commit hash
✅  **Resolves** trello ticket [BUG: hide spinner when polling has concluded](https://trello.com/c/yshWbxTu/5918-bug-hide-spinner-when-polling-has-concluded)

### How to review

Sense check

### Who can review

!me
