### PR TITLE
Hotfix/remove calls to parent area count

### DIFF
--- a/assets/templates/partials/census/variables-table.tmpl
+++ b/assets/templates/partials/census/variables-table.tmpl
@@ -32,7 +32,7 @@
                                     {{ if $dim.IsDefaultCoverage }}
                                         {{- localise "AreaTypeDefaultCoverage" $language 1 -}}
                                     {{ else }}
-                                        {{- $dim.Title }} ({{ thousandsSeparator $dim.TotalItems -}})
+                                        {{- $dim.Title }}
                                     {{ end }}
                                 </div>
                             {{else}}

--- a/handlers/filter_output.go
+++ b/handlers/filter_output.go
@@ -221,30 +221,31 @@ func filterOutput(w http.ResponseWriter, req *http.Request, zc ZebedeeClient, dc
 			return nil, 0, fmt.Errorf("failed to get dimension areas")
 		}
 
-		if dim.FilterByParent != "" {
+		// TODO: Hotfix to remove api call due to graphQL error
+		// if dim.FilterByParent != "" {
 
-			count, err := pc.GetParentAreaCount(ctx, population.GetParentAreaCountInput{
-				AuthTokens: population.AuthTokens{
-					UserAuthToken: userAccessToken,
-				},
-				PopulationType:   filterOutput.PopulationType,
-				AreaTypeID:       dim.ID,
-				ParentAreaTypeID: dim.FilterByParent,
-				Areas:            optsIDs,
-			})
+		// 	count, err := pc.GetParentAreaCount(ctx, population.GetParentAreaCountInput{
+		// 		AuthTokens: population.AuthTokens{
+		// 			UserAuthToken: userAccessToken,
+		// 		},
+		// 		PopulationType:   filterOutput.PopulationType,
+		// 		AreaTypeID:       dim.ID,
+		// 		ParentAreaTypeID: dim.FilterByParent,
+		// 		Areas:            optsIDs,
+		// 	})
 
-			if err != nil {
-				log.Error(ctx, "failed to get parent area count", err, log.Data{
-					"dataset_id":          filterOutput.PopulationType,
-					"area_type_id":        dim.ID,
-					"parent_area_type_id": dim.FilterByParent,
-					"areas":               optsIDs,
-				})
-				return nil, 0, err
-			}
+		// 	if err != nil {
+		// 		log.Error(ctx, "failed to get parent area count", err, log.Data{
+		// 			"dataset_id":          filterOutput.PopulationType,
+		// 			"area_type_id":        dim.ID,
+		// 			"parent_area_type_id": dim.FilterByParent,
+		// 			"areas":               optsIDs,
+		// 		})
+		// 		return nil, 0, err
+		// 	}
 
-			totalCount = count
-		}
+		// 	totalCount = count
+		// }
 
 		return options, totalCount, nil
 	}

--- a/handlers/filter_output_test.go
+++ b/handlers/filter_output_test.go
@@ -635,10 +635,11 @@ func TestFilterOutputHandler(t *testing.T) {
 						EXPECT().
 						GetArea(gomock.Any(), gomock.Any()).
 						Return(population.GetAreaResponse{}, nil)
-					mockPc.
-						EXPECT().
-						GetParentAreaCount(gomock.Any(), gomock.Any()).
-						Return(0, nil)
+					// TODO: Hotfix to remove api call due to graphQL error
+					// mockPc.
+					// 	EXPECT().
+					// 	GetParentAreaCount(gomock.Any(), gomock.Any()).
+					// 	Return(0, nil)
 
 					mockRend := NewMockRenderClient(mockCtrl)
 					mockRend.
@@ -868,69 +869,70 @@ func TestFilterOutputHandler(t *testing.T) {
 				})
 			})
 
