### PR TITLE
5983 remove categories count from label

### DIFF
--- a/mapper/census.go
+++ b/mapper/census.go
@@ -7,6 +7,7 @@ import (
 	"html/template"
 	"net/http"
 	"net/url"
+	"regexp"
 	"sort"
 	"strconv"
 	"strings"
@@ -411,7 +412,7 @@ func populateCollapsible(Dimensions []dataset.VersionDimension, isFilterOutput b
 		for _, dims := range Dimensions {
 			if dims.Description != "" {
 				var collapsibleContent coreModel.CollapsibleItem
-				collapsibleContent.Subheading = dims.Label
+				collapsibleContent.Subheading = cleanDimensionLabel(dims.Label)
 				collapsibleContent.Content = strings.Split(dims.Description, "\n")
 				collapsibleContentItems = append(collapsibleContentItems, collapsibleContent)
 			}
@@ -433,7 +434,7 @@ func mapCensusOptionsToDimensions(dims []dataset.VersionDimension, opts []datase
 				pDim.Description = dimension.Description
 				pDim.IsAreaType = helpers.IsBoolPtr(dimension.IsAreaType)
 				pDim.ShowChange = pDim.IsAreaType && isFlex || isMultivariate
-				pDim.Title = dimension.Label
+				pDim.Title = cleanDimensionLabel(dimension.Label)
 				pDim.ID = dimension.ID
 				if dimension.QualityStatementText != "" && dimension.QualityStatementURL != "" {
 					qs = append(qs, datasetLandingPageCensus.Panel{
@@ -482,7 +483,7 @@ func mapFilterOutputDims(dims []sharedModel.FilterDimension, queryStrValues []st
 			isAreaType = true
 		}
 		pDim := sharedModel.Dimension{}
-		pDim.Title = dim.Label
+		pDim.Title = cleanDimensionLabel(dim.Label)
 		pDim.ID = dim.ID
 		pDim.Name = dim.Name
 		pDim.IsAreaType = isAreaType
@@ -533,6 +534,13 @@ func generateTruncatePath(path, dimID string, q url.Values) string {
 		truncatePath += fmt.Sprintf("#%s", dimID)
 	}
 	return truncatePath
+}
+
+// cleanDimensionlabel is a helper function that parses dimension labels from cantabular into display text
+func cleanDimensionLabel(label string) string {
+	matcher := regexp.MustCompile(`(\(\d+ ((C|c)ategories|(C|c)ategory)\))`)
+	result := matcher.ReplaceAllString(label, "")
+	return strings.TrimSpace(result)
 }
 
 func getDataLayerJavaScript(analytics map[string]string) template.JS {

--- a/mapper/census_test.go
+++ b/mapper/census_test.go
@@ -214,6 +214,41 @@ func TestCreateCensusDatasetLandingPage(t *testing.T) {
 		So(page.ShowCensusBranding, ShouldBeTrue)
 	})
 
+	Convey("Census dataset landing page formats dimension labels", t, func() {
+		withDimensionLabelsDetails := dataset.Version{
+			ReleaseDate: "01-01-2021",
+			Downloads:   map[string]dataset.Download{},
+			Edition:     "2021",
+			Version:     1,
+			Links:       dataset.Links{},
+			Dimensions: []dataset.VersionDimension{
+				{
+					Description:          "A description on one line",
+					Name:                 "dim_1",
+					ID:                   "dim_1",
+					Label:                "Label 1 (1 Category)",
+					IsAreaType:           helpers.ToBoolPtr(true),
+					QualityStatementText: "This is a quality notice statement",
+					QualityStatementURL:  "#",
+				},
+				{
+					Description:          "A description on one line \n Then a line break",
+					Name:                 "dim_2",
+					Label:                "Label 2 (100 categories)",
+					ID:                   "dim_2",
+					QualityStatementText: "This is another quality notice statement",
+					QualityStatementURL:  "#",
+				},
+			},
+		}
+
+		page := CreateCensusDatasetLandingPage(true, context.Background(), req, pageModel, datasetModel, withDimensionLabelsDetails, datasetOptions, "", false, []dataset.Version{versionOneDetails}, 1, "/a/version/1", "", []string{}, 50, false, false, false, map[string]filter.Download{}, []sharedModel.FilterDimension{}, serviceMessage, emergencyBanner)
+
+		So(page.Collapsible.CollapsibleItems[2].Subheading, ShouldEqual, "Label 1")
+		So(page.Collapsible.CollapsibleItems[3].Subheading, ShouldEqual, "Label 2")
+		So(page.DatasetLandingPage.Dimensions[0].Title, ShouldEqual, "Label 1")
+	})
+
 	Convey("Census dataset landing page maps correctly with filter output", t, func() {
 		datasetModel.Type = "flexible"
 		page := CreateCensusDatasetLandingPage(true, context.Background(), req, pageModel, datasetModel, versionOneDetails, datasetOptions, "", false, []dataset.Version{versionOneDetails}, 1, "/a/version/1", "", []string{}, 50, false, true, true, filterOutput, fDims, serviceMessage, emergencyBanner)
@@ -1366,4 +1401,13 @@ func TestCreateCensusDatasetLandingPage(t *testing.T) {
 
 	})
 
+}
+
+func TestCleanDimensionsLabel(t *testing.T) {
+	Convey("Removes categories count from label - case insensitive", t, func() {
+		So(cleanDimensionLabel("Example (100 categories)"), ShouldEqual, "Example")
+		So(cleanDimensionLabel("Example (7 Categories)"), ShouldEqual, "Example")
+		So(cleanDimensionLabel("Example (1 category)"), ShouldEqual, "Example")
+		So(cleanDimensionLabel("Example (1 Category)"), ShouldEqual, "Example")
+	})
 }

--- a/mapper/census_test.go
+++ b/mapper/census_test.go
@@ -1427,5 +1427,8 @@ func TestCleanDimensionsLabel(t *testing.T) {
 		So(cleanDimensionLabel("Example (7 Categories)"), ShouldEqual, "Example")
 		So(cleanDimensionLabel("Example (1 category)"), ShouldEqual, "Example")
 		So(cleanDimensionLabel("Example (1 Category)"), ShouldEqual, "Example")
+		So(cleanDimensionLabel(""), ShouldEqual, "")
+		So(cleanDimensionLabel("Example 1 category"), ShouldEqual, "Example 1 category")
+		So(cleanDimensionLabel("Example (something in brackets) (1 Category)"), ShouldEqual, "Example (something in brackets)")
 	})
 }

--- a/mapper/census_test.go
+++ b/mapper/census_test.go
@@ -284,6 +284,24 @@ func TestCreateCensusDatasetLandingPage(t *testing.T) {
 		So(page.SearchNoIndexEnabled, ShouldBeTrue)
 	})
 
+	Convey("Census dataset landing page formats dimension labels with filter output", t, func() {
+		datasetModel.Type = "flexible"
+		fDimsWithCounts := []sharedModel.FilterDimension{
+			{
+				ModelDimension: filter.ModelDimension{
+					Label:      "Label 1 (100 categories)",
+					Options:    []string{"An option", "and another"},
+					IsAreaType: helpers.ToBoolPtr(true),
+					Name:       "Geography",
+				},
+				OptionsCount: 2,
+			},
+		}
+		page := CreateCensusDatasetLandingPage(true, context.Background(), req, pageModel, datasetModel, versionOneDetails, datasetOptions, "", false, []dataset.Version{versionOneDetails}, 1, "/a/version/1", "", []string{}, 50, false, true, true, filterOutput, fDimsWithCounts, serviceMessage, emergencyBanner)
+
+		So(page.DatasetLandingPage.Dimensions[0].Title, ShouldEqual, "Label 1")
+	})
+
 	Convey("Release date and hasOtherVersions is mapped correctly when v2 of Census DLP dataset is loaded", t, func() {
 		req := httptest.NewRequest("", "/datasets/cantabular-1/editions/2021/versions/2", nil)
 		page := CreateCensusDatasetLandingPage(true, context.Background(), req, pageModel, datasetModel, versionTwoDetails, datasetOptions, versionOneDetails.ReleaseDate, true, []dataset.Version{versionOneDetails, versionTwoDetails}, 2, "/a/version/123", "", []string{}, 50, false, false, false, map[string]filter.Download{}, []sharedModel.FilterDimension{}, serviceMessage, emergencyBanner)


### PR DESCRIPTION
### What
The metadata service includes category count as part of the dimension label i.e. "Age (100 Categories)". This PR removes the (100 Categories) part.

Changes in this service are made to ...

* Summary of variables on dataset landing page
* Summary of variables on filter outputs page

Before
![image](https://user-images.githubusercontent.com/6823289/211528019-579a2eae-8952-42b7-999b-9620c6812bb0.png)

After
![image](https://user-images.githubusercontent.com/6823289/211527707-ba69a45e-2669-4f49-8322-fc301d370125.png)

### How to review
Sense check
Media review
Tests pass

### Who can review
Frontend Go dev