### PR TITLE
Fix: Template name handled for datasets without 'type' 

### DIFF
--- a/handlers/filterable_landing_page.go
+++ b/handlers/filterable_landing_page.go
@@ -272,8 +272,13 @@ func filterableLanding(w http.ResponseWriter, req *http.Request, dc DatasetClien
 		})
 	
 		m.DatasetLandingPage.OSRLogo = helpers.GetOSRLogoDetails(m.Language)
+		
+		templateName := "filterable"
+		if datasetModel.Type == "nomis" {
+			templateName = "nomis"
+		}
 	
-		rend.BuildPage(w, m, datasetModel.Type)
+		rend.BuildPage(w, m, templateName)
 	}
 }
 


### PR DESCRIPTION
### What

This fixes an issue that was introduced by some refactoring, in which a dataset that is without datasetModel.type value is undefined. The hunk of code that handles this edge case has been reintroduced.

### How to review

Ensure all tests pass and that, when a type is not provided, the rendering defaults to the CMD style landing page

### Who can review

Anyone
