### PR TITLE
adding changes from PR #472 as there wasan unsigned commit as part of…

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "go.testTags": "production"
+}


### PR DESCRIPTION
[DIS-2283](https://jira.ons.gov.uk/browse/DIS-2283) Dataset Overview - most recent version

- Created a static dataset with an edition and a version and testing locally that calls to different api routes return the correct responses according to the ticket. See the comment in the ticket. `/datasets/<datasetId>/editions/<editionId>/versions` lists the versions associated with a dataset edition instead of redirecting to the latest version, but as this is the implemented functionality for other dataset types, and we need an endpoint to list versions, I assume this is correct
- Updated `handlers/filterable_landing_page_test.go` to refactor tests and add tests for static dataset types
- Added `.vscode/settings.json` to include a setting which sets the go build tag when running testing through vscode. I know we don't normally want to commit ide settings but this is required when testing a project using autogenerated assets

## How to review
Check out locally and confirm the url routing works as per the tests in the ticket
