### PR TITLE
feature/removing superfluous metadata for custom dataset pages

### DIFF
--- a/assets/locales/service.cy.toml
+++ b/assets/locales/service.cy.toml
@@ -420,3 +420,7 @@ one = "Population type"
 [PopulationTypeIntro]
 description = "Introductory sentence for selecting a population type"
 one = "We group Census 2021 data together based on who or what the information is about, for example, people or households. We make population types from these groups or subsets of them. For example, people who are usually resident in England or Wales make up the population type usual residents. <a href=\"/census/census2021dictionary/measurementsusedincensus2021data\">Read about the measurements we used for Census 2021 data.</a>"
+
+[CustomDatasetSummary]
+description = "Summary for BYO and customised multivariate datasets {{.populationLabel}} {{.nonGeoDims}}"
+one = "This dataset provides 2021 Census estimates that classify {{.arg0}} in England and Wales by {{.arg1}}. The estimates are as at census day, 27 March 2021."

--- a/assets/locales/service.en.toml
+++ b/assets/locales/service.en.toml
@@ -401,3 +401,7 @@ one = "Population type"
 [PopulationTypeIntro]
 description = "Introductory sentence for selecting a population type"
 one = "We group Census 2021 data together based on who or what the information is about, for example, people or households. We make population types from these groups or subsets of them. For example, people who are usually resident in England or Wales make up the population type usual residents. <a href=\"/census/census2021dictionary/measurementsusedincensus2021data\">Read about the measurements we used for Census 2021 data.</a>"
+
+[CustomDatasetSummary]
+description = "Summary for BYO and customised multivariate datasets {{.populationLabel}} {{.nonGeoDims}}"
+one = "This dataset provides 2021 Census estimates that classify {{.arg0}} in England and Wales by {{.arg1}}. The estimates are as at census day, 27 March 2021."

--- a/assets/templates/census-landing.tmpl
+++ b/assets/templates/census-landing.tmpl
@@ -4,7 +4,7 @@
         {{ if .Page.Error.Title }}
             {{ template "partials/error-summary" .Page.Error }}
         {{ end }}
-        <section class="ons-u-mb-xl">
+        <section class="{{ if .DatasetLandingPage.IsCustom }}ons-u-mb-s{{ else }}ons-u-mb-xl{{ end }}">
             {{ template "partials/census/panel" .DatasetLandingPage.Panels }}
             <div class="ons-grid">
                 <div class="ons-grid__col{{ if .IsNationalStatistic }} ons-col-10@m{{ end }}">

--- a/assets/templates/partials/census/id-datestamp.tmpl
+++ b/assets/templates/partials/census/id-datestamp.tmpl
@@ -1,23 +1,31 @@
 <dl class="ons-metadata metadata__list ons-grid ons-grid--gutterless ons-u-cf ons-u-mb-m" title="{{ localise "CensusDatasetLandingPageMetadataLabel" .Language 1 }}" aria-label="{{ localise "CensusDatasetLandingPageMetadataLabel" .Language 1 }}">
-    <div class="ons-grid__col ons-col-12@m">
-        <dt class="ons-metadata__term ons-u-mr-xs">{{ localise "DatasetID" .Language 1 }}</dt>
-        <dd class="ons-metadata__value ons-u-f-no">{{ .DatasetId }}</dd>
-    </div>
+    {{ if .DatasetId }}
+        <div class="ons-grid__col ons-col-12@m">
+            <dt class="ons-metadata__term ons-u-mr-xs">{{ localise "DatasetID" .Language 1 }}</dt>
+            <dd class="ons-metadata__value ons-u-f-no">{{ .DatasetId }}</dd>
+        </div>
+    {{ end }}
     {{ if .DatasetLandingPage.HasOtherVersions }}
         <div class="ons-grid__col ons-col-4@m ons-u-mt-xs">
             <dt class="ons-metadata__term ons-u-mr-xs">{{ localise "Released" .Language 1 }}:</dt>
-            <dd class="ons-metadata__value ons-u-f-no"><time datetime="{{ .ReleaseDate }}">{{ dateFormat .ReleaseDate }}</time></dd>
+            <dd class="ons-metadata__value ons-u-f-no">
+                <time datetime="{{ .ReleaseDate }}">{{ dateFormat .ReleaseDate }}</time>
+            </dd>
         </div>
         <div class="ons-grid__col ons-col-8@m ons-u-mt-xs">
             <dt class="ons-metadata__term ons-u-mr-xs">{{ localise "LastUpdated" .Language 1 }}:</dt>
-            <dd class="ons-metadata__value ons-u-f-no"><time datetime="{{ .Version.ReleaseDate }}">{{ dateFormat .Version.ReleaseDate }}</time> &mdash;
+            <dd class="ons-metadata__value ons-u-f-no">
+                <time datetime="{{ .Version.ReleaseDate }}">{{ dateFormat .Version.ReleaseDate }}</time>
+                &mdash;
                 <a href="#version-history">{{ localise "SeeVersionHistory" .Language 1 }}</a>
             </dd>
         </div>
