### PR TITLE
Remove references to 'census' in the overview pages

### DIFF
--- a/assets/templates/static.tmpl
+++ b/assets/templates/static.tmpl
@@ -31,35 +31,6 @@
         </div>
         {{ end }}
       </div>
-      {{ if .ShowCensusBranding }}
-      <div class="ons-grid ons-u-mb-m">
-        <div class="ons-grid__col">
-          {{ if eq .Language "en" }}
-          <img
-            src="https://cdn.ons.gov.uk/assets/images/census-logo/logo-census-2021-purple-landscape.svg"
-            title="Census 2021"
-            class="header__svg-logo margin-right--1"
-            xmlns="http://www.w3.org/2000/svg"
-            focusable="false"
-            width="167"
-            height="32"
-            viewBox="0 0 242 44"
-          />
-          {{ else }}
-          <img
-            src="https://cdn.ons.gov.uk/assets/images/census-logo/logo-cyfrifiad-2021-purple-landscape.svg"
-            title="Cyfrifiad 2021"
-            class="header__svg-logo margin-right--1"
-            xmlns="http://www.w3.org/2000/svg"
-            focusable="false"
-            width="167"
-            height="32"
-            viewBox="0 0 242 44"
-          />
-          {{ end }}
-        </div>
-      </div>
-      {{ end }}
       {{ template "partials/static/id-datestamp" . }}
     </section>
     <div

--- a/mapper/static_base.go
+++ b/mapper/static_base.go
@@ -69,7 +69,7 @@ func CreateStaticBasePage(
 	p.EmergencyBanner = mapEmergencyBanner(emergencyBannerContent)
 
 	// CENSUS BRANDING
-	p.ShowCensusBranding = d.Survey == "census"
+	p.ShowCensusBranding = false
 
 	// BREADCRUMBS
 	p.Breadcrumb = []coreModel.TaxonomyNode{
@@ -78,8 +78,8 @@ func CreateStaticBasePage(
 			URI:   "/",
 		},
 		{
-			Title: "Census",
-			URI:   "/census",
+			Title: "Overview page",
+			URI:   "#",
 		},
 	}
 


### PR DESCRIPTION
### What

Breadcrumbs and branding containing reference to census pages has been removed for the dataset overview pages.

(Census branding i.e. https://cdn.ons.gov.uk/assets/images/census-logo/logo-cyfrifiad-2021-purple-landscape.svg) 

### How to review

- Create a 'static' dataset, using the steps to publish a dataset here: https://confluence.ons.gov.uk/display/DIS/Discoverable+Datasets+-+Basic+API+Calls+-+Publish add 'static' type
- When creating the dataset, target http://localhost:23200/v1 (dp-api-router) and provide a bearer token.
- Run make up within \dp-compose\v2\stacks\dataset-catalogue to spin up the relevant stack.
- Run npm install && npm run dev within dp-design-system to load CSS
- Generate access token and id_token within cookies by visiting localhost:29500/florence/login and clicking an account. You can inspect they have been set within the browser.
- Visit the static page: localhost:20200/datasets/<id-you-created>/editions/<edition-you-created>/versions/1

... Reach out to me on slack or teams if you need help with these steps— Jake Andrews (AND Digital) :-)

### Who can review

Anyone
