### PR TITLE
feature/remove 'enable_census_pages' feature toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,23 +6,22 @@ An HTTP service for the controlling of data and rendering templates relevant to 
 
 ## Configuration
 
-| Environment variable         | Default                   | Description                                                                                          |
-| ---------------------------- | ------------------------- | ---------------------------------------------------------------------------------------------------- |
-| BIND_ADDR                    | :20200                    | The host and port to bind to.                                                                        |
-| DEBUG                        | false                     | Enable debug mode                                                                                    |
-| ENABLE_CENSUS_PAGES          | false                     | Enable 2021 census pages                                                                             |
-| ENABLE_MULTIVARIATE          | false                     | Enable 2021 [multivariate datasets](https://github.com/ONSdigital/dp-dataset-api/blob/5f9f4218b65aae4803809f4a876e9f72b9bf5305/models/dataset.go#L43); use with ENABLE_CENSUS_PAGES                                      |
-| API_ROUTER_URL               | http://localhost:23200/v1 | The URL of the [dp-api-router](https://github.com/ONSdigital/dp-api-router)                          |
+| Environment variable         | Default                   | Description                                                                                                                                           |
+| ---------------------------- | ------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
+| BIND_ADDR                    | :20200                    | The host and port to bind to.                                                                                                                         |
+| DEBUG                        | false                     | Enable debug mode                                                                                                                                     |
+| ENABLE_MULTIVARIATE          | false                     | Enable 2021 [multivariate datasets](https://github.com/ONSdigital/dp-dataset-api/blob/5f9f4218b65aae4803809f4a876e9f72b9bf5305/models/dataset.go#L43) |
+| API_ROUTER_URL               | http://localhost:23200/v1 | The URL of the [dp-api-router](https://github.com/ONSdigital/dp-api-router)                                                                           |
 | SITE_DOMAIN                  | localhost                 |
-| PATTERN_LIBRARY_ASSETS_PATH  | ""                        | Pattern library location                                                                             |
-| SUPPORTED_LANGUAGES          | []string{"en", "cy"}      | Supported languages                                                                                  |
-| DOWNLOAD_SERVICE_URL         | http://localhost:23600    | The URL of [dp-download-service](https://www.github.com/ONSdigital/dp-download-service).             |
-| GRACEFUL_SHUTDOWN_TIMEOUT    | 5s                        | The graceful shutdown timeout in seconds                                                             |
-| HEALTHCHECK_INTERVAL         | 30s                       | The time between calling healthcheck endpoints for check subsystems                                  |
-| HEALTHCHECK_CRITICAL_TIMEOUT | 90s                       | The time taken for the health changes from warning state to critical due to subsystem check failures |
-| ENABLE_PROFILER              | false                     | Flag to enable go profiler                                                                           |
-| PPROF_TOKEN                  | ""                        | The profiling token to access service profiling                                                      |
-| ENABLE_NEW_NAV_BAR           | false                     | Enable new nav bar                                                                                   |
+| PATTERN_LIBRARY_ASSETS_PATH  | ""                        | Pattern library location                                                                                                                              |
+| SUPPORTED_LANGUAGES          | []string{"en", "cy"}      | Supported languages                                                                                                                                   |
+| DOWNLOAD_SERVICE_URL         | http://localhost:23600    | The URL of [dp-download-service](https://www.github.com/ONSdigital/dp-download-service).                                                              |
+| GRACEFUL_SHUTDOWN_TIMEOUT    | 5s                        | The graceful shutdown timeout in seconds                                                                                                              |
+| HEALTHCHECK_INTERVAL         | 30s                       | The time between calling healthcheck endpoints for check subsystems                                                                                   |
+| HEALTHCHECK_CRITICAL_TIMEOUT | 90s                       | The time taken for the health changes from warning state to critical due to subsystem check failures                                                  |
+| ENABLE_PROFILER              | false                     | Flag to enable go profiler                                                                                                                            |
+| PPROF_TOKEN                  | ""                        | The profiling token to access service profiling                                                                                                       |
+| ENABLE_NEW_NAV_BAR           | false                     | Enable new nav bar                                                                                                                                    |
 
 ## Profiling
 

--- a/config/config.go
+++ b/config/config.go
@@ -12,7 +12,6 @@ var cfg *Config
 type Config struct {
 	BindAddr                      string        `envconfig:"BIND_ADDR"`
 	Debug                         bool          `envconfig:"DEBUG"`
-	EnableCensusPages             bool          `envconfig:"ENABLE_CENSUS_PAGES"`
 	EnableMultivariate            bool          `envconfig:"ENABLE_MULTIVARIATE"`
 	APIRouterURL                  string        `envconfig:"API_ROUTER_URL"`
 	SiteDomain                    string        `envconfig:"SITE_DOMAIN"`
@@ -53,7 +52,6 @@ func get() (*Config, error) {
 	cfg = &Config{
 		BindAddr:                      "localhost:20200",
 		Debug:                         false,
-		EnableCensusPages:             false,
 		EnableMultivariate:            false,
 		APIRouterURL:                  "http://localhost:23200/v1",
 		DownloadServiceURL:            "http://localhost:23600",

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -22,7 +22,6 @@ func TestConfig(t *testing.T) {
 			Convey("That the values should be set to the expected defaults", func() {
 				So(cfg.BindAddr, ShouldEqual, "localhost:20200")
 				So(cfg.Debug, ShouldBeFalse)
-				So(cfg.EnableCensusPages, ShouldBeFalse)
 				So(cfg.EnableMultivariate, ShouldBeFalse)
 				So(cfg.APIRouterURL, ShouldEqual, "http://localhost:23200/v1")
 				So(cfg.DownloadServiceURL, ShouldEqual, "http://localhost:23600")

--- a/handlers/filter_output_test.go
+++ b/handlers/filter_output_test.go
@@ -21,7 +21,7 @@ func TestFilterOutputHandler(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
 	ctx := gomock.Any()
-	cfg := config.Config{EnableCensusPages: true}
+	cfg := config.Config{}
 	versions := dataset.VersionsList{
 		Items: []dataset.Version{
 			{

--- a/handlers/filterable_landing_page.go
+++ b/handlers/filterable_landing_page.go
@@ -91,7 +91,7 @@ func filterableLanding(w http.ResponseWriter, req *http.Request, dc DatasetClien
 		return
 	}
 
-	if cfg.EnableCensusPages && strings.Contains(datasetModel.Type, "cantabular") {
+	if strings.Contains(datasetModel.Type, "cantabular") {
 		censusLanding(cfg.EnableMultivariate, ctx, w, req, dc, datasetModel, rend, edition, ver, displayOtherVersionsLink, allVers.Items, latestVersionNumber, latestVersionURL, collectionID, lang, userAccessToken, homepageContent.ServiceMessage, homepageContent.EmergencyBanner)
 		return
 	}

--- a/handlers/filterable_landing_page_test.go
+++ b/handlers/filterable_landing_page_test.go
@@ -162,7 +162,7 @@ func TestFilterableLandingPage(t *testing.T) {
 		mockZebedeeClient.EXPECT().GetHomepageContent(ctx, userAuthToken, collectionID, locale, "/")
 		mockRend := NewMockRenderClient(mockCtrl)
 		Convey("filterable landing handler returns census landing template for cantabular types", func() {
-			mockConfig := config.Config{EnableCensusPages: true}
+			mockConfig := config.Config{}
 			mockClient.EXPECT().Get(ctx, userAuthToken, serviceAuthToken, collectionID, "12345").Return(dataset.DatasetDetails{Contacts: &[]dataset.Contact{{Name: "Nick"}}, Type: "cantabular-table", URI: "/economy/grossdomesticproduct/datasets/gdpjanuary2018", Links: dataset.Links{LatestVersion: dataset.Link{URL: "/datasets/12345/editions/2021/versions/1"}}, ID: "12345"}, nil)
 			versions := dataset.VersionsList{
 				Items: []dataset.Version{
@@ -206,7 +206,7 @@ func TestFilterableLandingPage(t *testing.T) {
 		})
 
 		Convey("census dataset landing page correctly fetches version 1 data for initial release date field, when loading a later version", func() {
-			mockConfig := config.Config{EnableCensusPages: true}
+			mockConfig := config.Config{}
 			mockClient.EXPECT().Get(ctx, userAuthToken, serviceAuthToken, collectionID, "12345").Return(dataset.DatasetDetails{Contacts: &[]dataset.Contact{{Name: "Nick"}}, Type: "cantabular-table", URI: "/economy/grossdomesticproduct/datasets/gdpjanuary2018", Links: dataset.Links{LatestVersion: dataset.Link{URL: "/datasets/12345/editions/2021/versions/2"}}, ID: "12345"}, nil)
 			versions := dataset.VersionsList{
 				Items: []dataset.Version{
@@ -232,7 +232,7 @@ func TestFilterableLandingPage(t *testing.T) {
 		})
 
 		Convey("census dataset landing page returns 200 when no downloadable files provided", func() {
-			mockConfig := config.Config{EnableCensusPages: true}
+			mockConfig := config.Config{}
 			mockClient.EXPECT().Get(ctx, userAuthToken, serviceAuthToken, collectionID, "12345").Return(dataset.DatasetDetails{Contacts: &[]dataset.Contact{{Name: "Nick"}}, Type: "cantabular-table", URI: "/economy/grossdomesticproduct/datasets/gdpjanuary2018", Links: dataset.Links{LatestVersion: dataset.Link{URL: "/datasets/12345/editions/2021/versions/1"}}, ID: "12345"}, nil)
 			versions := dataset.VersionsList{
 				Items: []dataset.Version{
@@ -266,7 +266,7 @@ func TestFilterableLandingPage(t *testing.T) {
 		})
 
 		Convey("census dataset landing page returns 302 when valid download option chosen", func() {
-			mockConfig := config.Config{EnableCensusPages: true}
+			mockConfig := config.Config{}
 			mockClient.EXPECT().Get(ctx, userAuthToken, serviceAuthToken, collectionID, "12345").Return(dataset.DatasetDetails{Contacts: &[]dataset.Contact{{Name: "Nick"}}, Type: "cantabular-table", URI: "/economy/grossdomesticproduct/datasets/gdpjanuary2018", Links: dataset.Links{LatestVersion: dataset.Link{URL: "/datasets/12345/editions/2021/versions/1"}}, ID: "12345"}, nil)
 			versions := dataset.VersionsList{
 				Items: []dataset.Version{
@@ -304,7 +304,7 @@ func TestFilterableLandingPage(t *testing.T) {
 		})
 
 		Convey("census dataset landing page returns 200 when invalid download option chosen", func() {
-			mockConfig := config.Config{EnableCensusPages: true}
+			mockConfig := config.Config{}
 			mockClient.EXPECT().Get(ctx, userAuthToken, serviceAuthToken, collectionID, "12345").Return(dataset.DatasetDetails{Contacts: &[]dataset.Contact{{Name: "Nick"}}, Type: "cantabular-table", URI: "/economy/grossdomesticproduct/datasets/gdpjanuary2018", Links: dataset.Links{LatestVersion: dataset.Link{URL: "/datasets/12345/editions/2021/versions/1"}}, ID: "12345"}, nil)
 			versions := dataset.VersionsList{
 				Items: []dataset.Version{
@@ -337,7 +337,7 @@ func TestFilterableLandingPage(t *testing.T) {
 		})
 
 		Convey("census dataset landing page returns 200 when unknown get query request made", func() {
-			mockConfig := config.Config{EnableCensusPages: true}
+			mockConfig := config.Config{}
 			mockClient.EXPECT().Get(ctx, userAuthToken, serviceAuthToken, collectionID, "12345").Return(dataset.DatasetDetails{Contacts: &[]dataset.Contact{{Name: "Nick"}}, Type: "cantabular-table", URI: "/economy/grossdomesticproduct/datasets/gdpjanuary2018", Links: dataset.Links{LatestVersion: dataset.Link{URL: "/datasets/12345/editions/2021/versions/1"}}, ID: "12345"}, nil)
 			versions := dataset.VersionsList{
 				Items: []dataset.Version{
@@ -368,55 +368,5 @@ func TestFilterableLandingPage(t *testing.T) {
 
 			So(w.Code, ShouldEqual, http.StatusOK)
 		})
-
-		Convey("filterable landing page returned if census config is false", func() {
-			const numOptsSummary = 50
-			mockConfig := config.Config{EnableCensusPages: false}
-			mockClient.EXPECT().Get(ctx, userAuthToken, serviceAuthToken, collectionID, "12345").Return(dataset.DatasetDetails{Contacts: &[]dataset.Contact{{Name: "Nick"}}, Type: "cantabular-table", URI: "/economy/grossdomesticproduct/datasets/gdpjanuary2018", Links: dataset.Links{LatestVersion: dataset.Link{URL: "/datasets/1234/editions/5678/versions/2017"}}}, nil)
-			versions := dataset.VersionsList{
-				Items: []dataset.Version{
-					{
-						Downloads:   nil,
-						ReleaseDate: "02-01-2005",
-						Version:     1,
-						Links: dataset.Links{
-							Self: dataset.Link{
-								URL: "/datasets/12345/editions/2016/versions/1",
-							},
-						},
-					},
-				},
-			}
-			mockClient.EXPECT().GetVersions(ctx, userAuthToken, serviceAuthToken, collectionID, "", "12345", "5678", &dataset.QueryParams{Offset: 0, Limit: 1000}).Return(versions, nil)
-			mockClient.EXPECT().GetVersion(ctx, userAuthToken, serviceAuthToken, collectionID, "", "12345", "5678", "2017").Return(versions.Items[0], nil)
-			dims := dataset.VersionDimensions{
-				Items: []dataset.VersionDimension{
-					{
-						Name: "aggregate",
-					},
-				},
-			}
-			mockClient.EXPECT().GetVersionDimensions(ctx, userAuthToken, serviceAuthToken, collectionID, "12345", "5678", "2017").Return(dims, nil)
-			mockClient.EXPECT().GetOptions(ctx, userAuthToken, serviceAuthToken, collectionID, "12345", "5678", "2017", "aggregate",
-				&dataset.QueryParams{Offset: 0, Limit: numOptsSummary}).Return(datasetOptions(0, numOptsSummary), nil)
-			mockClient.EXPECT().GetVersionMetadata(ctx, userAuthToken, serviceAuthToken, collectionID, "12345", "5678", "2017")
-			mockClient.EXPECT().GetOptions(ctx, userAuthToken, serviceAuthToken, collectionID, "12345", "5678", "2017", "aggregate",
-				&dataset.QueryParams{Offset: 0, Limit: maxMetadataOptions}).Return(datasetOptions(0, maxMetadataOptions), nil)
-			mockZebedeeClient.EXPECT().GetBreadcrumb(ctx, userAuthToken, collectionID, locale, "")
-
-			mockRend.EXPECT().NewBasePageModel().Return(coreModel.NewPage(cfg.PatternLibraryAssetsPath, cfg.SiteDomain))
-			mockRend.EXPECT().BuildPage(gomock.Any(), gomock.Any(), "filterable")
-
-			w := httptest.NewRecorder()
-			req := httptest.NewRequest("GET", "/datasets/12345", nil)
-
-			router := mux.NewRouter()
-			router.HandleFunc("/datasets/{datasetID}", FilterableLanding(mockClient, mockRend, mockZebedeeClient, mockConfig, "/v1"))
-
-			router.ServeHTTP(w, req)
-
-			So(w.Code, ShouldEqual, http.StatusOK)
-		})
 	})
-
 }

--- a/main.go
+++ b/main.go
@@ -148,14 +148,12 @@ func run(ctx context.Context) error {
 	router.Path("/datasets/{datasetID}/editions/{editionID}").Methods("GET").HandlerFunc(handlers.FilterableLanding(dc, rend, zc, *cfg, apiRouterVersion))
 	router.Path("/datasets/{datasetID}/editions/{edition}/versions").Methods("GET").HandlerFunc(handlers.VersionsList(dc, zc, rend, *cfg))
 	router.Path("/datasets/{datasetID}/editions/{editionID}/versions/{versionID}").Methods("GET").HandlerFunc(handlers.FilterableLanding(dc, rend, zc, *cfg, apiRouterVersion))
-	router.Path("/datasets/{datasetID}/editions/{edition}/versions/{version}/metadata.txt").Methods("GET").HandlerFunc(handlers.MetadataText(dc, *cfg))
-
+	router.Path("/datasets/{datasetID}/editions/{editionID}/versions/{versionID}").Methods("POST").HandlerFunc(handlers.CreateFilterFlexID(f, dc))
 	router.Path("/datasets/{datasetID}/editions/{editionID}/versions/{versionID}/filter").Methods("POST").HandlerFunc(handlers.CreateFilterID(f, dc))
-	if cfg.EnableCensusPages {
-		router.Path("/datasets/{datasetID}/editions/{editionID}/versions/{versionID}").Methods("POST").HandlerFunc(handlers.CreateFilterFlexID(f, dc))
-		router.Path("/datasets/{datasetID}/editions/{editionID}/versions/{versionID}/filter-outputs/{filterOutputID}").Methods("GET").HandlerFunc(handlers.FilterOutput(zc, f, pc, dc, rend, *cfg, apiRouterVersion))
-		router.Path("/datasets/{datasetID}/editions/{editionID}/versions/{versionID}/filter-outputs/{filterOutputID}").Methods("POST").HandlerFunc(handlers.CreateFilterFlexIDFromOutput(f))
-	}
+	router.Path("/datasets/{datasetID}/editions/{editionID}/versions/{versionID}/filter-outputs/{filterOutputID}").Methods("GET").HandlerFunc(handlers.FilterOutput(zc, f, pc, dc, rend, *cfg, apiRouterVersion))
+	router.Path("/datasets/{datasetID}/editions/{editionID}/versions/{versionID}/filter-outputs/{filterOutputID}").Methods("POST").HandlerFunc(handlers.CreateFilterFlexIDFromOutput(f))
+
+	router.Path("/datasets/{datasetID}/editions/{edition}/versions/{version}/metadata.txt").Methods("GET").HandlerFunc(handlers.MetadataText(dc, *cfg))
 
 	router.PathPrefix("/dataset/").Methods("GET").Handler(http.StripPrefix("/dataset/", handlers.DatasetPage(zc, rend, fc, cacheList)))
 	router.HandleFunc("/{uri:.*}", handlers.LegacyLanding(zc, dc, fc, rend, cacheList))


### PR DESCRIPTION
### What

Census pages are now live ([example page](https://www.ons.gov.uk/datasets/TS008/editions/2021/versions/3)) and although they are in `beta` the pages are very unlikely to be unpublished so the feature toggle `enable_census_pages` is redundant.
✅ **Resolves** trello ticket [Remove ENABLE_CENSUS_PAGES feature toggle from frontend dataset controller](https://trello.com/c/wFJczTrs/6039-remove-enablecensuspages-feature-toggle-from-frontend-dataset-controller)

### How to review

Sense check
Tests pass

### Who can review

!me
