### PR TITLE
Custom URLs for Create a dataset journey

### DIFF
--- a/handlers/clients.go
+++ b/handlers/clients.go
@@ -24,6 +24,7 @@ type FilterClient interface {
 	CreateFlexibleBlueprint(ctx context.Context, userAuthToken, serviceAuthToken, downloadServiceToken, collectionID, datasetID, edition, version string, dimensions []filter.ModelDimension, population_type string) (filterID, eTag string, err error)
 	GetOutput(ctx context.Context, userAuthToken, serviceAuthToken, downloadServiceToken, collectionID, filterOutputID string) (m filter.Model, err error)
 	GetDimensionOptions(ctx context.Context, userAuthToken, serviceAuthToken, collectionID, filterID, name string, q *filter.QueryParams) (opts filter.DimensionOptions, eTag string, err error)
+	CreateFlexibleBlueprintCustom(ctx context.Context, uAuthToken, svcAuthToken, dlServiceToken string, req filter.CreateFlexBlueprintCustomRequest) (filterID, eTag string, err error)
 }
 
 // DatasetClient is an interface with methods required for a dataset client

--- a/handlers/create_filter_id.go
+++ b/handlers/create_filter_id.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/ONSdigital/dp-api-clients-go/v2/dataset"
 	"github.com/ONSdigital/dp-api-clients-go/v2/filter"
+	"github.com/ONSdigital/dp-frontend-dataset-controller/helpers"
 	"github.com/ONSdigital/dp-net/v2/handlers"
 	"github.com/ONSdigital/log.go/v2/log"
 	"github.com/gorilla/mux"
@@ -134,7 +135,17 @@ func CreateFilterFlexIDFromOutput(fc FilterClient) http.HandlerFunc {
 			dims = append(dims, dim)
 		}
 
