### PR TITLE
Feature/dis 2295 social media sharing

### DIFF
--- a/assets/templates/partials/share-dataset/icon-handler.tmpl
+++ b/assets/templates/partials/share-dataset/icon-handler.tmpl
@@ -1,11 +1,13 @@
 {{ $icon := . }}
-{{ if eq $icon "facebook" }}
+{{ if eq $icon "email" }}
+    {{ template "icons/email" }}
+{{ else if eq $icon "facebook" }}
     {{ template "icons/facebook" }}
-{{ else if eq $icon "twitter" }}
-    {{ template "icons/twitter" }}
 {{ else if eq $icon "linkedin" }}
     {{ template "icons/linkedin" }}
-{{ else if eq $icon "email" }}
-    {{ template "icons/email" }}
+{{ else if eq $icon "twitter" }}
+    {{ template "icons/twitter" }}    
+{{ else if eq $icon "x" }}
+    {{ template "icons/x" }}
 {{ end }}
 

--- a/helpers/helpers.go
+++ b/helpers/helpers.go
@@ -50,14 +50,14 @@ func GetCurrentURL(lang, siteDomain, urlPath string) string {
 // GenerateSharingLink returns a sharing link for different types of social media
 func GenerateSharingLink(socialType, currentURL, title string) string {
 	switch socialType {
-	case "facebook":
-		return fmt.Sprintf("https://www.facebook.com/sharer/sharer.php?u=%s", currentURL)
-	case "twitter":
-		return fmt.Sprintf("https://twitter.com/intent/tweet?original_referer&text=%s&url=%s", title, currentURL)
-	case "linkedin":
-		return fmt.Sprintf("https://www.linkedin.com/sharing/share-offsite/?url=%s", currentURL)
 	case "email":
 		return fmt.Sprintf("mailto:?subject=%s&body=%s\n%s", title, title, currentURL)
+	case "facebook":
+		return fmt.Sprintf("https://www.facebook.com/sharer/sharer.php?u=%s", currentURL)
+	case "linkedin":
+		return fmt.Sprintf("https://www.linkedin.com/sharing/share-offsite/?url=%s", currentURL)
+	case "twitter", "x":
+		return fmt.Sprintf("https://%s.com/intent/tweet?original_referer&text=%s&url=%s", socialType, title, currentURL)
 	default:
 		return ""
 	}

--- a/helpers/helpers_test.go
+++ b/helpers/helpers_test.go
@@ -81,6 +81,7 @@ func TestGenerateSharingLink(t *testing.T) {
 		So(GenerateSharingLink("twitter", url, title), ShouldResemble, fmt.Sprintf("https://twitter.com/intent/tweet?original_referer&text=%s&url=%s", title, url))
 		So(GenerateSharingLink("linkedin", url, title), ShouldResemble, fmt.Sprintf("https://www.linkedin.com/sharing/share-offsite/?url=%s", url))
 		So(GenerateSharingLink("email", url, title), ShouldResemble, fmt.Sprintf("mailto:?subject=%s&body=%s\n%s", title, title, url))
+		So(GenerateSharingLink("x", url, title), ShouldResemble, fmt.Sprintf("https://x.com/intent/tweet?original_referer&text=%s&url=%s", title, url))
 	})
 }
 

--- a/mapper/static_base.go
+++ b/mapper/static_base.go
@@ -195,9 +195,10 @@ func buildStaticSharingDetails(d dataset.DatasetDetails, lang, currentURL string
 			Icon:  "facebook",
 		},
 		{
-			Title: "Twitter",
-			Link:  helpers.GenerateSharingLink("twitter", currentURL, d.Title),
-			Icon:  "twitter",
+			Title: "X",
+			Link:  helpers.GenerateSharingLink("x", currentURL, d.Title),
+			// Icon name is still twitter in `dp-renderer`
+			Icon: "twitter",
 		},
 		{
 			Title: "LinkedIn",

--- a/mapper/static_base.go
+++ b/mapper/static_base.go
@@ -199,8 +199,7 @@ func buildStaticSharingDetails(d dataset.DatasetDetails, lang, currentURL string
 		{
 			Title: "X",
 			Link:  helpers.GenerateSharingLink("x", currentURL, d.Title),
-			// Icon name is still twitter in `dp-renderer`
-			Icon: "twitter",
+			Icon:  "x",
 		},
 		{
 			Title: "LinkedIn",


### PR DESCRIPTION
### What
[DIS-2295](https://jira.ons.gov.uk/browse/DIS-2295) Dataset Overview - social media sharing

- Updated `assets/templates/partials/share-dataset/icon-handler.tmpl` to include handling X
- Updated `GenerateSharingLink` in `helpers/helpers.go` to include an option to build an X sharing link
- Created new x logo template in `assets/templates/icons/x.tmpl` so this can be used if needed
- Updated `buildStaticSharingDetails` in `mapper/static_base.go` to change the twitter share details to X

See https://github.com/ONSdigital/dp-renderer/pull/176 for previous work adding the x logo to `dp-renderer`.

### How to review
Run a page locally and see that the x logo and link is rendered on a static dataset overview page.
