### PR TITLE
Feature/overview page template more features

### DIFF
--- a/assets/locales/service.cy.toml
+++ b/assets/locales/service.cy.toml
@@ -234,6 +234,18 @@ one = "Last updated"
 description = "See version history"
 one = "See version history"
 
+[PublisherName]
+description = "Publisher Name"
+one = "Publisher Name"
+
+[PublisherType]
+description = "Publisher Type"
+one = "Publisher Type"
+
+[PublisherURL]
+description = "Publisher URL"
+one = "Publisher URL"
+
 [VersionHistory]
 description = "Version history"
 one = "Version history"

--- a/assets/locales/service.en.toml
+++ b/assets/locales/service.en.toml
@@ -223,6 +223,18 @@ one = "Last updated"
 description = "See version history"
 one = "See version history"
 
+[PublisherName]
+description = "Publisher Name"
+one = "Publisher Name"
+
+[PublisherType]
+description = "Publisher Type"
+one = "Publisher Type"
+
+[PublisherURL]
+description = "Publisher URL"
+one = "Publisher URL"
+
 [VersionHistory]
 description = "Version history"
 one = "Version history"

--- a/assets/locales/service.en.toml
+++ b/assets/locales/service.en.toml
@@ -98,9 +98,17 @@ one = "View all data related to"
 description = "Contact us"
 one = "Contact us"
 
+[ContactDetails]
+description = "Contact details for this dataset"
+one = "Contact details for this dataset"
+
 [DatasetContactDetails]
 description = "Contact details for this dataset"
 one = "Contact details for this dataset"
+
+[Name]
+description = "Name"
+one = "Name"
 
 [Email]
 description = "Email"

--- a/assets/templates/census-landing.tmpl
+++ b/assets/templates/census-landing.tmpl
@@ -1,56 +1,89 @@
 <div class="ons-page__container ons-container">
-    <div class="ons-grid ons-js-toc-container ons-u-ml-no">
-        {{ if .Page.Error.Title }}
-            {{ template "partials/error-summary" .Page.Error }}
+  <div class="ons-grid ons-js-toc-container ons-u-ml-no">
+    {{ if .Page.Error.Title }}
+    {{ template "partials/error-summary" .Page.Error }}
+    {{ end }}
+    <section
+      class="{{ if .DatasetLandingPage.IsCustom }}ons-u-mb-s{{ else }}ons-u-mb-xl{{
+        end
+      }}"
+    >
+      {{ template "partials/census/panel" .DatasetLandingPage.Panels }}
+      <div class="ons-grid">
+        <div
+          class="ons-grid__col{{ if .IsNationalStatistic }} ons-col-10@m{{
+            end
+          }}"
+        >
+          <h1
+            class="ons-u-fs-xxxl ons-u-mt-s ons-u-mb-m ons-u-pb-no ons-u-pt-no"
+          >
+            {{- .Metadata.Title -}}
+          </h1>
+        </div>
+        {{ if .IsNationalStatistic }}
+        <div class="ons-grid__col ons-col-2@m">
+          <div
+            class="ons-grid--flex ons-grid--between@m ons-u-mt-s@m ons-u-mb-m@xxs ons-u-flex-jc-fe@m"
+          >
+            {{ template "partials/roundel-ns" . }}
+          </div>
+        </div>
         {{ end }}
-        <section class="{{ if .DatasetLandingPage.IsCustom }}ons-u-mb-s{{ else }}ons-u-mb-xl{{ end }}">
-            {{ template "partials/census/panel" .DatasetLandingPage.Panels }}
-            <div class="ons-grid">
-                <div class="ons-grid__col{{ if .IsNationalStatistic }} ons-col-10@m{{ end }}">
-                    <h1 class="ons-u-fs-xxxl ons-u-mt-s ons-u-mb-m ons-u-pb-no ons-u-pt-no">
-                        {{- .Metadata.Title -}}
-                    </h1>
-                </div>
-                {{ if .IsNationalStatistic }}
-                    <div class="ons-grid__col ons-col-2@m">
-                        <div class="ons-grid--flex ons-grid--between@m ons-u-mt-s@m ons-u-mb-m@xxs ons-u-flex-jc-fe@m">
-                            {{ template "partials/roundel-ns" . }}
-                        </div>
-                    </div>
-                {{ end }}
-            </div>
-            {{ if .ShowCensusBranding }}
-                <div class="ons-grid ons-u-mb-m">
-                    <div class="ons-grid__col">
-                        {{ if eq .Language "en" }}
-                            <img src="https://cdn.ons.gov.uk/assets/images/census-logo/logo-census-2021-purple-landscape.svg" title="Census 2021" class="header__svg-logo margin-right--1" xmlns="http://www.w3.org/2000/svg" focusable="false" width="167" height="32" viewBox="0 0 242 44"/>
-                        {{ else }}
-                            <img src="https://cdn.ons.gov.uk/assets/images/census-logo/logo-cyfrifiad-2021-purple-landscape.svg" title="Cyfrifiad 2021" class="header__svg-logo margin-right--1" xmlns="http://www.w3.org/2000/svg" focusable="false" width="167" height="32" viewBox="0 0 242 44"/>
-                        {{ end }}
-                    </div>
-                </div>
-            {{ end }}
-            {{ template "partials/census/id-datestamp" . }}
-        </section>
-        <div class="ons-grid__col ons-col-4@m ons-u-pl-no ons-grid__col--sticky@m" id="toc">
-            {{ template "partials/table-of-contents" . }}
+      </div>
+      {{ if .ShowCensusBranding }}
+      <div class="ons-grid ons-u-mb-m">
+        <div class="ons-grid__col">
+          {{ if eq .Language "en" }}
+          <img
+            src="https://cdn.ons.gov.uk/assets/images/census-logo/logo-census-2021-purple-landscape.svg"
+            title="Census 2021"
+            class="header__svg-logo margin-right--1"
+            xmlns="http://www.w3.org/2000/svg"
+            focusable="false"
+            width="167"
+            height="32"
+            viewBox="0 0 242 44"
+          />
+          {{ else }}
+          <img
+            src="https://cdn.ons.gov.uk/assets/images/census-logo/logo-cyfrifiad-2021-purple-landscape.svg"
+            title="Cyfrifiad 2021"
+            class="header__svg-logo margin-right--1"
+            xmlns="http://www.w3.org/2000/svg"
+            focusable="false"
+            width="167"
+            height="32"
+            viewBox="0 0 242 44"
+          />
+          {{ end }}
         </div>
-        <div class="ons-grid__col ons-col-8@m ons-u-pl-no">
-            {{ template "partials/census/panel" .DatasetLandingPage.QualityStatements }}
-            {{ template "partials/census/summary" . }}
-            {{ template "partials/census/variables-table" . }}
-            {{ template "partials/census/get-data" . }}
-            {{ if .HasContactDetails }}
-                {{ template "partials/census/contact-details" . }}
-            {{ end }}
-            {{ template "partials/census/protecting-personal-data" . }}
-            {{ if .DatasetLandingPage.HasOtherVersions }}
-                {{ template "partials/census/version-history" . }}
-            {{ end }}
-            {{ if .DatasetLandingPage.RelatedContentItems }}
-                {{ template "partials/census/related-content" . }}
-            {{ end }}
-        </div>
+      </div>
+      {{ end }}
+      {{ template "partials/census/id-datestamp" . }}
+    </section>
+    <div
+      class="ons-grid__col ons-col-4@m ons-u-pl-no ons-grid__col--sticky@m"
+      id="toc"
+    >
+      {{ template "partials/table-of-contents" . }}
     </div>
