### PR TITLE
Ensure that only static types attempt to render publisher details

### DIFF
--- a/assets/locales/service.en.toml
+++ b/assets/locales/service.en.toml
@@ -98,10 +98,6 @@ one = "View all data related to"
 description = "Contact us"
 one = "Contact us"
 
-[ContactDetails]
-description = "Contact details for this dataset"
-one = "Contact details for this dataset"
-
 [DatasetContactDetails]
 description = "Contact details for this dataset"
 one = "Contact details for this dataset"

--- a/assets/templates/partials/static/contact-details.tmpl
+++ b/assets/templates/partials/static/contact-details.tmpl
@@ -1,5 +1,5 @@
 <section id="contact" aria-label="{{ localise "RelatedLinksForCensus" .Language 1 }}">
-    <h2 class="ons-u-mt-xl ons-u-pb-no ons-u-pt-no" id="contact-details">{{ localise "ContactDetails" .Language 1 }}</h2>
+    <h2 class="ons-u-mt-xl ons-u-pb-no ons-u-pt-no" id="contact-details">{{ localise "DatasetContactDetails" .Language 1 }}</h2>
     <nav class="ons-related-content__navigation" aria-labelledby="contact-details">
         <ul class="ons-list ons-list--bare ons-u-fs-r">
             {{ if .ContactDetails.Name }}

--- a/assets/templates/partials/static/id-datestamp.tmpl
+++ b/assets/templates/partials/static/id-datestamp.tmpl
@@ -12,6 +12,9 @@
                 <time datetime="{{ .ReleaseDate }}">{{ dateFormat .ReleaseDate }}</time>
             </dd>
         </div>
+        {{ if .Publisher}}
+            {{ template "partials/static/publisher" . }}
+        {{ end }}
         <div class="ons-grid__col ons-col-8@m ons-u-mt-xs">
             <dt class="ons-metadata__term ons-u-mr-xs">{{ localise "LastUpdated" .Language 1 }}:</dt>
             <dd class="ons-metadata__value ons-u-f-no">
@@ -27,5 +30,8 @@
                 <time datetime="{{ .ReleaseDate }}">{{ dateFormat .ReleaseDate }}</time>
             </dd>
         </div>
+        {{ if .Publisher}}
+            {{ template "partials/static/publisher" . }}
+        {{ end }}
     {{ end }}
 </dl>

--- a/assets/templates/static.tmpl
+++ b/assets/templates/static.tmpl
@@ -60,7 +60,7 @@
         </div>
       </div>
       {{ end }}
-      {{ template "partials/census/id-datestamp" . }}
+      {{ template "partials/static/id-datestamp" . }}
     </section>
     <div
       class="ons-grid__col ons-col-4@m ons-u-pl-no ons-grid__col--sticky@m"


### PR DESCRIPTION
### What

This PR is to resolve potential problems when other dataset types access id-datestamp partial template. A new template has been made to achieve the same result, that is used by static. 

### How to review

### How to review
 - Create a 'static' dataset, using the steps to publish a dataset here: [https://confluence.ons.gov.uk/display/DIS/Discoverable+Datasets+-+Basic+API+Calls+-+Publish](https://confluence.ons.gov.uk/display/DIS/Discoverable+Datasets+-+Basic+API+Calls+-+Publish) add 'static' type
 - When creating the dataset, target `http://localhost:23200/v1`  (`dp-api-router`) and provide a bearer token.
 - Run `make up` within `\dp-compose\v2\stacks\dataset-catalogue` to spin up the relevant stack. 
 - Run `npm install && npm run dev` within `dp-design-system` to load CSS
 - Generate `access token` and `id_token` within cookies by visiting `localhost:29500/florence/login` and clicking an account. You can inspect they have been set within the browser.
 - Visit the static page: `localhost:20200/datasets/<id-you-created>/editions/<edition-you-created>/versions/1`
 - Review stated new content is there:

1. Contact details (contact name, email, telephone number)
2. Newer version (warning shows when a new version is created. I.e. you make a version 2, and then on the url for version 1 you should see a warning that says "There is a new version of this dataset. View the latest version" which links to the latest version)
3. Other versions (when multiple versions exist in dataset, display a table at bottom of page where the different versions can be viewed and clicked on to link to those versions)
4. Bookmark links (the bookmark component at bottom of the page shows and successfully copies the url — this functionality doesn't bookmark the url by itself, it is simply a prompt with copy functionality)
5. Contextual information( the page displays "release date", "last updated" [which shows when multiple versions are in the dataset], "quality indications"[which is just the flag for if something is a national_statistic, which when true will display the OSR_logo in the top right which says "accredited"], and "publisher" details [which include Name, Type and URL] which are currently conditionally rendered and omitempty
6. Test social media sharing links share successfully to the corresponding platforms — this should work in prod

 ... Reach out to me on slack or teams if you need help with these steps— Jake Andrews (AND Digital) :-)

### Who can review

Anyone