-			Convey("and the additional call to pc.GetParentAreaCount fails", func() {
-				mockDc := NewMockDatasetClient(mockCtrl)
-				mockDc.
-					EXPECT().
-					Get(ctx, userAuthToken, serviceAuthToken, collectionID, "12345").
-					Return(dataset.DatasetDetails{
-						Contacts: &[]dataset.Contact{{Name: "Nick"}},
-						Type:     "flexible",
-						URI:      "/economy/grossdomesticproduct/datasets/gdpjanuary2018",
-						Links: dataset.Links{
-							LatestVersion: dataset.Link{
-								URL: "/datasets/12345/editions/2021/versions/1",
-							},
-						},
-						ID: "12345",
-					}, nil)
-				mockDc.
-					EXPECT().
-					GetVersions(ctx, userAuthToken, serviceAuthToken, collectionID, "", "12345", "2021", &dataset.QueryParams{Offset: 0, Limit: 1000}).
-					Return(versions, nil)
-				mockDc.
-					EXPECT().
-					GetVersion(ctx, userAuthToken, serviceAuthToken, collectionID, "", "12345", "2021", "1").
-					Return(versions.Items[0], nil)
+			// TODO: Hotfix to remove api call due to graphQL error
+			// Convey("and the additional call to pc.GetParentAreaCount fails", func() {
+			// 	mockDc := NewMockDatasetClient(mockCtrl)
+			// 	mockDc.
+			// 		EXPECT().
+			// 		Get(ctx, userAuthToken, serviceAuthToken, collectionID, "12345").
+			// 		Return(dataset.DatasetDetails{
+			// 			Contacts: &[]dataset.Contact{{Name: "Nick"}},
+			// 			Type:     "flexible",
+			// 			URI:      "/economy/grossdomesticproduct/datasets/gdpjanuary2018",
+			// 			Links: dataset.Links{
+			// 				LatestVersion: dataset.Link{
+			// 					URL: "/datasets/12345/editions/2021/versions/1",
+			// 				},
+			// 			},
+			// 			ID: "12345",
+			// 		}, nil)
+			// 	mockDc.
+			// 		EXPECT().
+			// 		GetVersions(ctx, userAuthToken, serviceAuthToken, collectionID, "", "12345", "2021", &dataset.QueryParams{Offset: 0, Limit: 1000}).
+			// 		Return(versions, nil)
+			// 	mockDc.
+			// 		EXPECT().
+			// 		GetVersion(ctx, userAuthToken, serviceAuthToken, collectionID, "", "12345", "2021", "1").
+			// 		Return(versions.Items[0], nil)
 
-				mockFc := NewMockFilterClient(mockCtrl)
-				mockFc.
-					EXPECT().
-					GetOutput(ctx, gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-					Return(filterModels[3], nil)
-				mockFc.
-					EXPECT().
-					GetDimensionOptions(ctx, gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-					Return(filter.DimensionOptions{
-						Items: []filter.DimensionOption{
-							{
-								Option: "area 1",
-							},
-						},
-						TotalCount: 1,
-					}, "", nil)
+			// 	mockFc := NewMockFilterClient(mockCtrl)
+			// 	mockFc.
+			// 		EXPECT().
+			// 		GetOutput(ctx, gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+			// 		Return(filterModels[3], nil)
+			// 	mockFc.
+			// 		EXPECT().
+			// 		GetDimensionOptions(ctx, gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+			// 		Return(filter.DimensionOptions{
+			// 			Items: []filter.DimensionOption{
+			// 				{
+			// 					Option: "area 1",
+			// 				},
+			// 			},
+			// 			TotalCount: 1,
+			// 		}, "", nil)
 
-				mockPc := NewMockPopulationClient(mockCtrl)
-				mockPc.
-					EXPECT().
-					GetArea(gomock.Any(), gomock.Any()).
-					Return(population.GetAreaResponse{}, nil)
-				mockPc.
-					EXPECT().
-					GetParentAreaCount(gomock.Any(), gomock.Any()).
-					Return(0, errors.New("area parent count client error"))
+			// 	mockPc := NewMockPopulationClient(mockCtrl)
+			// 	mockPc.
+			// 		EXPECT().
+			// 		GetArea(gomock.Any(), gomock.Any()).
+			// 		Return(population.GetAreaResponse{}, nil)
+			// 	mockPc.
+			// 		EXPECT().
+			// 		GetParentAreaCount(gomock.Any(), gomock.Any()).
+			// 		Return(0, errors.New("area parent count client error"))
 
-				w := httptest.NewRecorder()
-				req := httptest.NewRequest("GET", "/datasets/12345/editions/2021/versions/1/filter-outputs/67890", nil)
+			// 	w := httptest.NewRecorder()
+			// 	req := httptest.NewRequest("GET", "/datasets/12345/editions/2021/versions/1/filter-outputs/67890", nil)
 
-				router := mux.NewRouter()
-				router.HandleFunc("/datasets/{datasetID}/editions/{editionID}/versions/{versionID}/filter-outputs/{filterOutputID}", FilterOutput(mockZebedeeClient, mockFc, mockPc, mockDc, NewMockRenderClient(mockCtrl), cfg, ""))
+			// 	router := mux.NewRouter()
+			// 	router.HandleFunc("/datasets/{datasetID}/editions/{editionID}/versions/{versionID}/filter-outputs/{filterOutputID}", FilterOutput(mockZebedeeClient, mockFc, mockPc, mockDc, NewMockRenderClient(mockCtrl), cfg, ""))
 
-				router.ServeHTTP(w, req)
-				Convey("Then the status code is 500", func() {
-					So(w.Code, ShouldEqual, http.StatusInternalServerError)
-				})
-			})
+			// 	router.ServeHTTP(w, req)
+			// 	Convey("Then the status code is 500", func() {
+			// 		So(w.Code, ShouldEqual, http.StatusInternalServerError)
+			// 	})
+			// })
 		})
 	})
 }


### PR DESCRIPTION
### What

Temporarily removed calls to `GetParentAreasCount` due to a production graphQL error

### How to review

Sense check
Tests pass

### Who can review

!me
