### PR TITLE
updated alpha feedback link and included favicons links in static styles

### DIFF
--- a/assets/templates/partials/header/static-header.tmpl
+++ b/assets/templates/partials/header/static-header.tmpl
@@ -9,9 +9,8 @@
           <div class="ons-grid__col ons-col-auto ons-u-flex-shrink">
               <p class="ons-phase-banner__desc ons-u-fs-s ons-u-mb-no">This is a new service. To help us improve it, 
 
-<a href="#0" class="ons-external-link" target="_blank" rel="noopener">
+<a href="https://www.smartsurvey.co.uk/s/RetailNovwebsite/" class="ons-external-link" target="_blank" rel="noopener">
   <span class="ons-external-link__text">give feedback</span>{{ template "icons/external-link" }}<span class="ons-external-link__new-window-description ons-u-vh">(opens in a new tab)</span></a>
-
 </p>
           </div>
       </div>

--- a/assets/templates/styles-static.tmpl
+++ b/assets/templates/styles-static.tmpl
@@ -1,2 +1,7 @@
+<link rel="icon" type="image/x-icon" href="https://cdn.ons.gov.uk/sdc/design-system/72.4.0/favicons/favicon.ico">
+<link rel="icon" type="image/png" href="https://cdn.ons.gov.uk/sdc/design-system/72.4.0/favicons/favicon-32x32.png" sizes="32x32">
+<link rel="icon" type="image/png" href="https://cdn.ons.gov.uk/sdc/design-system/72.4.0/favicons/favicon-16x16.png" sizes="16x16">
+<link rel="mask-icon" href="https://cdn.ons.gov.uk/sdc/design-system/72.4.0/favicons/safari-pinned-tab.svg" color="#000000">
+<link rel="apple-touch-icon" type="image/png" href="https://cdn.ons.gov.uk/sdc/design-system/72.4.0/favicons/apple-touch-icon.png" sizes="180x180">
 <link rel="stylesheet" href="https://cdn.ons.gov.uk/sdc/design-system/72.4.0/css/main.css"/>
 <link rel="stylesheet" media="print" href="https://cdn.ons.gov.uk/sdc/design-system/72.4.0/css/print.css">


### PR DESCRIPTION
### What

[DIS-2798](https://jira.ons.gov.uk/browse/DIS-2798) - Update preview page to reflect new designs

Further changes following review:

- Updated `assets/templates/partials/footer/static-header.tmpl` to use correct alpha feedback link
- Updated `assets/templates/styles-static.tmpl` to load icons from the design system

### How to review

Check out locally and check that the static dataset overview page matches designs in https://deploy-preview-3510--ons-design-system-preview.netlify.app/ and https://new-ons-website.framer.website/datasets/dataset-4.
