### PR TITLE
Remove publisher type from dataset overview pages

### DIFF
--- a/assets/locales/service.cy.toml
+++ b/assets/locales/service.cy.toml
@@ -242,10 +242,6 @@ one = "See version history"
 description = "Publisher name:"
 one = "Publisher name:"
 
-[PublisherType]
-description = "Publisher type:"
-one = "Publisher type:"
-
 [PublisherURL]
 description = "Publisher URL:"
 one = "Publisher URL:"

--- a/assets/locales/service.en.toml
+++ b/assets/locales/service.en.toml
@@ -227,10 +227,6 @@ one = "See version history"
 description = "Publisher name:"
 one = "Publisher name:"
 
-[PublisherType]
-description = "Publisher type:"
-one = "Publisher type:"
-
 [PublisherURL]
 description = "Publisher URL:"
 one = "Publisher URL:"

--- a/assets/templates/partials/static/id-datestamp.tmpl
+++ b/assets/templates/partials/static/id-datestamp.tmpl
@@ -31,11 +31,5 @@
             <dd class="ons-metadata__value ons-u-f-no"><a href={{ .Publisher.URL }}>{{ .Publisher.Name }}</a></dd>
         </div>
         {{ end }}
-        {{ if .Publisher.Type}}
-        <div class="ons-metadata__item">
-            <dt class="ons-metadata__term ons-u-mr-xs">{{ localise "PublisherType" .Language 1 }}</dt>
-            <dd class="ons-metadata__value ons-u-f-no">{{ .Publisher.Type}}</dd>
-        </div>
-        {{ end }}
     </div>
 </dl>


### PR DESCRIPTION
### What

Field 'publisher type' removed from overview pages

### How to review

- Create a 'static' dataset, using the steps to publish a dataset here: https://confluence.ons.gov.uk/display/DIS/Discoverable+Datasets+-+Basic+API+Calls+-+Publish add 'static' type
- When creating the dataset, target http://localhost:23200/v1 (dp-api-router) and provide a bearer token.
- Run make up within \dp-compose\v2\stacks\dataset-catalogue to spin up the relevant stack.
- Run npm install && npm run dev within dp-design-system to load CSS
- Generate access token and id_token within cookies by visiting localhost:29500/florence/login and clicking an account. You can inspect they have been set within the browser.
- Visit the static page: localhost:20200/datasets/<id-you-created>/editions/<edition-you-created>/versions/1

... Reach out to me on slack or teams if you need help with these steps— Jake Andrews (AND Digital) :-)

### Who can review

Anyone