-    {{ template "partials/share-dataset/share-section" . }}
+    <div class="ons-grid__col ons-col-8@m ons-u-pl-no">
+      {{ template "partials/census/panel" .DatasetLandingPage.QualityStatements }}
+      {{ template "partials/census/summary" . }}
+      {{ template "partials/census/variables-table" . }}
+      {{ template "partials/census/get-data" . }}
+      {{ if .HasContactDetails }}
+      {{ template "partials/census/contact-details" . }}
+      {{ end }}
+      {{ template "partials/census/protecting-personal-data" . }}
+      {{ if .DatasetLandingPage.HasOtherVersions }}
+      {{ template "partials/census/version-history" . }}
+      {{ end }}
+      {{ if .DatasetLandingPage.RelatedContentItems }}
+      {{ template "partials/census/related-content" . }}
+      {{ end }}
+    </div>
+  </div>
+  {{ template "partials/share-dataset/share-section" . }}
 </div>

--- a/assets/templates/partials/census/id-datestamp.tmpl
+++ b/assets/templates/partials/census/id-datestamp.tmpl
@@ -12,6 +12,9 @@
                 <time datetime="{{ .ReleaseDate }}">{{ dateFormat .ReleaseDate }}</time>
             </dd>
         </div>
+        {{ if .Publisher}}
+            {{ template "partials/static/publisher" . }}
+        {{ end }}
         <div class="ons-grid__col ons-col-8@m ons-u-mt-xs">
             <dt class="ons-metadata__term ons-u-mr-xs">{{ localise "LastUpdated" .Language 1 }}:</dt>
             <dd class="ons-metadata__value ons-u-f-no">
@@ -27,5 +30,8 @@
                 <time datetime="{{ .ReleaseDate }}">{{ dateFormat .ReleaseDate }}</time>
             </dd>
         </div>
+        {{ if .Publisher}}
+            {{ template "partials/static/publisher" . }}
+        {{ end }}
     {{ end }}
 </dl>

--- a/assets/templates/partials/static/contact-details.tmpl
+++ b/assets/templates/partials/static/contact-details.tmpl
@@ -1,0 +1,26 @@
+<section id="contact" aria-label="{{ localise "RelatedLinksForCensus" .Language 1 }}">
+    <h2 class="ons-u-mt-xl ons-u-pb-no ons-u-pt-no" id="contact-details">{{ localise "ContactDetails" .Language 1 }}</h2>
+    <nav class="ons-related-content__navigation" aria-labelledby="contact-details">
+        <ul class="ons-list ons-list--bare ons-u-fs-r">
+            {{ if .ContactDetails.Name }}
+                <li class="ons-list__item ons-u-mt-s">
+                    <p class="ons-u-mb-no">{{ localise "Name" .Language 1 }}</p>
+                    <p class="ons-u-mb-no">{{ .ContactDetails.Name }}</p>
+                </li>
+            {{ end }}
+            {{ if .ContactDetails.Email }}
+                <li class="ons-list__item ons-u-mt-s">
+                    <p class="ons-u-mb-no">{{ localise "Email" .Language 1 }}</p>
+                    <a href="mailto:{{.ContactDetails.Email}}">{{ .ContactDetails.Email }}</a>
+                </li>
+            {{ end }}
+            {{ if .ContactDetails.Telephone }}
+                <li class="ons-list__item ons-u-mt-s">
+                    <p class="ons-u-mb-no">{{ localise "Phone" .Language 1 }}</p>
+                    <a href="tel:{{ .ContactDetails.Telephone | safeHTML }}">{{ .ContactDetails.Telephone }}</a>
+                </li>
+            {{ end }}
+        </ul>
+    </nav>
+    {{ template "partials/census/back-to-contents" . }}
+</section>

--- a/assets/templates/partials/static/publisher.tmpl
+++ b/assets/templates/partials/static/publisher.tmpl
@@ -1,0 +1,23 @@
+{{/*  TODO: the layout of these details needs to be confirmed */}}
+<div class="ons-grid__col ons-col-12@m">
+  {{ if .Publisher.Name}}
+  <dt class="ons-metadata__term ons-u-mr-xs">
+    {{ localise "PublisherName" .Language 1 }}
+  </dt>
+  <dd class="ons-metadata__value ons-u-f-no">{{ .Publisher.Name}}</dd>
+  {{ end }}
+
+  {{ if .Publisher.URL}}
+  <dt class="ons-metadata__term ons-u-mr-xs">
+    {{ localise "PublisherURL" .Language 1 }}
+  </dt>
+  <dd class="ons-metadata__value ons-u-f-no">{{ .Publisher.URL}}</dd>
+  {{ end }}
+
+  {{ if .Publisher.Type}}
+  <dt class="ons-metadata__term ons-u-mr-xs">
+    {{ localise "PublisherType" .Language 1 }}
+  </dt>
+  <dd class="ons-metadata__value ons-u-f-no">{{ .Publisher.Type}}</dd>
+  {{ end }}
+</div>

--- a/assets/templates/static.tmpl
+++ b/assets/templates/static.tmpl
@@ -74,7 +74,7 @@
       {{ template "partials/census/variables-table" . }}
       {{ template "partials/census/get-data" . }}
       {{ if .HasContactDetails }}
-      {{ template "partials/census/contact-details" . }}
+      {{ template "partials/static/contact-details" . }}
       {{ end }}
       {{ template "partials/census/protecting-personal-data" . }}
       {{ if .DatasetLandingPage.HasOtherVersions }}

--- a/handlers/filterable_landing_page.go
+++ b/handlers/filterable_landing_page.go
@@ -225,6 +225,7 @@ func filterableLanding(w http.ResponseWriter, req *http.Request, dc DatasetClien
 			cfg.EnableMultivariate, 
 			pop,
 		)
