### PR TITLE
Overview page amendments — remove variables section/ add usage notes shortcut

### DIFF
--- a/assets/locales/service.cy.toml
+++ b/assets/locales/service.cy.toml
@@ -106,6 +106,10 @@ one = "Supporting files you may find useful"
 description = "Important notes and usage information"
 one = "Nodiadau pwysig a gwybodaeth ynghylch defnyddio"
 
+[UsageNotes]
+description = "Usage notes"
+one = "Usage notes"
+
 [ViewAllData]
 description = "View all data related to"
 one = "View all data related to"

--- a/assets/locales/service.en.toml
+++ b/assets/locales/service.en.toml
@@ -90,6 +90,10 @@ one = "Supporting files you may find useful"
 description = "Important notes and usage information"
 one = "Important notes and usage information"
 
+[UsageNotes]
+description = "Usage notes"
+one = "Usage notes"
+
 [ViewAllData]
 description = "View all data related to"
 one = "View all data related to"

--- a/assets/templates/partials/static/usage-notes.tmpl
+++ b/assets/templates/partials/static/usage-notes.tmpl
@@ -1,5 +1,5 @@
 <section id="usage-notes" aria-label="{{ localise "NotesAndUsage" .Language 1 }}">
-    <h2 class="ons-u-mt-xl ons-u-pb-no ons-u-pt-no" id="usage-notes">
+    <h2 class="ons-u-mt-xl ons-u-pb-no ons-u-pt-no">
         {{ localise "NotesAndUsage" .Language 1 }}
     </h2>
     {{ range .UsageNotes }}

--- a/assets/templates/static.tmpl
+++ b/assets/templates/static.tmpl
@@ -71,7 +71,6 @@
     <div class="ons-grid__col ons-col-8@m ons-u-pl-no">
       {{ template "partials/census/panel" .DatasetLandingPage.QualityStatements }}
       {{ template "partials/census/summary" . }}
-      {{ template "partials/census/variables-table" . }}
       {{ template "partials/census/get-data" . }}
       {{ if .HasContactDetails }}
       {{ template "partials/static/contact-details" . }}

--- a/mapper/static_base.go
+++ b/mapper/static_base.go
@@ -264,6 +264,16 @@ func buildStaticTableOfContents(p static.Page, d dataset.DatasetDetails, hasOthe
 		displayOrder = append(displayOrder, "contact")
 	}
 
+	if len(p.UsageNotes) > 0 {
+		sections["usage-notes"] = coreModel.ContentSection{
+			Title: coreModel.Localisation{
+				LocaleKey: "UsageNotes",
+				Plural:    1,
+			},
+		}
+		displayOrder = append(displayOrder, "usage-notes")
+	}
+
 	sections["protecting-personal-data"] = coreModel.ContentSection{
 		Title: coreModel.Localisation{
 			LocaleKey: "ProtectingPersonalDataTitle",

--- a/mapper/static_base.go
+++ b/mapper/static_base.go
@@ -238,14 +238,6 @@ func buildStaticTableOfContents(p static.Page, d dataset.DatasetDetails, hasOthe
 	}
 	displayOrder = append(displayOrder, "summary")
 
-	sections["variables"] = coreModel.ContentSection{
-		Title: coreModel.Localisation{
-			LocaleKey: "Variables",
-			Plural:    4,
-		},
-	}
-	displayOrder = append(displayOrder, "variables")
-
 	sections["get-data"] = coreModel.ContentSection{
 		Title: coreModel.Localisation{
 			LocaleKey: "GetData",

--- a/mapper/static_overview_page.go
+++ b/mapper/static_overview_page.go
@@ -86,15 +86,6 @@ func CreateStaticOverviewPage(
 		p.DatasetLandingPage.Dimensions = append([]sharedModel.Dimension{pop, area, coverage}, dims...)
 	}
 
-	// COLLAPSIBLE
-	p.Collapsible = coreModel.Collapsible{
-		Title: coreModel.Localisation{
-			LocaleKey: "VariablesExplanation",
-			Plural:    4,
-		},
-		CollapsibleItems: mapLandingCollapsible(version.Dimensions),
-	}
-
 	// ANALYTICS
 	p.PreGTMJavaScript = append(
 		p.PreGTMJavaScript,


### PR DESCRIPTION
### What

- Variables section is empty and should not be displayed  https://jira.ons.gov.uk/browse/DIS-2638 
- Usage notes was add to section shortcuts https://jira.ons.gov.uk/browse/DIS-2293 

### How to review

Use the steps outlines here to create a static overview page and test that the changes are as described here : https://confluence.ons.gov.uk/display/DIS/Testing+the+dataset+overview+page#Testingthedatasetoverviewpage-Local

### Who can review

Anyone 