-    {{ else }}
+    {{ else if .ReleaseDate }}
         <div class="ons-grid__col ons-col-12@m ons-u-mt-xs">
             <dt class="ons-metadata__term ons-u-mr-xs">{{ localise "Released" .Language 1 }}:</dt>
-            <dd class="ons-metadata__value ons-u-f-no"><time datetime="{{ .ReleaseDate }}">{{ dateFormat .ReleaseDate }}</time></dd>
+            <dd class="ons-metadata__value ons-u-f-no">
+                <time datetime="{{ .ReleaseDate }}">{{ dateFormat .ReleaseDate }}</time>
+            </dd>
         </div>
     {{ end }}
 </dl>

--- a/mapper/census_filter_outputs.go
+++ b/mapper/census_filter_outputs.go
@@ -16,6 +16,7 @@ import (
 	"github.com/ONSdigital/dp-api-clients-go/v2/zebedee"
 	"github.com/ONSdigital/dp-frontend-dataset-controller/helpers"
 	sharedModel "github.com/ONSdigital/dp-frontend-dataset-controller/model"
+	"github.com/ONSdigital/dp-frontend-dataset-controller/model/contactDetails"
 	"github.com/ONSdigital/dp-frontend-dataset-controller/model/datasetLandingPageCensus"
 	"github.com/ONSdigital/dp-renderer/helper"
 	coreModel "github.com/ONSdigital/dp-renderer/model"
@@ -31,6 +32,21 @@ func CreateCensusFilterOutputsPage(ctx context.Context, req *http.Request, baseP
 
 	p.Type += FilterOutput
 	p.SearchNoIndexEnabled = true
+
+	// CUSTOM PAGE METADATA OVERRIDES
+	if helpers.IsBoolPtr(filterOutput.Custom) {
+		p.ReleaseDate = ""
+		p.DatasetId = ""
+		p.IsNationalStatistic = true
+		p.ShowCensusBranding = true
+		p.DatasetLandingPage.IsCustom = true
+		p.HasContactDetails = true
+		p.ContactDetails = contactDetails.ContactDetails{
+			Email:     "census.customerservices@ons.gov.uk",
+			Telephone: "+44 1329 444972",
+		}
+		p.TableOfContents = buildTableOfContents(p, dataset.DatasetDetails{}, false)
+	}
 
 	// DOWNLOADS
 	for ext, download := range filterOutput.Downloads {
@@ -78,12 +94,14 @@ func CreateCensusFilterOutputsPage(ctx context.Context, req *http.Request, baseP
 	// CUSTOM TITLE
 	if helpers.IsBoolPtr(filterOutput.Custom) || p.DatasetLandingPage.IsMultivariate {
 		nonGeoDims := getNonGeographyDims(&p.DatasetLandingPage.Dimensions)
-		title := buildConjoinedList(nonGeoDims, true)
+		dimensionStr := buildConjoinedList(nonGeoDims, true)
 		vDims := getNonGeographyVersionDims(&version.Dimensions)
 		vTitle := buildConjoinedList(vDims, true)
-		if vTitle != title || helpers.IsBoolPtr(filterOutput.Custom) {
-			p.Metadata.Title = strings.ToUpper(title[:1]) + strings.ToLower(title[1:])
-			p.DatasetLandingPage.IsCustom = true
+		if vTitle != dimensionStr || helpers.IsBoolPtr(filterOutput.Custom) {
+			p.Metadata.Title = strings.ToUpper(dimensionStr[:1]) + strings.ToLower(dimensionStr[1:])
+			p.DatasetLandingPage.Description = []string{
+				helper.Localise("CustomDatasetSummary", lang, 1, strings.ToLower(pop.Title), strings.ToLower(dimensionStr)),
+			}
 		}
 	}
 

--- a/mapper/mocks/mocks.go
+++ b/mapper/mocks/mocks.go
@@ -25,6 +25,8 @@ var cyLocale = []string{
 	"other = \"All 10 areas available\"",
 	"[CreateCustomDatasetTitle]",
 	"one = \"Create a custom dataset\"",
+	"[CustomDatasetSummary]",
+	"one = \"This is a custom dataset\"",
 }
 
 var enLocale = []string{
@@ -50,6 +52,8 @@ var enLocale = []string{
 	"other = \"All 10 areas available\"",
 	"[CreateCustomDatasetTitle]",
 	"one = \"Create a custom dataset\"",
+	"[CustomDatasetSummary]",
+	"one = \"This is a custom dataset\"",
 }
 
 // MockAssetFunction returns mocked toml []bytes


### PR DESCRIPTION
### What

- Removing/overriding superfluous metadata for custom dataset pages
- Created summary for custom and 'changed' multivariate pages
✅ **Resolves** trello ticket [Remove any superfluous metadata for customised dataset landing pages](https://trello.com/c/P8movWzv/6070-remove-any-superfluous-metadata-for-customised-dataset-landing-pages)

### How to review

- Sense check
- Tests pass
- Image review

<img width="1060" alt="custom dataset page" src="https://user-images.githubusercontent.com/19624419/226847284-10bad1bf-43ef-4977-968c-ea49201149d3.png">


### Who can review

Frontend go dev