+		m.DatasetLandingPage.OSRLogo = helpers.GetOSRLogoDetails(m.Language)
 		rend.BuildPage(w, m, "static")
 	} else{
 		m := mapper.CreateFilterableLandingPage(
@@ -351,7 +352,8 @@ func censusLanding(cfg config.Config, ctx context.Context, w http.ResponseWriter
 	}
 
 	showAll := req.URL.Query()[queryStrKey]
-	basePage := rend.NewBasePageModel()
+	basePage := rend.NewBasePageModel() 
+
 	m := mapper.CreateCensusLandingPage(
 		req, 
 		basePage, 

--- a/handlers/filterable_landing_page.go
+++ b/handlers/filterable_landing_page.go
@@ -60,6 +60,7 @@ func filterableLanding(w http.ResponseWriter, req *http.Request, dc DatasetClien
 	// Fetch versions associated with dataset and redirect to latest if specific version isn't requested
 	q := dataset.QueryParams{Offset: 0, Limit: 1000}
 	allVers, err := dc.GetVersions(ctx, userAccessToken, "", "", collectionID, datasetID, edition, &q)
+
 	if err != nil {
 		setStatusCode(ctx, w, err)
 		return
@@ -92,6 +93,7 @@ func filterableLanding(w http.ResponseWriter, req *http.Request, dc DatasetClien
 	}
 
 	ver, err := dc.GetVersion(ctx, userAccessToken, "", "", collectionID, datasetID, edition, version)
+
 	if err != nil {
 		setStatusCode(ctx, w, err)
 		return
@@ -178,11 +180,7 @@ func filterableLanding(w http.ResponseWriter, req *http.Request, dc DatasetClien
 		categorisationsMap := getDimensionCategorisationCountMap(ctx, pc, userAccessToken, "", ver.Dimensions)
 		initialVersionReleaseDate := ""
 		idOfVersionBasedOn := "1" //This has been hardcoded as it is unclear if it is needed for static types. It simply makes it all work 
-	
-		if ver.Version != 1 {
-			ver, err = dc.GetVersion(ctx, userAccessToken, "", "", collectionID, datasetModel.ID, edition, idOfVersionBasedOn) 
-			initialVersionReleaseDate = ver.ReleaseDate
-		}
+				
 		if err != nil {
 			log.Error(ctx, "failed to get version", err)
 			setStatusCode(ctx, w, err)
@@ -206,6 +204,7 @@ func filterableLanding(w http.ResponseWriter, req *http.Request, dc DatasetClien
 
 		// 'Static' type builds page using census landing page mapper
 		// It is reccomended in the future to refactor, such that existing code within 'censusLanding' is shared
+
 		m := mapper.CreateCensusLandingPage(
 			req, 
 			basePage, 

--- a/handlers/filterable_landing_page.go
+++ b/handlers/filterable_landing_page.go
@@ -107,36 +107,35 @@ func filterableLanding(w http.ResponseWriter, req *http.Request, dc DatasetClien
 
 	if strings.Contains(datasetModel.Type, "cantabular") {
 		censusLanding(
-			cfg, 
-			ctx, 
-			w, 
-			req, 
-			dc, 
-			pc, 
-			datasetModel, 
-			rend, 
-			edition, 
-			ver, 
-			displayOtherVersionsLink, 
-			allVers.Items, 
-			latestVersionNumber, 
-			latestVersionURL, 
-			collectionID, 
-			lang, 
-			userAccessToken, 
-			homepageContent.ServiceMessage, 
+			cfg,
+			ctx,
+			w,
+			req,
+			dc,
+			pc,
+			datasetModel,
+			rend,
+			edition,
+			ver,
+			displayOtherVersionsLink,
+			allVers.Items,
+			latestVersionNumber,
+			latestVersionURL,
+			collectionID,
+			lang,
+			userAccessToken,
+			homepageContent.ServiceMessage,
 			homepageContent.EmergencyBanner,
 		)
 		return
 
 	}
 
-
 	dims := dataset.VersionDimensions{Items: nil}
 	var bc []zebedee.Breadcrumb
 
 	// Unless type is nomis or static, update values of bc and dims
-	if !( datasetModel.Type == "nomis" || datasetModel.Type == "static"){
+	if !(datasetModel.Type == "nomis" || datasetModel.Type == "static") {
 		dims, err = dc.GetVersionDimensions(ctx, userAccessToken, "", collectionID, datasetID, edition, version)
 		if err != nil {
 			setStatusCode(ctx, w, err)
@@ -176,21 +175,21 @@ func filterableLanding(w http.ResponseWriter, req *http.Request, dc DatasetClien
 	// Build page context and render
 	basePage := rend.NewBasePageModel()
 
-	if datasetModel.Type == "static"{
+	if datasetModel.Type == "static" {
 		categorisationsMap := getDimensionCategorisationCountMap(ctx, pc, userAccessToken, "", ver.Dimensions)
 		initialVersionReleaseDate := ""
-		idOfVersionBasedOn := "1" //This has been hardcoded as it is unclear if it is needed for static types. It simply makes it all work 
-				
+		idOfVersionBasedOn := "1" //This has been hardcoded as it is unclear if it is needed for static types. It simply makes it all work
+
 		if err != nil {
 			log.Error(ctx, "failed to get version", err)
 			setStatusCode(ctx, w, err)
 			return
 		}
-	
+
 		var form = req.URL.Query().Get("f")
 		var format = req.URL.Query().Get("format")
-		isValidationError := false 
-	
+		isValidationError := false
+
 		if form == "get-data" && format == "" {
 			isValidationError = true
 		}
@@ -205,49 +204,49 @@ func filterableLanding(w http.ResponseWriter, req *http.Request, dc DatasetClien
 		// 'Static' type builds page using census landing page mapper
 		// It is reccomended in the future to refactor, such that existing code within 'censusLanding' is shared
 
-		m := mapper.CreateCensusLandingPage(
-			req, 
-			basePage, 
-			datasetModel, 
-			ver, 
-			opts, 
-			categorisationsMap, 
-			initialVersionReleaseDate, 
-			hasOtherVersions, 
-			allVersions, 
-			latestVersionNumber, 
-			latestVersionURL, 
-			lang, 
-			showAll, 
-			isValidationError, 
-			homepageContent.ServiceMessage, 
-			homepageContent.EmergencyBanner, 
-			cfg.EnableMultivariate, 
+		m := mapper.CreateStaticOverviewPage(
+			req,
+			basePage,
+			datasetModel,
+			ver,
+			opts,
+			categorisationsMap,
+			initialVersionReleaseDate,
+			hasOtherVersions,
+			allVersions,
+			latestVersionNumber,
+			latestVersionURL,
+			lang,
+			showAll,
+			isValidationError,
+			homepageContent.ServiceMessage,
+			homepageContent.EmergencyBanner,
+			cfg.EnableMultivariate,
 			pop,
 		)
-		m.DatasetLandingPage.OSRLogo = helpers.GetOSRLogoDetails(m.Language)
+
 		rend.BuildPage(w, m, "static")
-	} else{
+	} else {
 		m := mapper.CreateFilterableLandingPage(
-			ctx, 
-			basePage, 
-			req, 
-			datasetModel, 
-			ver, 
-			datasetID, 
-			opts, 
-			dims, 
-			displayOtherVersionsLink, 
-			bc, 
-			latestVersionNumber, 
-			latestVersionURL, 
-			lang, 
-			apiRouterVersion, 
-			numOptsSummary, 
-			homepageContent.ServiceMessage, 
+			ctx,
+			basePage,
+			req,
+			datasetModel,
+			ver,
+			datasetID,
+			opts,
+			dims,
+			displayOtherVersionsLink,
+			bc,
+			latestVersionNumber,
+			latestVersionURL,
+			lang,
+			apiRouterVersion,
+			numOptsSummary,
+			homepageContent.ServiceMessage,
 			homepageContent.EmergencyBanner,
 		)
-		
+
 		for i, d := range m.DatasetLandingPage.Version.Downloads {
 			if len(cfg.DownloadServiceURL) > 0 {
 				downloadURL, err := url.Parse(d.URI)
@@ -255,12 +254,12 @@ func filterableLanding(w http.ResponseWriter, req *http.Request, dc DatasetClien
 					setStatusCode(ctx, w, err)
 					return
 				}
-	
+
 				d.URI = cfg.DownloadServiceURL + downloadURL.Path
 				m.DatasetLandingPage.Version.Downloads[i] = d
 			}
 		}
-	
+
 		// This needs to be after the for-loop to add the download files,
 		// because the loop adds the download services domain to the URLs
 		// which this text file doesn't need because it's created on-the-fly
@@ -270,14 +269,14 @@ func filterableLanding(w http.ResponseWriter, req *http.Request, dc DatasetClien
 			Size:      strconv.Itoa(len(textBytes)),
 			URI:       fmt.Sprintf("/datasets/%s/editions/%s/versions/%s/metadata.txt", datasetID, edition, version),
 		})
-	
+
 		m.DatasetLandingPage.OSRLogo = helpers.GetOSRLogoDetails(m.Language)
-		
+
 		templateName := "filterable"
 		if datasetModel.Type == "nomis" {
 			templateName = "nomis"
 		}
-	
+
 		rend.BuildPage(w, m, templateName)
 	}
 }
@@ -315,22 +314,22 @@ func censusLanding(cfg config.Config, ctx context.Context, w http.ResponseWriter
 
 	dims := dataset.VersionDimensions{Items: version.Dimensions}
 	categorisationsMap := getDimensionCategorisationCountMap(
-		ctx, 
-		pc, 
-		userAccessToken, 
-		idOfVersionBasedOn, 
+		ctx,
+		pc,
+		userAccessToken,
+		idOfVersionBasedOn,
 		version.Dimensions,
 	)
 
 	opts, err := getOptionsSummary(
-		ctx, 
-		dc, 
-		userAccessToken, 
-		collectionID, 
-		datasetModel.ID, 
-		edition, 
-		fmt.Sprint(version.Version), 
-		dims, 
+		ctx,
+		dc,
+		userAccessToken,
+		collectionID,
+		datasetModel.ID,
+		edition,
+		fmt.Sprint(version.Version),
+		dims,
 		numOptsSummary,
 	)
 	if err != nil {
@@ -352,31 +351,31 @@ func censusLanding(cfg config.Config, ctx context.Context, w http.ResponseWriter
 	}
 
 	showAll := req.URL.Query()[queryStrKey]
-	basePage := rend.NewBasePageModel() 
+	basePage := rend.NewBasePageModel()
 
 	m := mapper.CreateCensusLandingPage(
-		req, 
-		basePage, 
-		datasetModel, 
-		version, 
-		opts, 
-		categorisationsMap, 
-		initialVersionReleaseDate, 
-		hasOtherVersions, 
-		allVersions, 
-		latestVersionNumber, 
-		latestVersionURL, 
-		lang, 
-		showAll, 
-		isValidationError, 
-		serviceMessage, 
-		emergencyBannerContent, 
-		cfg.EnableMultivariate, 
+		req,
+		basePage,
+		datasetModel,
+		version,
+		opts,
+		categorisationsMap,
+		initialVersionReleaseDate,
+		hasOtherVersions,
+		allVersions,
+		latestVersionNumber,
+		latestVersionURL,
+		lang,
+		showAll,
+		isValidationError,
+		serviceMessage,
+		emergencyBannerContent,
+		cfg.EnableMultivariate,
 		pop,
 	)
 	m.DatasetLandingPage.OSRLogo = helpers.GetOSRLogoDetails(m.Language)
 
-	if datasetModel.Type == "static"{
+	if datasetModel.Type == "static" {
 		rend.BuildPage(w, m, "static")
 	} else {
 		rend.BuildPage(w, m, "census-landing")

--- a/mapper/census_base.go
+++ b/mapper/census_base.go
@@ -179,6 +179,12 @@ func getContactDetails(d dataset.DatasetDetails) (contact.Details, bool) {
 
 	if d.Contacts != nil && len(*d.Contacts) > 0 {
 		contacts := *d.Contacts
+		if d.Type == "static" {
+			if contacts[0].Name != "" {
+				details.Name = contacts[0].Name
+				hasContactDetails = true
+			}
+		}
 		if contacts[0].Telephone != "" {
 			details.Telephone = contacts[0].Telephone
 			hasContactDetails = true

--- a/mapper/census_base.go
+++ b/mapper/census_base.go
@@ -29,7 +29,6 @@ func CreateCensusBasePage(req *http.Request, basePage coreModel.Page, d dataset.
 	}
 
 	MapCookiePreferences(req, &p.Page.CookiesPreferencesSet, &p.Page.CookiesPolicy)
-
 	// PAGE META-DATA
 	p.Type = d.Type
 	p.Metadata.Title = d.Title

--- a/mapper/census_landing_page.go
+++ b/mapper/census_landing_page.go
@@ -18,7 +18,27 @@ import (
 )
 
 // CreateCensusLandingPage creates a census-landing page based on api model responses
-func CreateCensusLandingPage(req *http.Request, basePage coreModel.Page, d dataset.DatasetDetails, version dataset.Version, opts []dataset.Options, categorisationsMap map[string]int, initialVersionReleaseDate string, hasOtherVersions bool, allVersions []dataset.Version, latestVersionNumber int, latestVersionURL, lang string, queryStrValues []string, isValidationError bool, serviceMessage string, emergencyBannerContent zebedee.EmergencyBanner, isEnableMultivariate bool, pop population.GetPopulationTypeResponse) census.Page {
+func CreateCensusLandingPage(
+	req *http.Request, 
+	basePage coreModel.Page, 
+	d dataset.DatasetDetails, 
+	version dataset.Version, 
+	opts []dataset.Options, 
+	categorisationsMap map[string]int, 
+	initialVersionReleaseDate string, 
+	hasOtherVersions bool, 
+	allVersions []dataset.Version, 
+	latestVersionNumber int, 
+	latestVersionURL, 
+	lang string, 
+	queryStrValues []string, 
+	isValidationError bool, 
+	serviceMessage string, 
+	emergencyBannerContent zebedee.EmergencyBanner, 
+	isEnableMultivariate bool, 
+	pop population.GetPopulationTypeResponse,
+) census.Page {
+
 	p := CreateCensusBasePage(req, basePage, d, version, initialVersionReleaseDate, hasOtherVersions, allVersions, latestVersionNumber, latestVersionURL, lang, isValidationError, serviceMessage, emergencyBannerContent, isEnableMultivariate)
 
 	// DOWNLOADS

--- a/mapper/legacy.go
+++ b/mapper/legacy.go
@@ -12,7 +12,7 @@ import (
 	"github.com/ONSdigital/dp-api-clients-go/v2/zebedee"
 	"github.com/ONSdigital/dp-frontend-dataset-controller/model/contact"
 	"github.com/ONSdigital/dp-frontend-dataset-controller/model/related"
-	"github.com/ONSdigital/dp-frontend-dataset-controller/model/static"
+	"github.com/ONSdigital/dp-frontend-dataset-controller/model/staticlegacy"
 	coreModel "github.com/ONSdigital/dp-renderer/v2/model"
 	topicModel "github.com/ONSdigital/dp-topic-api/models"
 	"github.com/ONSdigital/log.go/v2/log"
@@ -21,7 +21,7 @@ import (
 const staticFilesDownloadEndpoint = "downloads-new"
 
 // StaticDatasetLandingPage is a StaticDatasetLandingPage representation
-type StaticDatasetLandingPage static.Page
+type StaticDatasetLandingPage staticlegacy.Page
 
 // CreateLegacyDatasetLanding maps a zebedee response struct into a frontend model to be used for rendering
 //
@@ -113,21 +113,21 @@ func CreateLegacyDatasetLanding(ctx context.Context, basePage coreModel.Page, re
 	}
 
 	for i := range ds {
-		var dataset static.Dataset
+		var dataset staticlegacy.Dataset
 		dataset.URI = ds[i].URI
 		dataset.VersionLabel = ds[i].Description.VersionLabel
 
 		for _, download := range ds[i].Downloads {
 			if download.URI != "" { // i.e. new static files sourced files
 				filePath := strings.TrimPrefix(download.URI, "/")
-				dataset.Downloads = append(dataset.Downloads, static.Download{
+				dataset.Downloads = append(dataset.Downloads, staticlegacy.Download{
 					URI:         download.URI,
 					DownloadURL: fmt.Sprintf("/%s/%s", staticFilesDownloadEndpoint, filePath),
 					Extension:   strings.TrimPrefix(filepath.Ext(download.URI), "."),
 					Size:        download.Size,
 				})
 			} else { // old legacy Zebedee-source files
-				dataset.Downloads = append(dataset.Downloads, static.Download{
+				dataset.Downloads = append(dataset.Downloads, staticlegacy.Download{
 					URI:         download.File,
 					DownloadURL: fmt.Sprintf("/file?uri=%s/%s", dataset.URI, download.File),
 					Extension:   strings.TrimPrefix(filepath.Ext(download.File), "."),
@@ -138,7 +138,7 @@ func CreateLegacyDatasetLanding(ctx context.Context, basePage coreModel.Page, re
 		for _, supplementaryFile := range ds[i].SupplementaryFiles {
 			if supplementaryFile.URI != "" { // i.e. new static files sourced files
 				filePath := strings.TrimPrefix(supplementaryFile.URI, "/")
-				dataset.SupplementaryFiles = append(dataset.SupplementaryFiles, static.SupplementaryFile{
+				dataset.SupplementaryFiles = append(dataset.SupplementaryFiles, staticlegacy.SupplementaryFile{
 					Title:       supplementaryFile.Title,
 					URI:         supplementaryFile.URI,
 					DownloadURL: fmt.Sprintf("/%s/%s", staticFilesDownloadEndpoint, filePath),
@@ -146,7 +146,7 @@ func CreateLegacyDatasetLanding(ctx context.Context, basePage coreModel.Page, re
 					Size:        supplementaryFile.Size,
 				})
 			} else { // old legacy Zebedee-source files
-				dataset.SupplementaryFiles = append(dataset.SupplementaryFiles, static.SupplementaryFile{
+				dataset.SupplementaryFiles = append(dataset.SupplementaryFiles, staticlegacy.SupplementaryFile{
 					Title:       supplementaryFile.Title,
 					URI:         supplementaryFile.File,
 					DownloadURL: fmt.Sprintf("/file?uri=%s/%s", dataset.URI, supplementaryFile.File),
@@ -171,12 +171,12 @@ func CreateLegacyDatasetLanding(ctx context.Context, basePage coreModel.Page, re
 			log.Error(ctx, "unrecognised alert type", errors.New("unrecognised alert type"), log.Data{"alert": value})
 			fallthrough
 		case "alert":
-			sdlp.DatasetLandingPage.Notices = append(sdlp.DatasetLandingPage.Notices, static.Message{
+			sdlp.DatasetLandingPage.Notices = append(sdlp.DatasetLandingPage.Notices, staticlegacy.Message{
 				Date:     value.Date,
 				Markdown: value.Markdown,
 			})
 		case "correction":
-			sdlp.DatasetLandingPage.Corrections = append(sdlp.DatasetLandingPage.Corrections, static.Message{
+			sdlp.DatasetLandingPage.Corrections = append(sdlp.DatasetLandingPage.Corrections, staticlegacy.Message{
 				Date:     value.Date,
 				Markdown: value.Markdown,
 			})

--- a/mapper/static.go
+++ b/mapper/static.go
@@ -1,0 +1,14 @@
+package mapper
+
+import (
+	"github.com/ONSdigital/dp-frontend-dataset-controller/model/static"
+)
+
+// formatPanels is a helper function given an array of panels will format the final panel with the appropriate css class
+func formatStaticPanels(panels []static.Panel) []static.Panel {
+	if len(panels) > 0 {
+		panelLen := len(panels)
+		panels[panelLen-1].CSSClasses = append(panels[panelLen-1].CSSClasses, "ons-u-mb-l")
+	}
+	return panels
+}

--- a/mapper/static_base.go
+++ b/mapper/static_base.go
@@ -1,0 +1,324 @@
+package mapper
+
+import (
+	"net/http"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/ONSdigital/dp-api-clients-go/v2/dataset"
+	"github.com/ONSdigital/dp-api-clients-go/v2/zebedee"
+	"github.com/ONSdigital/dp-frontend-dataset-controller/helpers"
+	sharedModel "github.com/ONSdigital/dp-frontend-dataset-controller/model"
+	"github.com/ONSdigital/dp-frontend-dataset-controller/model/publisher"
+	"github.com/ONSdigital/dp-frontend-dataset-controller/model/static"
+	"github.com/ONSdigital/dp-renderer/v2/helper"
+	coreModel "github.com/ONSdigital/dp-renderer/v2/model"
+)
+
+// CreateCensusBasePage builds a base datasetLandingPageCensus.Page with shared functionality between Dataset Landing Pages and Filter Output pages
+func CreateStaticBasePage(
+	req *http.Request,
+	basePage coreModel.Page,
+	d dataset.DatasetDetails,
+	version dataset.Version,
+	initialVersionReleaseDate string,
+	hasOtherVersions bool,
+	allVersions []dataset.Version,
+	latestVersionNumber int,
+	latestVersionURL,
+	lang string,
+	isValidationError bool,
+	serviceMessage string,
+	emergencyBannerContent zebedee.EmergencyBanner,
+	isEnableMultivariate bool,
+) static.Page {
+	p := static.Page{
+		Page: basePage,
+	}
+
+	MapCookiePreferences(req, &p.Page.CookiesPreferencesSet, &p.Page.CookiesPolicy)
+	// PAGE META-DATA
+	p.Type = d.Type
+	p.Metadata.Title = d.Title
+	p.Language = lang
+	p.URI = req.URL.Path
+	p.Metadata.Description = d.Description
+	p.IsNationalStatistic = d.NationalStatistic
+	p.DatasetId = d.ID
+	p.ContactDetails, p.HasContactDetails = getContactDetails(d)
+
+	p.Version.ReleaseDate = version.ReleaseDate
+	p.ReleaseDate = getReleaseDate(initialVersionReleaseDate, p.Version.ReleaseDate)
+
+	p.DatasetLandingPage.Description = strings.Split(d.Description, "\n")
+	p.DatasetLandingPage.HasOtherVersions = hasOtherVersions
+
+	p.DatasetLandingPage.IsMultivariate = strings.Contains(d.Type, "multivariate") && isEnableMultivariate
+	p.DatasetLandingPage.IsFlexibleForm = p.DatasetLandingPage.IsMultivariate || strings.Contains(d.Type, "flexible")
+
+	p.Publisher = getPublisherDetails(d)
+
+	p.DatasetLandingPage.OSRLogo = helpers.GetOSRLogoDetails(lang)
+
+	// SITE-WIDE BANNERS
+	p.BetaBannerEnabled = true
+	p.ServiceMessage = serviceMessage
+	p.EmergencyBanner = mapEmergencyBanner(emergencyBannerContent)
+
+	// CENSUS BRANDING
+	p.ShowCensusBranding = d.Survey == "census"
+
+	// BREADCRUMBS
+	p.Breadcrumb = []coreModel.TaxonomyNode{
+		{
+			Title: "Home",
+			URI:   "/",
+		},
+		{
+			Title: "Census",
+			URI:   "/census",
+		},
+	}
+
+	// FEEDBACK API
+	p.FeatureFlags.EnableFeedbackAPI = cfg.EnableFeedbackAPI
+	p.FeatureFlags.FeedbackAPIURL = cfg.FeedbackAPIURL
+
+	// BACK LINK
+	p.BackTo = coreModel.BackTo{
+		Text: coreModel.Localisation{
+			LocaleKey: "BackToContents",
+			Plural:    4,
+		},
+		AnchorFragment: "toc",
+	}
+
+	// ALERTS
+	if version.Alerts != nil {
+		for _, alert := range *version.Alerts {
+			switch alert.Type {
+			case CorrectionAlertType:
+				p.DatasetLandingPage.Panels = append(p.DatasetLandingPage.Panels, static.Panel{
+					DisplayIcon: true,
+					Body:        []string{helper.Localise("HasCorrectionNotice", lang, 1)},
+					CSSClasses:  []string{"ons-u-mt-m", "ons-u-mb-l"},
+				})
+			case AlertType:
+				p.DatasetLandingPage.Panels = append(p.DatasetLandingPage.Panels, static.Panel{
+					DisplayIcon: true,
+					Body:        []string{helper.Localise("HasAlert", lang, 1, alert.Description)},
+					CSSClasses:  []string{"ons-u-mt-m", "ons-u-mb-l"},
+				})
+			}
+		}
+	}
+
+	// TABLE OF CONTENTS
+	p.TableOfContents = buildStaticTableOfContents(p, d, hasOtherVersions)
+
+	// VERSIONS TABLE
+	if hasOtherVersions {
+		for i := range allVersions {
+			var version sharedModel.Version
+			version.VersionNumber = allVersions[i].Version
+			version.ReleaseDate = allVersions[i].ReleaseDate
+			versionURL := helpers.DatasetVersionURL(
+				allVersions[i].Links.Dataset.ID,
+				allVersions[i].Edition,
+				strconv.Itoa(allVersions[i].Version))
+			version.VersionURL = versionURL
+			version.IsCurrentPage = versionURL == req.URL.Path
+			mapCorrectionAlert(&allVersions[i], &version)
+
+			p.Versions = append(p.Versions, version)
+		}
+
+		sort.Slice(p.Versions, func(i, j int) bool { return p.Versions[i].VersionNumber > p.Versions[j].VersionNumber })
+
+		p.DatasetLandingPage.LatestVersionURL = latestVersionURL
+	}
+
+	// LATEST VERSIONS PANEL
+	if latestVersionNumber != version.Version && hasOtherVersions {
+		p.DatasetLandingPage.Panels = append(p.DatasetLandingPage.Panels, static.Panel{
+			DisplayIcon: true,
+			Body:        []string{helper.Localise("HasNewVersion", lang, 1, latestVersionURL)},
+			CSSClasses:  []string{"ons-u-mt-m", "ons-u-mb-l"},
+		})
+	}
+
+	// SHARING LINKS
+	currentURL := helpers.GetCurrentURL(lang, p.SiteDomain, req.URL.Path)
+	p.DatasetLandingPage.DatasetURL = currentURL
+	p.DatasetLandingPage.ShareDetails = buildStaticSharingDetails(d, lang, currentURL)
+
+	// RELATED CONTENT
+	p.DatasetLandingPage.RelatedContentItems = []static.RelatedContentItem{}
+	if d.RelatedContent != nil {
+		for _, content := range *d.RelatedContent {
+			p.DatasetLandingPage.RelatedContentItems = append(p.DatasetLandingPage.RelatedContentItems, static.RelatedContentItem{
+				Title: content.Title,
+				Link:  content.HRef,
+				Text:  content.Description,
+			})
+		}
+	}
+
+	// ERRORS
+	if isValidationError {
+		p.Error = coreModel.Error{
+			Title: p.Metadata.Title,
+			ErrorItems: []coreModel.ErrorItem{
+				{
+					Description: coreModel.Localisation{
+						LocaleKey: "GetDataValidationError",
+						Plural:    1,
+					},
+					URL: "#select-format-error",
+				},
+			},
+			Language: lang,
+		}
+	}
+
+	return p
+}
+
+func buildStaticSharingDetails(d dataset.DatasetDetails, lang, currentURL string) static.ShareDetails {
+	shareDetails := static.ShareDetails{}
+	shareDetails.Language = lang
+	shareDetails.ShareLocations = []static.Share{
+		{
+			Title: "Facebook",
+			Link:  helpers.GenerateSharingLink("facebook", currentURL, d.Title),
+			Icon:  "facebook",
+		},
+		{
+			Title: "Twitter",
+			Link:  helpers.GenerateSharingLink("twitter", currentURL, d.Title),
+			Icon:  "twitter",
+		},
+		{
+			Title: "LinkedIn",
+			Link:  helpers.GenerateSharingLink("linkedin", currentURL, d.Title),
+			Icon:  "linkedin",
+		},
+		{
+			Title: "Email",
+			Link:  helpers.GenerateSharingLink("email", currentURL, d.Title),
+			Icon:  "email",
+		},
+	}
+	return shareDetails
+}
+
+func buildStaticTableOfContents(p static.Page, d dataset.DatasetDetails, hasOtherVersions bool) coreModel.TableOfContents {
+	sections := make(map[string]coreModel.ContentSection)
+	displayOrder := make([]string, 0)
+
+	tableOfContents := coreModel.TableOfContents{
+		AriaLabel: coreModel.Localisation{
+			LocaleKey: "ContentsAria",
+			Plural:    1,
+		},
+		Title: coreModel.Localisation{
+			LocaleKey: "Contents",
+			Plural:    1,
+		},
+	}
+
+	sections["summary"] = coreModel.ContentSection{
+		Title: coreModel.Localisation{
+			LocaleKey: "Summary",
+			Plural:    1,
+		},
+	}
+	displayOrder = append(displayOrder, "summary")
+
+	sections["variables"] = coreModel.ContentSection{
+		Title: coreModel.Localisation{
+			LocaleKey: "Variables",
+			Plural:    4,
+		},
+	}
+	displayOrder = append(displayOrder, "variables")
+
+	sections["get-data"] = coreModel.ContentSection{
+		Title: coreModel.Localisation{
+			LocaleKey: "GetData",
+			Plural:    1,
+		},
+	}
+	displayOrder = append(displayOrder, "get-data")
+
+	if p.HasContactDetails {
+		sections["contact"] = coreModel.ContentSection{
+			Title: coreModel.Localisation{
+				LocaleKey: "ContactUs",
+				Plural:    1,
+			},
+		}
+		displayOrder = append(displayOrder, "contact")
+	}
+
+	sections["protecting-personal-data"] = coreModel.ContentSection{
+		Title: coreModel.Localisation{
+			LocaleKey: "ProtectingPersonalDataTitle",
+			Plural:    1,
+		},
+	}
+	displayOrder = append(displayOrder, "protecting-personal-data")
+
+	if hasOtherVersions {
+		sections["version-history"] = coreModel.ContentSection{
+			Title: coreModel.Localisation{
+				LocaleKey: "VersionHistory",
+				Plural:    1,
+			},
+		}
+		displayOrder = append(displayOrder, "version-history")
+	}
+
+	if d.RelatedContent != nil {
+		sections["related-content"] = coreModel.ContentSection{
+			Title: coreModel.Localisation{
+				LocaleKey: "RelatedContentTitle",
+				Plural:    1,
+			},
+		}
+		displayOrder = append(displayOrder, "related-content")
+	}
+
+	tableOfContents.Sections = sections
+	tableOfContents.DisplayOrder = displayOrder
+
+	return tableOfContents
+}
+
+func getPublisherDetails(d dataset.DatasetDetails) publisher.Publisher {
+	publisherInstance := publisher.Publisher{}
+
+	// TODO: this code should be refactored to be uncoupled from predefined variables
+	// Currennt available variables:
+	// 		URL  string `json:"href"`
+	// 		Name string `json:"name"`
+	// 		Type string `json:"type"`
+
+	if d.Publisher != nil {
+		incomingPublisherDataset := *d.Publisher
+
+		if incomingPublisherDataset.URL != "" {
+			publisherInstance.URL = incomingPublisherDataset.URL
+		}
+
+		if incomingPublisherDataset.Name != "" {
+			publisherInstance.Name = incomingPublisherDataset.Name
+		}
+		if incomingPublisherDataset.Type != "" {
+			publisherInstance.Type = incomingPublisherDataset.Type
+		}
+	}
+
+	return publisherInstance
+}

--- a/model/datasetLandingPageFilterable/model.go
+++ b/model/datasetLandingPageFilterable/model.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/ONSdigital/dp-frontend-dataset-controller/model/contact"
 	"github.com/ONSdigital/dp-frontend-dataset-controller/model/osrlogo"
-	"github.com/ONSdigital/dp-frontend-dataset-controller/model/static"
+	"github.com/ONSdigital/dp-frontend-dataset-controller/model/staticlegacy"
 	"github.com/ONSdigital/dp-renderer/v2/model"
 )
 
@@ -18,7 +18,7 @@ type Page struct {
 
 // DatasetLandingPage represents the data on the dataset landing page
 type DatasetLandingPage struct {
-	static.DatasetLandingPage
+	staticlegacy.DatasetLandingPage
 	Dimensions               []sharedModel.Dimension `json:"dimensions"`
 	Version                  sharedModel.Version     `json:"version"`
 	HasOlderVersions         bool                    `json:"has_older_versions"`

--- a/model/publisher/model.go
+++ b/model/publisher/model.go
@@ -1,0 +1,8 @@
+package publisher
+
+// Publisher represents the data for a single publisher
+type Publisher struct {
+	URL  string `json:"href"`
+	Name string `json:"name"`
+	Type string `json:"type"`
+}

--- a/model/static/model.go
+++ b/model/static/model.go
@@ -1,80 +1,72 @@
 package static
 
 import (
+	sharedModel "github.com/ONSdigital/dp-frontend-dataset-controller/model"
 	"github.com/ONSdigital/dp-frontend-dataset-controller/model/contact"
 	"github.com/ONSdigital/dp-frontend-dataset-controller/model/osrlogo"
-	"github.com/ONSdigital/dp-frontend-dataset-controller/model/related"
+	"github.com/ONSdigital/dp-frontend-dataset-controller/model/publisher"
+
 	"github.com/ONSdigital/dp-renderer/v2/model"
 )
 
-// Page contains data re-used for each page type a Data struct for data specific to the page type
+// Page contains data for the census landing page
 type Page struct {
 	model.Page
-	DatasetLandingPage DatasetLandingPage `json:"data"`
-	FilterID           string             `json:"filter_id"`
-	contact.Details
+	DatasetLandingPage  DatasetLandingPage    `json:"data"`
+	Version             sharedModel.Version   `json:"version"`
+	Versions            []sharedModel.Version `json:"versions"`
+	ID                  string                `json:"id"`
+	ContactDetails      contact.Details       `json:"contact_details"`
+	HasContactDetails   bool                  `json:"has_contact_details"`
+	IsNationalStatistic bool                  `json:"is_national_statistic"`
+	ShowCensusBranding  bool                  `json:"show_census_branding"`
+	Publisher           publisher.Publisher   `json:"publisher,omitempty"`
 }
 
-// DatasetLandingPage represents a frontend dataset landing page
+// StaticOverviewPage contains properties related to the static dataset
 type DatasetLandingPage struct {
-	DatasetID           string          `json:"dataset_id"`
-	FilterID            string          `json:"filter_id"`
-	Related             Related         `json:"related"`
-	Datasets            []Dataset       `json:"datasets"`
-	Notes               string          `json:"markdown"`
-	MetaDescription     string          `json:"meta_description"`
-	IsNationalStatistic bool            `json:"national_statistic"`
-	Survey              string          `json:"survey"`
-	ReleaseDate         string          `json:"release_date"`
-	NextRelease         string          `json:"next_release"`
-	IsTimeseries        bool            `json:"is_timeseries"`
-	Corrections         []Message       `json:"corrections"`
-	Notices             []Message       `json:"notices"`
-	ParentPath          string          `json:"parent_path"`
-	OSRLogo             osrlogo.OSRLogo `json:"osr_logo"`
-	EnableFeedbackAPI   bool            `json:"enable_feedback_api"`
-	FeedbackAPIURL      string          `json:"feedback_api_url"`
+	HasOtherVersions    bool                    `json:"has_other_versions"`
+	HasDownloads        bool                    `json:"has_downloads"`
+	LatestVersionURL    string                  `json:"latest_version_url"`
+	Dimensions          []sharedModel.Dimension `json:"dimensions"`
+	ShareDetails        ShareDetails
+	Description         []string             `json:"description"`
+	IsCustom            bool                 `json:"is_custom"`
+	IsFlexibleForm      bool                 `json:"is_flexible_form"`
+	DatasetURL          string               `json:"dataset_url"`
+	Panels              []Panel              `json:"panels"`
+	QualityStatements   []Panel              `json:"quality_statements"`
+	SDC                 []Panel              `json:"sdc"`
+	HasSDC              bool                 `json:"has_sdc"`
+	RelatedContentItems []RelatedContentItem `json:"related_content_items"`
+	IsMultivariate      bool                 `json:"is_multivariate"`
+	ShowXLSXInfo        bool                 `json:"show_xlsx_info"`
+	OSRLogo             osrlogo.OSRLogo      `json:"osr_logo"`
+	EnableFeedbackAPI   bool                 `json:"enable_feedback_api"`
+	FeedbackAPIURL      string               `json:"feedback_api_url"`
+	ImproveResults      model.Collapsible
 }
 
-// Related content (split by type) to this page
-type Related struct {
-	Publications       []related.Related `json:"related_publications"`
-	FilterableDatasets []related.Related `json:"related_filterable_datasets"`
-	Datasets           []related.Related `json:"related_datasets"`
-	Methodology        []related.Related `json:"related_methodology"`
-	Links              []related.Related `json:"related_links"`
+// ShareDetails contains the locations the page can be shared to, as well as the language attribute for localisation
+type ShareDetails struct {
+	ShareLocations []Share `json:"share_locations"`
+	Language       string  `json:"language"`
 }
 
-// Dataset has the file and title information for an individual dataset
-type Dataset struct {
-	Title              string              `json:"title"`
-	Downloads          []Download          `json:"downloads"`
-	URI                string              `json:"uri"`
-	HasVersions        bool                `json:"has_versions"`
-	SupplementaryFiles []SupplementaryFile `json:"supplementary_files"`
-	VersionLabel       string              `json:"version_label"`
-	IsLast             bool                `json:"is_last"`
+/*
+Share includes details for a specific place the dataset can be shared
+Included icons: 'facebook', 'twitter', 'email', 'linkedin'
+*/
+type Share struct {
+	Title string `json:"title"`
+	Link  string `json:"link"`
+	Icon  string `json:"icon"`
 }
 
-// Download has the details for the an individual dataset's downloadable files
-type Download struct {
-	Extension   string `json:"extension"`
-	Size        string `json:"size"`
-	URI         string `json:"uri"`
-	DownloadURL string `json:"download_url"`
-}
-
-// SupplementaryFile is a downloadable file that is associated to an individual dataset
-type SupplementaryFile struct {
-	Title       string `json:"title"`
-	Extension   string `json:"extension"`
-	Size        string `json:"size"`
-	URI         string `json:"uri"`
-	DownloadURL string `json:"download_url"`
-}
-
-// Message has a date and time, used for either correction or notices
-type Message struct {
-	Date     string `json:"date"`
-	Markdown string `json:"markdown"`
+/* RelatedContentItem contains details for a section of related content
+ */
+type RelatedContentItem struct {
+	Title string `json:"title"`
+	Link  string `json:"link"`
+	Text  string `json:"text"`
 }

--- a/model/static/panel.go
+++ b/model/static/panel.go
@@ -1,0 +1,34 @@
+package static
+
+type PanelType int
+
+const (
+	Info PanelType = iota
+	Pending
+	Success
+	Error
+)
+
+// Panel contains the data required to populate a panel UI component
+type Panel struct {
+	Type        PanelType `json:"type"`
+	DisplayIcon bool      `json:"display_icon"`
+	CSSClasses  []string  `json:"css_classes"`
+	Body        []string  `json:"body"`
+	Language    string    `json:"language"`
+}
+
+// FuncGetPanelType returns the panel type as a string
+func (p Panel) FuncGetPanelType() (panelType string) {
+	switch p.Type {
+	case Info:
+		return "info"
+	case Pending:
+		return "pending"
+	case Success:
+		return "success"
+	case Error:
+		return "error"
+	}
+	return panelType
+}

--- a/model/static/panel_test.go
+++ b/model/static/panel_test.go
@@ -1,0 +1,52 @@
+package static
+
+import (
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestFuncGetPanelType(t *testing.T) {
+	Convey("Given a panel struct", t, func() {
+		Convey("When the FuncGetPanelType function is called", func() {
+			Convey("Then it returns the expected panel type", func() {
+				tc := []struct {
+					given    int
+					expected string
+				}{
+					{
+						// info returned to ensure backwards compatibility
+						given:    0,
+						expected: "info",
+					},
+					{
+						given:    int(Info),
+						expected: "info",
+					},
+					{
+						given:    int(Pending),
+						expected: "pending",
+					},
+					{
+						given:    int(Success),
+						expected: "success",
+					},
+					{
+						given:    int(Error),
+						expected: "error",
+					},
+					{
+						given:    25,
+						expected: "",
+					},
+				}
+				for _, t := range tc {
+					mockPanel := Panel{
+						Type: PanelType(t.given),
+					}
+					So(mockPanel.FuncGetPanelType(), ShouldEqual, t.expected)
+				}
+			})
+		})
+	})
+}

--- a/model/staticlegacy/model.go
+++ b/model/staticlegacy/model.go
@@ -1,0 +1,80 @@
+package staticlegacy
+
+import (
+	"github.com/ONSdigital/dp-frontend-dataset-controller/model/contact"
+	"github.com/ONSdigital/dp-frontend-dataset-controller/model/osrlogo"
+	"github.com/ONSdigital/dp-frontend-dataset-controller/model/related"
+	"github.com/ONSdigital/dp-renderer/v2/model"
+)
+
+// Page contains data re-used for each page type a Data struct for data specific to the page type
+type Page struct {
+	model.Page
+	DatasetLandingPage DatasetLandingPage `json:"data"`
+	FilterID           string             `json:"filter_id"`
+	contact.Details
+}
+
+// DatasetLandingPage represents a frontend dataset landing page
+type DatasetLandingPage struct {
+	DatasetID           string          `json:"dataset_id"`
+	FilterID            string          `json:"filter_id"`
+	Related             Related         `json:"related"`
+	Datasets            []Dataset       `json:"datasets"`
+	Notes               string          `json:"markdown"`
+	MetaDescription     string          `json:"meta_description"`
+	IsNationalStatistic bool            `json:"national_statistic"`
+	Survey              string          `json:"survey"`
+	ReleaseDate         string          `json:"release_date"`
+	NextRelease         string          `json:"next_release"`
+	IsTimeseries        bool            `json:"is_timeseries"`
+	Corrections         []Message       `json:"corrections"`
+	Notices             []Message       `json:"notices"`
+	ParentPath          string          `json:"parent_path"`
+	OSRLogo             osrlogo.OSRLogo `json:"osr_logo"`
+	EnableFeedbackAPI   bool            `json:"enable_feedback_api"`
+	FeedbackAPIURL      string          `json:"feedback_api_url"`
+}
+
+// Related content (split by type) to this page
+type Related struct {
+	Publications       []related.Related `json:"related_publications"`
+	FilterableDatasets []related.Related `json:"related_filterable_datasets"`
+	Datasets           []related.Related `json:"related_datasets"`
+	Methodology        []related.Related `json:"related_methodology"`
+	Links              []related.Related `json:"related_links"`
+}
+
+// Dataset has the file and title information for an individual dataset
+type Dataset struct {
+	Title              string              `json:"title"`
+	Downloads          []Download          `json:"downloads"`
+	URI                string              `json:"uri"`
+	HasVersions        bool                `json:"has_versions"`
+	SupplementaryFiles []SupplementaryFile `json:"supplementary_files"`
+	VersionLabel       string              `json:"version_label"`
+	IsLast             bool                `json:"is_last"`
+}
+
+// Download has the details for the an individual dataset's downloadable files
+type Download struct {
+	Extension   string `json:"extension"`
+	Size        string `json:"size"`
+	URI         string `json:"uri"`
+	DownloadURL string `json:"download_url"`
+}
+
+// SupplementaryFile is a downloadable file that is associated to an individual dataset
+type SupplementaryFile struct {
+	Title       string `json:"title"`
+	Extension   string `json:"extension"`
+	Size        string `json:"size"`
+	URI         string `json:"uri"`
+	DownloadURL string `json:"download_url"`
+}
+
+// Message has a date and time, used for either correction or notices
+type Message struct {
+	Date     string `json:"date"`
+	Markdown string `json:"markdown"`
+}


### PR DESCRIPTION
### What
#### New stuff
- Add contact details — https://jira.ons.gov.uk/browse/DIS-2281 
- Show 'newer version available' alert — https://jira.ons.gov.uk/browse/DIS-2284
- Show a list of versions with link to them and reason for creation — https://jira.ons.gov.uk/browse/DIS-2285
- Ensure that bookmark component renders and copy functionality works — https://jira.ons.gov.uk/browse/DIS-2296
- Ensure OSR Logo renders
- Ensure contextual information (Release date, last updated, newer version warning and quality indicators) renders — https://jira.ons.gov.uk/browse/DIS-2280

#### Other, related stuff
Some of best-practise tickets can be assumed to be followed as part of this piece of work. 
- Ensure page is build using re-usable components — https://jira.ons.gov.uk/browse/DIS-2282
- Mobile compatibility — https://jira.ons.gov.uk/browse/DIS-2289
- Search engine readable (the metadata is set up in the metadata tag, and this is being set as the 'description' which can be checked by inspecting the <meta> tags in the browser and comparing to what was set as the description [also sometimes called dataset 'summary']) — https://jira.ons.gov.uk/browse/DIS-2291
- Has design alignment. I.e. it follows the design system that was set out before. This is being done, with the CSS and components being reused/ created from preexisting content to ensure it follows this criteria — https://jira.ons.gov.uk/browse/DIS-2286
-  Feedback form included — https://jira.ons.gov.uk/browse/DIS-2297



### How to review
 - Create a 'static' dataset, using the steps to publish a dataset here: [https://confluence.ons.gov.uk/display/DIS/Discoverable+Datasets+-+Basic+API+Calls+-+Publish](https://confluence.ons.gov.uk/display/DIS/Discoverable+Datasets+-+Basic+API+Calls+-+Publish) add 'static' type
 - When creating the dataset, target `http://localhost:23200/v1`  (`dp-api-router`) and provide a bearer token.
 - Run `make up` within `\dp-compose\v2\stacks\dataset-catalogue` to spin up the relevant stack. 
 - Run `npm install && npm run dev` within `dp-design-system` to load CSS
 - Generate `access token` and `id_token` within cookies by visiting `localhost:29500/florence/login` and clicking an account. You can inspect they have been set within the browser.
 - Visit the static page: `localhost:20200/datasets/<id-you-created>/editions/<edition-you-created>/versions/1`
 - Review stated new content is there:

1. Contact details (contact name, email, telephone number)
2. Newer version (warning shows when a new version is created. I.e. you make a version 2, and then on the url for version 1 you should see a warning that says "There is a new version of this dataset. View the latest version" which links to the latest version)
3. Other versions (when multiple versions exist in dataset, display a table at bottom of page where the different versions can be viewed and clicked on to link to those versions)
4. Bookmark links (the bookmark component at bottom of the page shows and successfully copies the url — this functionality doesn't bookmark the url by itself, it is simply a prompt with copy functionality)
5. Contextual information( the page displays "release date", "last updated" [which shows when multiple versions are in the dataset], "quality indications"[which is just the flag for if something is a national_statistic, which when true will display the OSR_logo in the top right which says "accredited"], and "publisher" details [which include Name, Type and URL] which are currently conditionally rendered and omitempty

 ... Reach out to me on slack or teams if you need help with these steps— Jake Andrews (AND Digital) :-)

 
### Who can review

Anyone

