### PR TITLE
updated breadcrumb to use absolute home link, and removing news link …

### DIFF
--- a/assets/templates/partials/footer/static-footer.tmpl
+++ b/assets/templates/partials/footer/static-footer.tmpl
@@ -55,7 +55,7 @@
                             <a href="#0" class="ons-list__link">Release calendar</a>
                         </li>
                         <li class="ons-list__item">
-                            <a href="https://www.ons.gov.uk/news">{{ localise "News" .Language 1 }}</a>
+                            <a href="#0">{{ localise "News" .Language 1 }}</a>
                         </li>
                     </ul>
                 </div>

--- a/mapper/static_base.go
+++ b/mapper/static_base.go
@@ -76,7 +76,7 @@ func CreateStaticBasePage(
 	p.Breadcrumb = []coreModel.TaxonomyNode{
 		{
 			Title: "Home",
-			URI:   "/",
+			URI:   "https://www.ons.gov.uk/",
 		},
 		{
 			Title: "Overview page",


### PR DESCRIPTION
### What

[DIS-2798](https://jira.ons.gov.uk/browse/DIS-2798) - Update preview page to reflect new designs

Further changes following review:

- Updated `assets/templates/partials/footer/static-footer.tmpl` to remove news link
- Updated `mapper/static_base.go` to make home breadcrumb an absolute url instead of relative

### How to review

Check out locally and check that the static dataset overview page matches designs in https://deploy-preview-3510--ons-design-system-preview.netlify.app/ and https://new-ons-website.framer.website/datasets/dataset-4.
