### PR TITLE
feature/custom title

### DIFF
--- a/assets/locales/service.cy.toml
+++ b/assets/locales/service.cy.toml
@@ -419,4 +419,4 @@ one = "Population type"
 
 [PopulationTypeIntro]
 description = "Introductory sentence for selecting a population type"
-one = "Census 2021 collected information about people and their households in England and Wales on Census Day, 21 March 2021. We group data together based on who or what the information is about, for example, people or households. We make population types from these groups or subsets of them. For example, people who are usually resident in England or Wales make up the population type usual residents. <a href=\"/census/census2021dictionary/measurementsusedincensus2021data\">Read about the measurements we used for Census 2021 data.</a>"
+one = "We group Census 2021 data together based on who or what the information is about, for example, people or households. We make population types from these groups or subsets of them. For example, people who are usually resident in England or Wales make up the population type usual residents. <a href=\"/census/census2021dictionary/measurementsusedincensus2021data\">Read about the measurements we used for Census 2021 data.</a>"

--- a/assets/locales/service.en.toml
+++ b/assets/locales/service.en.toml
@@ -400,4 +400,4 @@ one = "Population type"
 
 [PopulationTypeIntro]
 description = "Introductory sentence for selecting a population type"
-one = "Census 2021 collected information about people and their households in England and Wales on Census Day, 21 March 2021. We group data together based on who or what the information is about, for example, people or households. We make population types from these groups or subsets of them. For example, people who are usually resident in England or Wales make up the population type usual residents. <a href=\"/census/census2021dictionary/measurementsusedincensus2021data\">Read about the measurements we used for Census 2021 data.</a>"
+one = "We group Census 2021 data together based on who or what the information is about, for example, people or households. We make population types from these groups or subsets of them. For example, people who are usually resident in England or Wales make up the population type usual residents. <a href=\"/census/census2021dictionary/measurementsusedincensus2021data\">Read about the measurements we used for Census 2021 data.</a>"

--- a/mapper/census_filter_outputs.go
+++ b/mapper/census_filter_outputs.go
@@ -81,7 +81,7 @@ func CreateCensusFilterOutputsPage(ctx context.Context, req *http.Request, baseP
 		title := buildConjoinedList(nonGeoDims, true)
 		vDims := getNonGeographyVersionDims(&version.Dimensions)
 		vTitle := buildConjoinedList(vDims, true)
-		if vTitle != title {
+		if vTitle != title || helpers.IsBoolPtr(filterOutput.Custom) {
 			p.Metadata.Title = strings.ToUpper(title[:1]) + strings.ToLower(title[1:])
 			p.DatasetLandingPage.IsCustom = true
 		}

--- a/model/datasetLandingPageCensus/model.go
+++ b/model/datasetLandingPageCensus/model.go
@@ -28,6 +28,7 @@ type DatasetLandingPage struct {
 	Dimensions          []sharedModel.Dimension `json:"dimensions"`
 	ShareDetails        ShareDetails
 	Description         []string             `json:"description"`
+	IsCustom            bool                 `json:"is_custom"`
 	IsFlexibleForm      bool                 `json:"is_flexible_form"`
 	DatasetURL          string               `json:"dataset_url"`
 	Panels              []Panel              `json:"panels"`


### PR DESCRIPTION
### What

1. Fixed dimension ordering on filter outputs
2. Customising title for `multivariate` datasets that have been customised and `build your own`; the title for these types of datasets should be a string of the non-geography dimensions conjoined with a ',' or 'and' as appropriate
✅ **Resolves** trello ticket [Change title on filter outputs page for customised multivariates/BYO](https://trello.com/c/otChEwfb/6053-change-h1-title-on-filter-outputs-page-for-customised-multivariates-byo)
e.g. 
N.B In the examples change the domain to your local instance of the frontend-router or frontend-dataset-controller
- Multivariate dataset with one non-geog dimension added (disability); title = `Disability` [example filter record](https://dp.aws.onsdigital.uk/datasets/Testing-MV-Stuff/editions/2021/versions/1/filter-outputs/e383d12e-ccf8-45fe-8d58-73cd07c1755f)
- Multivariate dataset with three non-geog dimensions added (Ethnic group, general health and sex); title = `Ethnic group, general health and sex` [example filter record](https://dp.aws.onsdigital.uk/datasets/Testing-MV-Stuff/editions/2021/versions/1/filter-outputs/be08cf97-26ca-4ac9-9f89-8fd624be7619)
- Non customised dataset; original title  [example filter record](https://dp.aws.onsdigital.uk/datasets/Testing-MV-Stuff/editions/2021/versions/1/filter-outputs/a4aa8494-3e11-45fd-9543-bee7dca61c76)
- Custom dataset; title = `Age, country of birth and ethnic group` [example filter record](https://dp.aws.onsdigital.uk/datasets/create/filter-outputs/8de113ad-4d3f-4305-8bf4-af0b6f8a2946)

### How to review

Sense check
Tests pass

### Who can review

Frontend go dev
