### PR TITLE
fixed issue with url params

### DIFF
--- a/main.go
+++ b/main.go
@@ -190,7 +190,7 @@ func run(ctx context.Context) error {
 	router.Path("/datasets/{datasetID}/editions/{editionID}/versions/{versionID}/filter-outputs/{filterOutputID}").Methods("GET").HandlerFunc(handlers.FilterOutput(zc, f, pc, datasetAPISdkClient, rend, *cfg, apiRouterVersion))
 	router.Path("/datasets/{datasetID}/editions/{editionID}/versions/{versionID}/filter-outputs/{filterOutputID}").Methods("POST").HandlerFunc(handlers.CreateFilterFlexIDFromOutput(f))
 
-	router.Path("/datasets/{datasetID}/editions/{edition}/versions/{version}/metadata.txt").Methods("GET").HandlerFunc(handlers.MetadataText(datasetAPISdkClient, *cfg))
+	router.Path("/datasets/{datasetID}/editions/{editionID}/versions/{versionID}/metadata.txt").Methods("GET").HandlerFunc(handlers.MetadataText(datasetAPISdkClient, *cfg))
 
 	router.PathPrefix("/dataset/").Methods("GET").Handler(http.StripPrefix("/dataset/", handlers.DatasetPage(zc, rend, fc, cacheList)))
 	router.HandleFunc("/{uri:.*}", handlers.LegacyLanding(zc, apiClientsGoDatasetClient, fc, rend, cacheList, *cfg))


### PR DESCRIPTION
### What

[DIS-3202](https://jira.ons.gov.uk/browse/DIS-3202) Update FilterableLanding handler to include metadata size calculation

- Updated `main.go` `MetadataText` route to fix issue with url param naming. Param names now follow the same convention as other routes

### How to review

Checkout locally and view the cpih01 dataset overview page. The Other download options section should list the supporting information as a text file and a valid file size should be shown instead of "0B". Clicking on this file should allow the download of a valid metadata text file. See the https://jira.ons.gov.uk/browse/DIS-3157 ticket for more info.
