### PR TITLE
feature/population types page improvements

### DIFF
--- a/assets/locales/service.cy.toml
+++ b/assets/locales/service.cy.toml
@@ -416,3 +416,7 @@ one = "Continue"
 [PopulationType]
 description = "Population type"
 one = "Population type"
+
+[PopulationTypeIntro]
+description = "Introductory sentence for selecting a population type"
+one = "Census 2021 collected information about people and their households in England and Wales on Census Day, 21 March 2021. We group data together based on who or what the information is about, for example, people or households. We make population types from these groups or subsets of them. For example, people who are usually resident in England or Wales make up the population type usual residents. <a href=\"/census/census2021dictionary/measurementsusedincensus2021data\">Read about the measurements we used for Census 2021 data.</a>"

--- a/assets/locales/service.en.toml
+++ b/assets/locales/service.en.toml
@@ -397,3 +397,7 @@ one = "Continue"
 [PopulationType]
 description = "Population type"
 one = "Population type"
+
+[PopulationTypeIntro]
+description = "Introductory sentence for selecting a population type"
+one = "Census 2021 collected information about people and their households in England and Wales on Census Day, 21 March 2021. We group data together based on who or what the information is about, for example, people or households. We make population types from these groups or subsets of them. For example, people who are usually resident in England or Wales make up the population type usual residents. <a href=\"/census/census2021dictionary/measurementsusedincensus2021data\">Read about the measurements we used for Census 2021 data.</a>"

--- a/assets/templates/create-custom-dataset.tmpl
+++ b/assets/templates/create-custom-dataset.tmpl
@@ -1,54 +1,60 @@
-{{$Language := .Language}}
-{{ $length := len .CreateCustomDatasetPage.PopulationTypes }}
+{{$length := len .CreateCustomDatasetPage.PopulationTypes}}
 <div class="ons-page__container ons-container">
     <div class="ons-grid ons-u-ml-no">
         {{ template "partials/breadcrumb" . }}
         {{ if .Page.Error.Title }}
             {{ template "partials/error-summary" .Page.Error }}
         {{ end }}
-        <h1 class="ons-u-fs-xxxl ons-u-mt-s">{{localise "CreateCustomDatasetTitle" .Language 1}}</h1>
+        <h1 class="ons-u-fs-xxxl ons-u-mt-s">{{- localise "CreateCustomDatasetTitle" .Language 1 -}}</h1>
         <div class="ons-grid__col ons-col-8@m ons-u-pl-no">
-            <div class="ons-page__main ons-u-mt-l">
+            <div class="ons-page__main ons-u-mt-s">
+                <p class="ons-u-mb-xl default-line-height">
+                    {{- localise "PopulationTypeIntro" .Language 1 | safeHTML -}}
+                </p>
                 <form method="post" id="population-type">
                     {{ if .Page.Error.Title }}
                         <div class="ons-panel ons-panel--error ons-panel--no-title" id="coverage-error">
                             <span class="ons-u-vh">
-                                {{ localise "CreateCustomDatasetErrorTitle" .Language 1 }}:
+                                {{- localise "CreateCustomDatasetErrorTitle" .Language 1 -}}:
                             </span>
                             <div class="ons-panel__body">
                                 <p class="ons-panel__error">
                                     <strong>{{- localise "CreateCustomDatasetErrorText" .Language 1 -}}</strong>
                                 </p>
-                    {{ end }}
-
-                    <fieldset class="ons-fieldset" >
-                        <legend class="ons-fieldset__legend ons-u-mb-s">
-                            {{localise "CreateCustomDatasetLegend" .Language 1}}
-                        </legend>
-                        <div class="ons-radios__items">
-                            {{ range $i, $populationType := .CreateCustomDatasetPage.PopulationTypes }}
-                                <span class="ons-radios__item ons-radios__item--no-border ons-u-mb-s">
-                                    <span class="ons-radio ons-radio--no-border">
-                                    <input type="radio" id="{{ .Name }}" class="ons-radio__input ons-js-radio" value="{{ .Name }}" name="populationType">
-                                        <label class=" ons-radio__label  ons-label--with-description ons-badge" aria-describedby="{{ .Name }}-label-description-hint" for="{{ .Name }}" id="{{ .Name }}-label">{{ .Label }}
-                                                <span class="ons-label__description ons-radio__label--with-description">{{- .Description -}}</span>
-                                        </label>
-                                        <span class="ons-label__visually-hidden-description ons-u-vh" id="{{ .Name }}-label-description-hint">{{- .Description -}}</span>
-                                        </span>
-                                </span>
-                                {{ if notLastItem $length $i }}<br>{{ end }}
                             {{ end }}
-                        </div>
-                    </fieldset>
-
-                    {{ if .Page.Error.Title }}
+                            <fieldset class="ons-fieldset">
+                                <legend class="ons-fieldset__legend ons-u-mb-s">
+                                    {{- localise "CreateCustomDatasetLegend" .Language 1 -}}
+                                </legend>
+                                <div class="ons-radios__items">
+                                    {{ range $i, $populationType := .CreateCustomDatasetPage.PopulationTypes }}
+                                        <span class="ons-radios__item ons-radios__item--no-border ons-u-mb-s">
+                                            <span class="ons-radio ons-radio--no-border">
+                                                <input type="radio" id="{{- .Name -}}" class="ons-radio__input ons-js-radio" value="{{- .Name -}}" name="populationType">
+                                                <label class="ons-radio__label ons-label--with-description" aria-describedby="{{- .Name -}}-label-description-hint" for="{{- .Name -}}" id="{{- .Name -}}-label">
+                                                    {{- .Label -}}
+                                                    <span class="ons-label__description ons-radio__label--with-description">
+                                                        {{- .Description -}}
+                                                    </span>
+                                                </label>
+                                                <span class="ons-label__visually-hidden-description ons-u-vh" id="{{ .Name }}-label-description-hint">
+                                                    {{- .Description -}}
+                                                </span>
+                                            </span>
+                                        </span>
+                                        {{ if notLastItem $length $i }}
+                                            <br>
+                                        {{ end }}
+                                    {{ end }}
+                                </div>
+                            </fieldset>
+                            {{ if .Page.Error.Title }}
                             </div>
                         </div>
                     {{ end }}
-
                     <div class="ons-u-mt-l">
-                        <button type="submit" class="ons-btn ons-u-mt-s ons-u-mb-s">
-                            <span class="ons-btn__inner">{{ localise "Continue" $.Language 1 }}</span>
+                        <button type="submit" class="ons-btn ons-u-mb-s">
+                            <span class="ons-btn__inner">{{- localise "Continue" .Language 1 -}}</span>
                         </button>
                     </div>
                 </form>


### PR DESCRIPTION
### What

Fixed bug where description was in wrong location (see image ⬇️); ✅ **resolves** trello ticket [Fix select pop types page](https://trello.com/c/srGlbYQq/6056-fix-select-pop-types-page)
<img width="680" alt="misaligned description" src="https://user-images.githubusercontent.com/19624419/224047383-1d9107fd-8646-4400-9b2a-b395960a8515.png">
Added introductory paragraph; ✅ **resolves** trello ticket [Introductory paragraph](https://trello.com/c/V8bJ9h68/6057-add-a-paragraph-above-the-population-types-field-set-within-the-create-custom-dataset-screen)

### How to review

Sense check
Image review
<img width="742" alt="select population types page" src="https://user-images.githubusercontent.com/19624419/224048277-4b1f8cf4-181d-478c-943a-6e7d3cda7887.png">

### Who can review

Frontend dev
