### PR TITLE
Fix/logo not loading on filter output pages

### DIFF
--- a/handlers/filter_output.go
+++ b/handlers/filter_output.go
@@ -432,6 +432,8 @@ func filterOutput(w http.ResponseWriter, req *http.Request, zc ZebedeeClient, dc
 	showAll := req.URL.Query()[queryStrKey]
 	basePage := rend.NewBasePageModel()
 	m := mapper.CreateCensusFilterOutputsPage(req, basePage, datasetModel, ver, initialVersionReleaseDate, hasOtherVersions, allVers.Items, latestVersionNumber, latestVersionURL, lang, showAll, isValidationError, hasNoAreaOptions, filterOutput, fDims, homepageContent.ServiceMessage, homepageContent.EmergencyBanner, cfg.EnableMultivariate, dimDescriptions, *sdc, pop)
+	m.DatasetLandingPage.OSRLogo = helpers.GetOSRLogoDetails(cfg.EnableOfficialStatisticsLogo, false, m.Language)
+
 	rend.BuildPage(w, m, "census-landing")
 }
 


### PR DESCRIPTION
### What

This fixes an issue with the osr logo not loading on filter output pages.

### How to review

Change `EnableMultivariate` in config to true
Pull this branch and run app with make debug
Run sixteens and dp-design-system
Port forward the api router to sandbox dp ssh sandbox web 1 -p 23200:localhost:10800
Go [here](http://localhost:20200/datasets/create/filter-outputs/ee05bc11-d0bf-4ccf-9d7b-9f349e8269a9)
You can toggle the logo by changing `EnableOfficialStatisticsLogo` in the config file.

or
![image](https://github.com/ONSdigital/dp-frontend-dataset-controller/assets/110108574/a5842b36-bfa4-46e6-9645-2e6632367335)


### Who can review

Frontend