-		fid, _, err := fc.CreateFlexibleBlueprint(ctx, userAccessToken, "", "", collectionID, fo.Dataset.DatasetID, fo.Dataset.Edition, strconv.Itoa(fo.Dataset.Version), dims, fo.PopulationType)
+		fid := ""
+		isCustom := helpers.IsBoolPtr(fo.Custom)
+		if isCustom {
+			fid, _, err = fc.CreateFlexibleBlueprintCustom(ctx, userAccessToken, "", "", filter.CreateFlexBlueprintCustomRequest{
+				Dataset:        fo.Dataset,
+				Dimensions:     fo.Dimensions,
+				PopulationType: fo.PopulationType,
+			})
+		} else {
+			fid, _, err = fc.CreateFlexibleBlueprint(ctx, userAccessToken, "", "", collectionID, fo.Dataset.DatasetID, fo.Dataset.Edition, strconv.Itoa(fo.Dataset.Version), dims, fo.PopulationType)
+		}
 		if err != nil {
 			setStatusCode(ctx, w, err)
 			return

--- a/handlers/create_filter_id.go
+++ b/handlers/create_filter_id.go
@@ -140,8 +140,9 @@ func CreateFilterFlexIDFromOutput(fc FilterClient) http.HandlerFunc {
 		if isCustom {
 			fid, _, err = fc.CreateFlexibleBlueprintCustom(ctx, userAccessToken, "", "", filter.CreateFlexBlueprintCustomRequest{
 				Dataset:        fo.Dataset,
-				Dimensions:     fo.Dimensions,
+				Dimensions:     dims,
 				PopulationType: fo.PopulationType,
+				CollectionID:   collectionID,
 			})
 		} else {
 			fid, _, err = fc.CreateFlexibleBlueprint(ctx, userAccessToken, "", "", collectionID, fo.Dataset.DatasetID, fo.Dataset.Edition, strconv.Itoa(fo.Dataset.Version), dims, fo.PopulationType)

--- a/handlers/create_filter_id.go
+++ b/handlers/create_filter_id.go
@@ -120,6 +120,7 @@ func CreateFilterFlexIDFromOutput(fc FilterClient) http.HandlerFunc {
 
 		fo, err := fc.GetOutput(ctx, userAccessToken, "", "", collectionID, filterOutputID)
 		if err != nil {
+			log.Error(ctx, "unable to get filter output", err)
 			setStatusCode(ctx, w, err)
 			return
 		}
@@ -148,6 +149,7 @@ func CreateFilterFlexIDFromOutput(fc FilterClient) http.HandlerFunc {
 			fid, _, err = fc.CreateFlexibleBlueprint(ctx, userAccessToken, "", "", collectionID, fo.Dataset.DatasetID, fo.Dataset.Edition, strconv.Itoa(fo.Dataset.Version), dims, fo.PopulationType)
 		}
 		if err != nil {
+			log.Error(ctx, "unable to create new filter", err)
 			setStatusCode(ctx, w, err)
 			return
 		}

--- a/handlers/filter_output.go
+++ b/handlers/filter_output.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"sort"
@@ -45,17 +46,37 @@ func filterOutput(w http.ResponseWriter, req *http.Request, zc ZebedeeClient, dc
 	var dimCategories population.GetDimensionCategoriesResponse
 	var dimIds, areaOpts []string
 	var dmErr, versErr, verErr, fErr, dErr, sErr, dcErr error
+	var wg sync.WaitGroup
 
 	vars := mux.Vars(req)
+	ctx := req.Context()
 	datasetID := vars["datasetID"]
 	edition := vars["editionID"]
 	version := vars["versionID"]
 	filterOutputID := vars["filterOutputID"]
-	ctx := req.Context()
 
-	var wg sync.WaitGroup
-	wg.Add(4)
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		filterOutput, fErr = fc.GetOutput(ctx, userAccessToken, "", "", collectionID, filterOutputID)
+		for _, dim := range filterOutput.Dimensions {
+			dimIds = append(dimIds, dim.ID)
+		}
+	}()
 
+	// If url doesn't include datasetID, edition and version wait and retrieve from the filter object
+	if datasetID == "" {
+		wg.Wait()
+		if logError(ctx, w, fErr, "failed to get filter output", log.Data{"filterOutputID": filterOutputID}) {
+			return
+		}
+
+		datasetID = filterOutput.Dataset.DatasetID
+		edition = filterOutput.Dataset.Edition
+		version = strconv.Itoa(filterOutput.Dataset.Version)
+	}
+
+	wg.Add(3)
 	go func() {
 		defer wg.Done()
 		datasetModel, dmErr = dc.Get(ctx, userAccessToken, "", collectionID, datasetID)
@@ -76,41 +97,18 @@ func filterOutput(w http.ResponseWriter, req *http.Request, zc ZebedeeClient, dc
 		}
 	}()
 
-	go func() {
-		defer wg.Done()
-		filterOutput, fErr = fc.GetOutput(ctx, userAccessToken, "", "", collectionID, filterOutputID)
-		for _, dim := range filterOutput.Dimensions {
-			dimIds = append(dimIds, dim.ID)
-		}
-	}()
-
 	wg.Wait()
 
-	if dmErr != nil {
-		log.Error(ctx, "failed to get dataset", dmErr, log.Data{"dataset": datasetID})
-		setStatusCode(ctx, w, dmErr)
+	if logError(ctx, w, dmErr, "failed to get dataset", log.Data{"dataset": datasetID}) {
 		return
 	}
-	if versErr != nil {
-		log.Error(ctx, "failed to get dataset versions", versErr, log.Data{
-			"dataset": datasetID,
-			"edition": edition,
-		})
-		setStatusCode(ctx, w, versErr)
+	if logError(ctx, w, versErr, "failed to get dataset versions", log.Data{"dataset": datasetID, "edition": edition}) {
 		return
 	}
-	if verErr != nil {
-		log.Error(ctx, "failed to get dataset version", verErr, log.Data{
-			"dataset": datasetID,
-			"edition": edition,
-			"version": version,
-		})
-		setStatusCode(ctx, w, verErr)
+	if logError(ctx, w, verErr, "failed to get dataset version", log.Data{"dataset": datasetID, "edition": edition, "version": version}) {
 		return
 	}
-	if fErr != nil {
-		log.Error(ctx, "failed to get filter output", fErr, log.Data{"filter_output_id": filterOutputID})
-		setStatusCode(ctx, w, fErr)
+	if logError(ctx, w, fErr, "failed to get filter output", log.Data{"filterOutputID": filterOutputID}) {
 		return
 	}
 
@@ -431,4 +429,13 @@ func filterOutput(w http.ResponseWriter, req *http.Request, zc ZebedeeClient, dc
 	basePage := rend.NewBasePageModel()
 	m := mapper.CreateCensusFilterOutputsPage(ctx, req, basePage, datasetModel, ver, initialVersionReleaseDate, hasOtherVersions, allVers.Items, latestVersionNumber, latestVersionURL, lang, showAll, numOptsSummary, isValidationError, hasNoAreaOptions, filterOutput.Downloads, fDims, homepageContent.ServiceMessage, homepageContent.EmergencyBanner, cfg.EnableMultivariate, dimDescriptions, *sdc)
 	rend.BuildPage(w, m, "census-landing")
+}
+
+func logError(ctx context.Context, w http.ResponseWriter, err error, msg string, data log.Data) bool {
+	if err != nil {
+		log.Error(ctx, msg, err, data)
+		setStatusCode(ctx, w, err)
+		return true
+	}
+	return false
 }

--- a/handlers/mock_clients.go
+++ b/handlers/mock_clients.go
@@ -88,6 +88,22 @@ func (mr *MockFilterClientMockRecorder) CreateFlexibleBlueprint(ctx, userAuthTok
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateFlexibleBlueprint", reflect.TypeOf((*MockFilterClient)(nil).CreateFlexibleBlueprint), ctx, userAuthToken, serviceAuthToken, downloadServiceToken, collectionID, datasetID, edition, version, dimensions, population_type)
 }
 
+// CreateFlexibleBlueprintCustom mocks base method.
+func (m *MockFilterClient) CreateFlexibleBlueprintCustom(ctx context.Context, uAuthToken, svcAuthToken, dlServiceToken string, req filter.CreateFlexBlueprintCustomRequest) (string, string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateFlexibleBlueprintCustom", ctx, uAuthToken, svcAuthToken, dlServiceToken, req)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(string)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// CreateFlexibleBlueprintCustom indicates an expected call of CreateFlexibleBlueprintCustom.
+func (mr *MockFilterClientMockRecorder) CreateFlexibleBlueprintCustom(ctx, uAuthToken, svcAuthToken, dlServiceToken, req interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateFlexibleBlueprintCustom", reflect.TypeOf((*MockFilterClient)(nil).CreateFlexibleBlueprintCustom), ctx, uAuthToken, svcAuthToken, dlServiceToken, req)
+}
+
 // GetDimensionOptions mocks base method.
 func (m *MockFilterClient) GetDimensionOptions(ctx context.Context, userAuthToken, serviceAuthToken, collectionID, filterID, name string, q *filter.QueryParams) (filter.DimensionOptions, string, error) {
 	m.ctrl.T.Helper()

--- a/main.go
+++ b/main.go
@@ -146,6 +146,8 @@ func run(ctx context.Context) error {
 	if cfg.EnableMultivariate {
 		router.Path("/datasets/create").Methods("GET").HandlerFunc(handlers.CreateCustomDataset(pc, zc, rend, *cfg, apiRouterVersion))
 		router.Path("/datasets/create").Methods("POST").HandlerFunc(handlers.PostCreateCustomDataset(f))
+		router.Path("/datasets/create/filter-outputs/{filterOutputID}").Methods("GET").HandlerFunc(handlers.FilterOutput(zc, f, pc, dc, rend, *cfg, apiRouterVersion))
+		router.Path("/datasets/create/filter-outputs/{filterOutputID}").Methods("POST").HandlerFunc(handlers.CreateFilterFlexIDFromOutput(f))
 	}
 
 	router.Path("/datasets/{datasetID}").Methods("GET").HandlerFunc(handlers.EditionsList(dc, zc, rend, *cfg, apiRouterVersion))


### PR DESCRIPTION
### What

Open alternate URL for filter-outputs page on `/datasets/create/filter-outputs/{filterId}` for journeys that start at Create a dataset

Also includes fixes for ongoing journey from the custom filter-outputs page which was looping us back into the multivariate journey by using `CreateFlexBlueprintRequest` instead of `CreateFlexBlueprintCustomRequest`

Links to https://github.com/ONSdigital/dp-frontend-filter-flex-dataset/pull/152

### How to review

Tests pass
Sense check

### Who can review

Frontend go dev
