### PR TITLE
fix/hardcoding xlsx label

### DIFF
--- a/assets/templates/partials/census/get-data.tmpl
+++ b/assets/templates/partials/census/get-data.tmpl
@@ -29,7 +29,14 @@
                             <span class="ons-radios__item ons-radios__item--no-border ons-u-mb-s">
                                 <span class="ons-radio ons-radio--no-border">
                                     <input type="radio" id="{{ .Extension }}" class="ons-radio__input ons-js-radio" value="{{ .Extension }}" name="format">
-                                    <label class="ons-radio__label{{ if or (eq .Extension "txt") (eq .Extension "csvw") (eq .Extension "xls") }} ons-label--with-description{{ end }}" for="{{ .Extension }}" id="{{ .Extension }}-label"><span class="ons-u-tt-u">{{ .Extension }}</span> format ({{ humanSize .Size }})
+                                    <label class="ons-radio__label{{ if or (eq .Extension "txt") (eq .Extension "csvw") (eq .Extension "xls") }} ons-label--with-description{{ end }}" for="{{ .Extension }}" id="{{ .Extension }}-label">
+                                        <span class="ons-u-tt-u">
+                                            {{ if or (eq .Extension "xls") (eq .Extension "xlsx") }}
+                                                xlsx
+                                            {{ else }}
+                                                {{ .Extension }}
+                                            {{ end }}
+                                        </span> format ({{ humanSize .Size }})
                                         <span id="{{ .Extension }}-label-description-hint" class="ons-label__description ons-radio__label--with-description">
                                             {{ if or (eq .Extension "xls") (eq .Extension "xlsx") }}
                                                 {{- localise "IncludesSupportingInfo" $.Language 1 -}}


### PR DESCRIPTION
### What

Hardcoding the `xlsx` label as the backend changes require multiple republications of existing datasets, this fix avoid that (for the frontend)

### How to review

Sense check

<img width="461" alt="hardcoded xlsx label" src="https://user-images.githubusercontent.com/19624419/207842164-252261f3-08c6-4263-ba99-132de86aadf1.png">

### Who can review

Frontend dev
