### PR TITLE
Topics fetched and used to create breadcrumbs

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -22,6 +22,7 @@ type Config struct {
 	GracefulShutdownTimeout       time.Duration `envconfig:"GRACEFUL_SHUTDOWN_TIMEOUT"`
 	HealthCheckCriticalTimeout    time.Duration `envconfig:"HEALTHCHECK_CRITICAL_TIMEOUT"`
 	HealthCheckInterval           time.Duration `envconfig:"HEALTHCHECK_INTERVAL"`
+	IsPublishing                  bool          `envconfig:"IS_PUBLISHING"`
 	OTBatchTimeout                time.Duration `encconfig:"OTEL_BATCH_TIMEOUT"`
 	OTServiceName                 string        `envconfig:"OTEL_SERVICE_NAME"`
 	OTExporterOTLPEndpoint        string        `envconfig:"OTEL_EXPORTER_OTLP_ENDPOINT"`
@@ -67,6 +68,7 @@ func get() (*Config, error) {
 		GracefulShutdownTimeout:       5 * time.Second,
 		HealthCheckCriticalTimeout:    90 * time.Second,
 		HealthCheckInterval:           30 * time.Second,
+		IsPublishing:                  false,
 		OTBatchTimeout:                5 * time.Second,
 		OTExporterOTLPEndpoint:        "localhost:4317",
 		OTServiceName:                 "dp-frontend-dataset-controller",

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -29,6 +29,7 @@ func TestConfig(t *testing.T) {
 				So(cfg.GracefulShutdownTimeout, ShouldEqual, 5*time.Second)
 				So(cfg.HealthCheckInterval, ShouldEqual, 30*time.Second)
 				So(cfg.HealthCheckCriticalTimeout, ShouldEqual, 90*time.Second)
+				So(cfg.IsPublishing, ShouldEqual, false)
 				So(cfg.EnableProfiler, ShouldBeFalse)
 				So(cfg.PatternLibraryAssetsPath, ShouldEqual, "//cdn.ons.gov.uk/dp-design-system/6d9a222")
 			})

--- a/handlers/clients.go
+++ b/handlers/clients.go
@@ -85,6 +85,7 @@ type PopulationClient interface {
 // TopicClient is an interface with methods required for a topic client
 type TopicAPIClient interface {
 	GetTopicPublic(ctx context.Context, headers dpTopicApiSdk.Headers, id string) (*dpTopicApiModels.Topic, dpTopicApiErrors.Error)
+	GetTopicPrivate(ctx context.Context, headers dpTopicApiSdk.Headers, id string) (*dpTopicApiModels.TopicResponse, dpTopicApiErrors.Error)
 }
 
 // ClientError is an interface that can be used to retrieve the status code if a client has errored

--- a/handlers/clients.go
+++ b/handlers/clients.go
@@ -14,10 +14,13 @@ import (
 	dpDatasetApiModels "github.com/ONSdigital/dp-dataset-api/models"
 	dpDatasetApiSdk "github.com/ONSdigital/dp-dataset-api/sdk"
 	coreModel "github.com/ONSdigital/dp-renderer/v2/model"
+	dpTopicApiModels "github.com/ONSdigital/dp-topic-api/models"
+	dpTopicApiSdk "github.com/ONSdigital/dp-topic-api/sdk"
+	dpTopicApiErrors "github.com/ONSdigital/dp-topic-api/sdk/errors"
 )
 
 // To mock interfaces in this file
-//go:generate mockgen -source=clients.go -destination=mock_clients.go -package=handlers github.com/ONSdigital/dp-frontend-dataset-controller/handlers FilterClient,APIClientsGoDatasetClient,DatasetAPISdkClient,RenderClient
+//go:generate mockgen -source=clients.go -destination=mock_clients.go -package=handlers github.com/ONSdigital/dp-frontend-dataset-controller/handlers FilterClient,APIClientsGoDatasetClient,DatasetAPISdkClient,RenderClient,TopicAPIClient
 
 // FilterClient is an interface with the methods required for a filter client
 type FilterClient interface {
@@ -77,6 +80,11 @@ type PopulationClient interface {
 	GetPopulationType(ctx context.Context, input population.GetPopulationTypeInput) (population.GetPopulationTypeResponse, error)
 	GetPopulationTypes(ctx context.Context, input population.GetPopulationTypesInput) (population.GetPopulationTypesResponse, error)
 	GetPopulationTypeMetadata(ctx context.Context, input population.GetPopulationTypeMetadataInput) (population.GetPopulationTypeMetadataResponse, error)
+}
+
+// TopicClient is an interface with methods required for a topic client
+type TopicAPIClient interface {
+	GetTopicPublic(ctx context.Context, headers dpTopicApiSdk.Headers, id string) (*dpTopicApiModels.Topic, dpTopicApiErrors.Error)
 }
 
 // ClientError is an interface that can be used to retrieve the status code if a client has errored

--- a/handlers/filterable_landing_page.go
+++ b/handlers/filterable_landing_page.go
@@ -372,7 +372,7 @@ func GetPublicOrPrivateTopics(
 		if err != nil {
 			return nil, err
 		} else {
-			return topicResponse.Current, err
+			return topicResponse.Next, err
 		}
 	} else {
 		return topicsClient.GetTopicPublic(ctx, topicHeaders, topicID)

--- a/handlers/filterable_landing_page.go
+++ b/handlers/filterable_landing_page.go
@@ -20,6 +20,7 @@ import (
 	"github.com/ONSdigital/dp-net/v3/handlers"
 	dpTopicApiModels "github.com/ONSdigital/dp-topic-api/models"
 	dpTopicApiSdk "github.com/ONSdigital/dp-topic-api/sdk"
+	errors "github.com/ONSdigital/dp-topic-api/sdk/errors"
 	"github.com/ONSdigital/log.go/v2/log"
 	"github.com/gorilla/mux"
 )
@@ -175,7 +176,7 @@ func filterableLanding(responseWriter http.ResponseWriter, request *http.Request
 		someTopicAPIFetchesFailed := false
 
 		for _, topicID := range topicsIDList {
-			topicObject, err := tc.GetTopicPublic(ctx, topicHeaders, topicID)
+			topicObject, err := GetPublicOrPrivateTopics(tc, cfg, ctx, topicHeaders, topicID)
 			if err != nil {
 				someTopicAPIFetchesFailed = true
 				log.Warn(
@@ -357,4 +358,23 @@ func sortedOpts(opts []dpDatasetApiSdk.VersionDimensionOptionsList) []dpDatasetA
 		})
 	}
 	return sorted
+}
+
+func GetPublicOrPrivateTopics(
+	topicsClient TopicAPIClient,
+	cfg config.Config,
+	ctx context.Context,
+	topicHeaders dpTopicApiSdk.Headers,
+	topicID string,
+) (*dpTopicApiModels.Topic, errors.Error) {
+	if cfg.IsPublishing {
+		topicResponse, err := topicsClient.GetTopicPrivate(ctx, topicHeaders, topicID)
+		if err != nil {
+			return nil, err
+		} else {
+			return topicResponse.Current, err
+		}
+	} else {
+		return topicsClient.GetTopicPublic(ctx, topicHeaders, topicID)
+	}
 }

--- a/handlers/filterable_landing_page_test.go
+++ b/handlers/filterable_landing_page_test.go
@@ -667,6 +667,13 @@ func TestFilterableLandingPageStaticDataType(t *testing.T) {
 		Keywords:    &[]string{"test"},
 		State:       "published",
 	}
+	mockGetTopicPrivateResponse := dpTopicApiModels.TopicResponse{
+		ID: "123",
+		Current: &dpTopicApiModels.Topic{
+			ID: "123",
+		},
+		Next: &dpTopicApiModels.Topic{},
+	}
 	headers := dpDatasetApiSdk.Headers{
 		CollectionID:         collectionID,
 		DownloadServiceToken: downloadServiceAuthToken,
@@ -823,10 +830,6 @@ func TestFilterableLandingPageStaticDataType(t *testing.T) {
 		})
 
 		Convey("test filterable landing page successfully builds when one of two topic-api calls fails", func() {
-			var buf bytes.Buffer
-			var fbBuf bytes.Buffer
-			dpLogger.SetDestination(&buf, &fbBuf)
-
 			testTopicAPIError := dpTopicApiErrors.StatusError{
 				Code: 404,
 				Err:  errors.New("test error"),
@@ -875,6 +878,115 @@ func TestFilterableLandingPageStaticDataType(t *testing.T) {
 			router.HandleFunc("/datasets/{datasetID}/editions/{editionID}/versions/{versionID}", FilterableLanding(mockDatasetClient, mockPopulationClient, mockRenderClient, mockZebedeeClient, mockTopicClient, mockConfig, ""))
 
 			router.ServeHTTP(mockRequestWriter, mockRequest)
+			So(mockRequestWriter.Code, ShouldEqual, http.StatusOK)
+		})
+		Convey("Given IsPublishing flag is enabled", func() {
+			mockConfig.IsPublishing = true
+
+			Convey("When GetTopicPrivate is called with invalid topicID", func() {
+				var buf bytes.Buffer
+				var fbBuf bytes.Buffer
+				dpLogger.SetDestination(&buf, &fbBuf)
+
+				testTopicAPIError := dpTopicApiErrors.StatusError{
+					Code: 404,
+					Err:  errors.New("test error"),
+				}
+
+				mockDatasetClient.EXPECT().GetDataset(
+					mockContext, headers, collectionID, datasetID,
+				).Return(
+					mockGetResponse, nil,
+				)
+				mockDatasetClient.EXPECT().GetVersions(
+					mockContext, headers, datasetID, editionID, &getVersionsQueryParams,
+				).Return(
+					mockGetVersionsResponse, nil,
+				)
+				mockDatasetClient.EXPECT().GetVersion(
+					mockContext, headers, datasetID, editionID, versionID,
+				).Return(
+					mockGetVersionsResponse.Items[0], nil,
+				)
+				mockDatasetClient.EXPECT().GetVersionMetadata(mockContext, headers, datasetID, editionID, versionID).Return(
+					mockGetVersionMetadataResponse, nil,
+				)
+				mockTopicClient.EXPECT().GetTopicPrivate(mockContext, topicHeaders, "123").Return(
+					nil, testTopicAPIError,
+				)
+				mockZebedeeClient.EXPECT().GetHomepageContent(mockContext, userAuthToken, collectionID, locale, "/")
+				mockRenderClient.EXPECT().NewBasePageModel().Return(
+					coreModel.NewPage(mockConfig.PatternLibraryAssetsPath, mockConfig.SiteDomain),
+				)
+				// `BuildPage` should be called with the `dataset.DatasetDetails.Type` defining the template to be used
+				mockRenderClient.EXPECT().BuildPage(gomock.Any(), gomock.Any(), datasetType)
+
+				mockRequestWriter := httptest.NewRecorder()
+				mockRequest := httptest.NewRequest("GET", fmt.Sprintf("/datasets/%s/editions/%s/versions/%s", datasetID, editionID, versionID), http.NoBody)
+
+				router := mux.NewRouter()
+				router.HandleFunc("/datasets/{datasetID}/editions/{editionID}/versions/{versionID}", FilterableLanding(mockDatasetClient, mockPopulationClient, mockRenderClient, mockZebedeeClient, mockTopicClient, mockConfig, ""))
+
+				router.ServeHTTP(mockRequestWriter, mockRequest)
+				Convey("Then filterable landing page logs correct warning", func() {
+					So(buf.String(), ShouldContainSubstring, "unable to get topic data for topic ID: 123")
+				})
+			})
+
+			Convey("When one of two topic api calls fails", func() {
+				testTopicAPIError := dpTopicApiErrors.StatusError{
+					Code: 404,
+					Err:  errors.New("test error"),
+				}
+
+				mockGetVersionMetadataResponse := dpDatasetApiModels.Metadata{
+					EditableMetadata: dpDatasetApiModels.EditableMetadata{
+						Subtopics: []string{"123", "456"},
+					},
+				}
+				mockDatasetClient.EXPECT().GetDataset(
+					mockContext, headers, collectionID, datasetID,
+				).Return(
+					mockGetResponse, nil,
+				)
+				mockDatasetClient.EXPECT().GetVersions(
+					mockContext, headers, datasetID, editionID, &getVersionsQueryParams,
+				).Return(
+					mockGetVersionsResponse, nil,
+				)
+				mockDatasetClient.EXPECT().GetVersion(
+					mockContext, headers, datasetID, editionID, versionID,
+				).Return(
+					mockGetVersionsResponse.Items[0], nil,
+				)
+				mockDatasetClient.EXPECT().GetVersionMetadata(mockContext, headers, datasetID, editionID, versionID).Return(
+					mockGetVersionMetadataResponse, nil,
+				)
+				mockTopicClient.EXPECT().GetTopicPrivate(mockContext, topicHeaders, "123").Return(
+					nil, testTopicAPIError,
+				)
+				mockTopicClient.EXPECT().GetTopicPrivate(mockContext, topicHeaders, "456").Return(
+					&mockGetTopicPrivateResponse, nil,
+				)
+				mockZebedeeClient.EXPECT().GetHomepageContent(mockContext, userAuthToken, collectionID, locale, "/")
+				mockRenderClient.EXPECT().NewBasePageModel().Return(
+					coreModel.NewPage(mockConfig.PatternLibraryAssetsPath, mockConfig.SiteDomain),
+				)
+				// `BuildPage` should be called with the `dataset.DatasetDetails.Type` defining the template to be used
+				mockRenderClient.EXPECT().BuildPage(gomock.Any(), gomock.Any(), datasetType)
+
+				mockRequestWriter := httptest.NewRecorder()
+				mockRequest := httptest.NewRequest("GET", fmt.Sprintf("/datasets/%s/editions/%s/versions/%s", datasetID, editionID, versionID), http.NoBody)
+
+				router := mux.NewRouter()
+				router.HandleFunc("/datasets/{datasetID}/editions/{editionID}/versions/{versionID}", FilterableLanding(mockDatasetClient, mockPopulationClient, mockRenderClient, mockZebedeeClient, mockTopicClient, mockConfig, ""))
+
+				router.ServeHTTP(mockRequestWriter, mockRequest)
+
+				Convey("Then the filterable landing page builds correctly, with status 200", func() {
+					So(mockRequestWriter.Code, ShouldEqual, http.StatusOK)
+				})
+			})
 		})
 	})
 }

--- a/handlers/mock_clients.go
+++ b/handlers/mock_clients.go
@@ -724,6 +724,21 @@ func (m *MockTopicAPIClient) EXPECT() *MockTopicAPIClientMockRecorder {
 	return m.recorder
 }
 
+// GetTopicPrivate mocks base method.
+func (m *MockTopicAPIClient) GetTopicPrivate(ctx context.Context, headers sdk0.Headers, id string) (*models0.TopicResponse, errors.Error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetTopicPrivate", ctx, headers, id)
+	ret0, _ := ret[0].(*models0.TopicResponse)
+	ret1, _ := ret[1].(errors.Error)
+	return ret0, ret1
+}
+
+// GetTopicPrivate indicates an expected call of GetTopicPrivate.
+func (mr *MockTopicAPIClientMockRecorder) GetTopicPrivate(ctx, headers, id interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTopicPrivate", reflect.TypeOf((*MockTopicAPIClient)(nil).GetTopicPrivate), ctx, headers, id)
+}
+
 // GetTopicPublic mocks base method.
 func (m *MockTopicAPIClient) GetTopicPublic(ctx context.Context, headers sdk0.Headers, id string) (*models0.Topic, errors.Error) {
 	m.ctrl.T.Helper()

--- a/handlers/mock_clients.go
+++ b/handlers/mock_clients.go
@@ -17,6 +17,9 @@ import (
 	models "github.com/ONSdigital/dp-dataset-api/models"
 	sdk "github.com/ONSdigital/dp-dataset-api/sdk"
 	model "github.com/ONSdigital/dp-renderer/v2/model"
+	models0 "github.com/ONSdigital/dp-topic-api/models"
+	sdk0 "github.com/ONSdigital/dp-topic-api/sdk"
+	errors "github.com/ONSdigital/dp-topic-api/sdk/errors"
 	gomock "github.com/golang/mock/gomock"
 )
 
@@ -696,6 +699,44 @@ func (m *MockPopulationClient) GetPopulationTypes(ctx context.Context, input pop
 func (mr *MockPopulationClientMockRecorder) GetPopulationTypes(ctx, input interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPopulationTypes", reflect.TypeOf((*MockPopulationClient)(nil).GetPopulationTypes), ctx, input)
+}
+
+// MockTopicAPIClient is a mock of TopicAPIClient interface.
+type MockTopicAPIClient struct {
+	ctrl     *gomock.Controller
+	recorder *MockTopicAPIClientMockRecorder
+}
+
+// MockTopicAPIClientMockRecorder is the mock recorder for MockTopicAPIClient.
+type MockTopicAPIClientMockRecorder struct {
+	mock *MockTopicAPIClient
+}
+
+// NewMockTopicAPIClient creates a new mock instance.
+func NewMockTopicAPIClient(ctrl *gomock.Controller) *MockTopicAPIClient {
+	mock := &MockTopicAPIClient{ctrl: ctrl}
+	mock.recorder = &MockTopicAPIClientMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockTopicAPIClient) EXPECT() *MockTopicAPIClientMockRecorder {
+	return m.recorder
+}
+
+// GetTopicPublic mocks base method.
+func (m *MockTopicAPIClient) GetTopicPublic(ctx context.Context, headers sdk0.Headers, id string) (*models0.Topic, errors.Error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetTopicPublic", ctx, headers, id)
+	ret0, _ := ret[0].(*models0.Topic)
+	ret1, _ := ret[1].(errors.Error)
+	return ret0, ret1
+}
+
+// GetTopicPublic indicates an expected call of GetTopicPublic.
+func (mr *MockTopicAPIClientMockRecorder) GetTopicPublic(ctx, headers, id interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTopicPublic", reflect.TypeOf((*MockTopicAPIClient)(nil).GetTopicPublic), ctx, headers, id)
 }
 
 // MockClientError is a mock of ClientError interface.

--- a/main.go
+++ b/main.go
@@ -182,9 +182,9 @@ func run(ctx context.Context) error {
 
 	router.Path("/datasets/{datasetID}").Methods("GET").HandlerFunc(handlers.EditionsList(apiClientsGoDatasetClient, zc, rend, *cfg, apiRouterVersion))
 	router.Path("/datasets/{datasetID}/editions").Methods("GET").HandlerFunc(handlers.EditionsList(apiClientsGoDatasetClient, zc, rend, *cfg, apiRouterVersion))
-	router.Path("/datasets/{datasetID}/editions/{editionID}").Methods("GET").HandlerFunc(handlers.FilterableLanding(datasetAPISdkClient, pc, rend, zc, *cfg, apiRouterVersion))
+	router.Path("/datasets/{datasetID}/editions/{editionID}").Methods("GET").HandlerFunc(handlers.FilterableLanding(datasetAPISdkClient, pc, rend, zc, tc, *cfg, apiRouterVersion))
 	router.Path("/datasets/{datasetID}/editions/{edition}/versions").Methods("GET").HandlerFunc(handlers.VersionsList(apiClientsGoDatasetClient, zc, rend, *cfg))
-	router.Path("/datasets/{datasetID}/editions/{editionID}/versions/{versionID}").Methods("GET").HandlerFunc(handlers.FilterableLanding(datasetAPISdkClient, pc, rend, zc, *cfg, apiRouterVersion))
+	router.Path("/datasets/{datasetID}/editions/{editionID}/versions/{versionID}").Methods("GET").HandlerFunc(handlers.FilterableLanding(datasetAPISdkClient, pc, rend, zc, tc, *cfg, apiRouterVersion))
 	router.Path("/datasets/{datasetID}/editions/{editionID}/versions/{versionID}").Methods("POST").HandlerFunc(handlers.CreateFilterFlexID(f, apiClientsGoDatasetClient))
 	router.Path("/datasets/{datasetID}/editions/{editionID}/versions/{versionID}/filter").Methods("POST").HandlerFunc(handlers.CreateFilterID(f, apiClientsGoDatasetClient))
 	router.Path("/datasets/{datasetID}/editions/{editionID}/versions/{versionID}/filter-outputs/{filterOutputID}").Methods("GET").HandlerFunc(handlers.FilterOutput(zc, f, pc, datasetAPISdkClient, rend, *cfg, apiRouterVersion))

--- a/mapper/mapper.go
+++ b/mapper/mapper.go
@@ -15,6 +15,7 @@ import (
 	datasetMdl "github.com/ONSdigital/dp-frontend-dataset-controller/model/dataset"
 	filterable "github.com/ONSdigital/dp-frontend-dataset-controller/model/datasetLandingPageFilterable"
 	edition "github.com/ONSdigital/dp-frontend-dataset-controller/model/editions"
+	dpTopicApiModels "github.com/ONSdigital/dp-topic-api/models"
 	"golang.org/x/text/cases"
 	"golang.org/x/text/language"
 
@@ -627,4 +628,28 @@ func UpdateBasePage(basePage *dpRendererModel.Page, dataset dpDatasetApiModels.D
 	basePage.ServiceMessage = homepageContent.ServiceMessage
 	basePage.Type = dataset.Type
 	basePage.URI = request.URL.Path
+}
+
+func CreateBreadcrumbsFromTopicList(baseURL string, topicObjectList []dpTopicApiModels.Topic) []dpRendererModel.TaxonomyNode {
+	breadcrumbsObject := []dpRendererModel.TaxonomyNode{
+		{
+			Title: "Home",
+			URI:   baseURL,
+		},
+	}
+	path := baseURL
+
+	for i, topicObject := range topicObjectList {
+		if i == 0 {
+			path += topicObject.Slug
+		} else {
+			// topic1 URI => /slug1 ... topic2 URI => /slug1/slug2... etc..
+			path += "/" + topicObject.Slug
+		}
+		breadcrumbsObject = append(breadcrumbsObject, dpRendererModel.TaxonomyNode{
+			Title: topicObject.Title,
+			URI:   path,
+		})
+	}
+	return breadcrumbsObject
 }

--- a/mapper/static_base.go
+++ b/mapper/static_base.go
@@ -74,17 +74,9 @@ func CreateStaticBasePage(basePage coreModel.Page, d dpDatasetApiModels.Dataset,
 	p.ShowCensusBranding = false
 
 	// BREADCRUMBS
-	breadcrumbsObject := []coreModel.TaxonomyNode{}
+	baseURL := "https://www.ons.gov.uk/"
 
-	for _, topicObject := range topicObjectList {
-		entry := coreModel.TaxonomyNode{
-			Title: topicObject.Title,
-			URI:   "#",
-		}
-		breadcrumbsObject = append(breadcrumbsObject, entry)
-	}
-
-	p.Breadcrumb = breadcrumbsObject
+	p.Breadcrumb = CreateBreadcrumbsFromTopicList(baseURL, topicObjectList)
 
 	// ALERTS
 	if version.Alerts != nil {

--- a/mapper/static_base.go
+++ b/mapper/static_base.go
@@ -12,11 +12,12 @@ import (
 	"github.com/ONSdigital/dp-frontend-dataset-controller/model/static"
 	"github.com/ONSdigital/dp-renderer/v2/helper"
 	coreModel "github.com/ONSdigital/dp-renderer/v2/model"
+	dpTopicApiModels "github.com/ONSdigital/dp-topic-api/models"
 )
 
 // CreateCensusBasePage builds a base datasetLandingPageCensus.Page with shared functionality between Dataset Landing Pages and Filter Output pages
 func CreateStaticBasePage(basePage coreModel.Page, d dpDatasetApiModels.Dataset, version dpDatasetApiModels.Version,
-	allVersions []dpDatasetApiModels.Version, isEnableMultivariate bool,
+	allVersions []dpDatasetApiModels.Version, isEnableMultivariate bool, topicObjectList []dpTopicApiModels.Topic,
 ) static.Page {
 	p := static.Page{
 		Page: basePage,
@@ -73,16 +74,17 @@ func CreateStaticBasePage(basePage coreModel.Page, d dpDatasetApiModels.Dataset,
 	p.ShowCensusBranding = false
 
 	// BREADCRUMBS
-	p.Breadcrumb = []coreModel.TaxonomyNode{
-		{
-			Title: "Home",
-			URI:   "https://www.ons.gov.uk/",
-		},
-		{
-			Title: "Overview page",
+	breadcrumbsObject := []coreModel.TaxonomyNode{}
+
+	for _, topicObject := range topicObjectList {
+		entry := coreModel.TaxonomyNode{
+			Title: topicObject.Title,
 			URI:   "#",
-		},
+		}
+		breadcrumbsObject = append(breadcrumbsObject, entry)
 	}
+
+	p.Breadcrumb = breadcrumbsObject
 
 	// ALERTS
 	if version.Alerts != nil {

--- a/mapper/static_base_test.go
+++ b/mapper/static_base_test.go
@@ -1,0 +1,37 @@
+package mapper
+
+import (
+	"testing"
+
+	dpDatasetApiModels "github.com/ONSdigital/dp-dataset-api/models"
+	coreModel "github.com/ONSdigital/dp-renderer/v2/model"
+	dpTopicApiModels "github.com/ONSdigital/dp-topic-api/models"
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestCreateStaticBasePage(t *testing.T) {
+	Convey("Given a topicObjectList with two topics", t, func() {
+		basePage := coreModel.Page{}
+		dataset := dpDatasetApiModels.Dataset{}
+		version := dpDatasetApiModels.Version{}
+		allVersions := []dpDatasetApiModels.Version{}
+		isEnableMultivariate := false
+
+		topicObjectList := []dpTopicApiModels.Topic{
+			{Title: "Topic One"},
+			{Title: "Topic Two"},
+		}
+
+		Convey("When CreateStaticBasePage is called", func() {
+			breadcrumbObject := CreateStaticBasePage(basePage, dataset, version, allVersions, isEnableMultivariate, topicObjectList)
+
+			Convey("Then the breadcrumbs object should contain a TaxonomyNode for each topic ", func() {
+				So(breadcrumbObject.Breadcrumb, ShouldHaveLength, 2)
+				So(breadcrumbObject.Breadcrumb[0].Title, ShouldEqual, "Topic One")
+				So(breadcrumbObject.Breadcrumb[0].URI, ShouldEqual, "#")
+				So(breadcrumbObject.Breadcrumb[1].Title, ShouldEqual, "Topic Two")
+				So(breadcrumbObject.Breadcrumb[1].URI, ShouldEqual, "#")
+			})
+		})
+	})
+}

--- a/mapper/static_base_test.go
+++ b/mapper/static_base_test.go
@@ -3,34 +3,30 @@ package mapper
 import (
 	"testing"
 
-	dpDatasetApiModels "github.com/ONSdigital/dp-dataset-api/models"
-	coreModel "github.com/ONSdigital/dp-renderer/v2/model"
 	dpTopicApiModels "github.com/ONSdigital/dp-topic-api/models"
 	. "github.com/smartystreets/goconvey/convey"
 )
 
 func TestCreateStaticBasePage(t *testing.T) {
 	Convey("Given a topicObjectList with two topics", t, func() {
-		basePage := coreModel.Page{}
-		dataset := dpDatasetApiModels.Dataset{}
-		version := dpDatasetApiModels.Version{}
-		allVersions := []dpDatasetApiModels.Version{}
-		isEnableMultivariate := false
-
 		topicObjectList := []dpTopicApiModels.Topic{
-			{Title: "Topic One"},
-			{Title: "Topic Two"},
+			{Title: "Topic One", Slug: "slug1"},
+			{Title: "Topic Two", Slug: "slug2"},
 		}
 
-		Convey("When CreateStaticBasePage is called", func() {
-			breadcrumbObject := CreateStaticBasePage(basePage, dataset, version, allVersions, isEnableMultivariate, topicObjectList)
+		baseURL := "https://www.ons.gov.uk/"
+
+		Convey("When CreateBreadcrumbsFromTopicList is called to build the breadcrumbs from the topics list", func() {
+			breadcrumbObject := CreateBreadcrumbsFromTopicList(baseURL, topicObjectList)
 
 			Convey("Then the breadcrumbs object should contain a TaxonomyNode for each topic ", func() {
-				So(breadcrumbObject.Breadcrumb, ShouldHaveLength, 2)
-				So(breadcrumbObject.Breadcrumb[0].Title, ShouldEqual, "Topic One")
-				So(breadcrumbObject.Breadcrumb[0].URI, ShouldEqual, "#")
-				So(breadcrumbObject.Breadcrumb[1].Title, ShouldEqual, "Topic Two")
-				So(breadcrumbObject.Breadcrumb[1].URI, ShouldEqual, "#")
+				So(breadcrumbObject, ShouldHaveLength, 3)
+				So(breadcrumbObject[0].Title, ShouldEqual, "Home")
+				So(breadcrumbObject[0].URI, ShouldEqual, "https://www.ons.gov.uk/")
+				So(breadcrumbObject[1].Title, ShouldEqual, "Topic One")
+				So(breadcrumbObject[1].URI, ShouldEqual, "https://www.ons.gov.uk/slug1")
+				So(breadcrumbObject[2].Title, ShouldEqual, "Topic Two")
+				So(breadcrumbObject[2].URI, ShouldEqual, "https://www.ons.gov.uk/slug1/slug2")
 			})
 		})
 	})

--- a/mapper/static_overview_page.go
+++ b/mapper/static_overview_page.go
@@ -8,13 +8,14 @@ import (
 	sharedModel "github.com/ONSdigital/dp-frontend-dataset-controller/model"
 	"github.com/ONSdigital/dp-frontend-dataset-controller/model/static"
 	coreModel "github.com/ONSdigital/dp-renderer/v2/model"
+	dpTopicApiModels "github.com/ONSdigital/dp-topic-api/models"
 )
 
 // CreateStaticLandingPage creates a static-overview page based on api model responses
 func CreateStaticOverviewPage(basePage coreModel.Page, datasetDetails dpDatasetApiModels.Dataset,
-	version dpDatasetApiModels.Version, allVersions []dpDatasetApiModels.Version, isEnableMultivariate bool,
+	version dpDatasetApiModels.Version, allVersions []dpDatasetApiModels.Version, isEnableMultivariate bool, topicObjectList []dpTopicApiModels.Topic,
 ) static.Page {
-	p := CreateStaticBasePage(basePage, datasetDetails, version, allVersions, isEnableMultivariate)
+	p := CreateStaticBasePage(basePage, datasetDetails, version, allVersions, isEnableMultivariate, topicObjectList)
 
 	// DOWNLOADS
 	if version.Distributions != nil {


### PR DESCRIPTION
### What

- fetches topics from `dp-topic-api` sdk using `getTopicPublic()` to create breadcrumbs within the dataset overview pages

### How to review

Ensure all tests are running 

### Who can review

Anyone
