### PR TITLE
Sort dimensions on filter outputs page

### DIFF
--- a/mapper/census_filter_outputs.go
+++ b/mapper/census_filter_outputs.go
@@ -105,7 +105,11 @@ func CreateCensusFilterOutputsPage(ctx context.Context, req *http.Request, baseP
 // mapFilterOutputDims links dimension options to FilterDimensions and prepares them for display
 func mapFilterOutputDims(dims []sharedModel.FilterDimension, queryStrValues []string, path string, isMultivariate bool) []sharedModel.Dimension {
 	sort.Slice(dims, func(i, j int) bool {
-		return *dims[i].IsAreaType
+		if *dims[i].IsAreaType {
+			return true
+		} else {
+			return dims[i].Label < dims[j].Label
+		}
 	})
 	dimensions := []sharedModel.Dimension{}
 	for _, dim := range dims {
@@ -211,13 +215,7 @@ func mapBlockedAreasPanel(sdc *cantabular.GetBlockedAreaCountResult, panelType d
 }
 
 func mapImproveResultsCollapsible(dims *[]sharedModel.Dimension, lang string) coreModel.Collapsible {
-	var dimsList []string
-	for _, dim := range *dims {
-		if !dim.IsAreaType && !dim.IsCoverage {
-			dimsList = append(dimsList, dim.Title)
-		}
-	}
-	stringList := buildDimsList(dimsList)
+	text := buildImproveResultsText(dims)
 
 	return coreModel.Collapsible{
 		Title: coreModel.Localisation{
@@ -228,11 +226,21 @@ func mapImproveResultsCollapsible(dims *[]sharedModel.Dimension, lang string) co
 			{
 				Subheading: helper.Localise("ImproveResultsSubHeading", lang, 1),
 				SafeHTML: coreModel.Localisation{
-					Text: helper.Localise("ImproveResultsList", lang, 1, stringList),
+					Text: helper.Localise("ImproveResultsList", lang, 1, text),
 				},
 			},
 		},
 	}
+}
+
+func buildImproveResultsText(dims *[]sharedModel.Dimension) string {
+	var dimsList []string
+	for _, dim := range *dims {
+		if !dim.IsAreaType && !dim.IsCoverage && !dim.IsPopulationType {
+			dimsList = append(dimsList, dim.Title)
+		}
+	}
+	return buildDimsList(dimsList)
 }
 
 func buildDimsList(dimsList []string) (ListStr string) {

--- a/mapper/census_filter_outputs_test.go
+++ b/mapper/census_filter_outputs_test.go
@@ -47,7 +47,9 @@ func TestCreateCensusFilterOutputsPage(t *testing.T) {
 		version := getTestVersionDetails(1, getTestDefaultDimensions(), getTestDownloads([]string{"xlsx"}), nil)
 		filterDims := []sharedModel.FilterDimension{
 			getTestFilterDimension("geography", true, []string{"option 1", "option 2"}, 2),
-			getTestFilterDimension("non-geog", false, []string{"option a", "option b"}, 2)}
+			getTestFilterDimension("ethnicity", false, []string{"option a", "option b"}, 2),
+			getTestFilterDimension("age", false, []string{"option a", "option b"}, 2),
+			getTestFilterDimension("sex", false, []string{"option a", "option b"}, 1)}
 		filterOutputs := filter.Model{
 			Downloads:      getTestFilterDownloads([]string{"xlsx"}),
 			PopulationType: "UR",
@@ -72,7 +74,7 @@ func TestCreateCensusFilterOutputsPage(t *testing.T) {
 				So(page.SearchNoIndexEnabled, ShouldBeTrue)
 			})
 
-			Convey("and dimensions map correctly", func() {
+			Convey("and dimensions map correctly to population, area-type and coverage", func() {
 				So(page.DatasetLandingPage.Dimensions[0].IsPopulationType, ShouldBeTrue)
 				So(page.DatasetLandingPage.Dimensions[0].ShowChange, ShouldBeFalse)
 				So(page.DatasetLandingPage.Dimensions[1].Title, ShouldEqual, filterDims[0].Label)
@@ -82,6 +84,12 @@ func TestCreateCensusFilterOutputsPage(t *testing.T) {
 				So(page.DatasetLandingPage.Dimensions[2].IsCoverage, ShouldBeTrue)
 				So(page.DatasetLandingPage.Dimensions[2].Values, ShouldResemble, filterDims[0].Options)
 				So(page.DatasetLandingPage.Dimensions[2].ShowChange, ShouldBeTrue)
+			})
+
+			Convey("and variable dimensions are sorted alphabetically", func() {
+				So(page.DatasetLandingPage.Dimensions[3].Title, ShouldEqual, "Label age")
+				So(page.DatasetLandingPage.Dimensions[4].Title, ShouldEqual, "Label ethnicity")
+				So(page.DatasetLandingPage.Dimensions[5].Title, ShouldEqual, "Label sex")
 			})
 
 			Convey("and collapsible items are ordered correctly", func() {
@@ -603,6 +611,49 @@ func TestMapImproveResultsCollapsible(t *testing.T) {
 		Convey("When the mapImproveResultsCollapsible function is called", func() {
 			Convey("Then the given dimensions returns the expected collapsible", func() {
 				So(mapImproveResultsCollapsible(&mockDims, "en"), ShouldResemble, mockCollapsible)
+			})
+		})
+	})
+
+	Convey("Given a dimensions list including non variable dimensions", t, func() {
+		mockDims := []sharedModel.Dimension{
+			{
+				Title:      "Area type",
+				IsAreaType: true,
+				IsCoverage: false,
+			},
+			{
+				Title:      "Bob",
+				IsAreaType: false,
+				IsCoverage: false,
+			},
+			{
+				Title:      "Coverage",
+				IsAreaType: false,
+				IsCoverage: true,
+			},
+			{
+				Title:      "Charlie",
+				IsAreaType: false,
+				IsCoverage: false,
+			},
+			{
+				Title:      "Alice",
+				IsAreaType: false,
+				IsCoverage: false,
+			},
+			{
+				Title:            "Usual Residents",
+				IsAreaType:       false,
+				IsCoverage:       false,
+				IsPopulationType: true,
+			},
+		}
+		Convey("When the buildImproveResultsText function is called", func() {
+			text := buildImproveResultsText(&mockDims)
+
+			Convey("Then the text includes only the variable dimensions in original order", func() {
+				So(text, ShouldEqual, "Bob, Charlie or Alice")
 			})
 		})
 	})


### PR DESCRIPTION
### What

Sorted dimensions for the variables table and in the sdc messaging

Note - removing 1 categorisation variables from sdc rules is part of separate PR

<img width="639" alt="image" src="https://user-images.githubusercontent.com/6823289/224363051-8f8624b0-081c-433b-8bf5-a8b6c972ffc7.png">
<img width="1026" alt="image" src="https://user-images.githubusercontent.com/6823289/224363124-7a8ba9df-eff1-41ee-b74b-3cf8bbc50c01.png">


### How to review
Media review
Tests pass
Sense check

### Who can review

FE Go dev
