### PR TITLE
Feature/dis 3219 append edition to title of overview page

### DIFF
--- a/assets/templates/static.tmpl
+++ b/assets/templates/static.tmpl
@@ -23,7 +23,7 @@
       <h2 class="ons-hero--topic">Dataset</h2>
       <div class="ons-hero__title-container">
         <header>
-          <h1 class="ons-hero__title ons-u-fs-3xl">{{- .Metadata.Title -}}</h1>
+          <h1 class="ons-hero__title ons-u-fs-3xl">{{ .Metadata.Title }}: {{ .Version.Edition }}</h1>
         </header>
         {{ range .DatasetLandingPage.Description }}
         <p class="ons-hero__text">{{ . }}</p>

--- a/assets/templates/static.tmpl
+++ b/assets/templates/static.tmpl
@@ -23,7 +23,7 @@
       <h2 class="ons-hero--topic">Dataset</h2>
       <div class="ons-hero__title-container">
         <header>
-          <h1 class="ons-hero__title ons-u-fs-3xl">{{ .Metadata.Title }}: {{ .Version.Edition }}</h1>
+          <h1 class="ons-hero__title ons-u-fs-3xl">{{ .Metadata.Title }}{{if .Version.Edition }}: {{ .Version.Edition }}{{ end }}</h1>
         </header>
         {{ range .DatasetLandingPage.Description }}
         <p class="ons-hero__text">{{ . }}</p>

--- a/mapper/mapper_test.go
+++ b/mapper/mapper_test.go
@@ -14,6 +14,7 @@ import (
 	dpDatasetApiSdk "github.com/ONSdigital/dp-dataset-api/sdk"
 	sharedModel "github.com/ONSdigital/dp-frontend-dataset-controller/model"
 	dpRendererModel "github.com/ONSdigital/dp-renderer/v2/model"
+	dpTopicApiModels "github.com/ONSdigital/dp-topic-api/models"
 	. "github.com/smartystreets/goconvey/convey"
 )
 
@@ -643,4 +644,29 @@ func getTestEmergencyBanner() zebedee.EmergencyBanner {
 
 func getTestServiceMessage() string {
 	return "Test service message"
+}
+
+func TestCreateBreadcrumbsFromTopicList(t *testing.T) {
+	Convey("Given a topicObjectList with two topics", t, func() {
+		topicObjectList := []dpTopicApiModels.Topic{
+			{Title: "Topic One", Slug: "slug1"},
+			{Title: "Topic Two", Slug: "slug2"},
+		}
+
+		baseURL := "https://www.ons.gov.uk/"
+
+		Convey("When CreateBreadcrumbsFromTopicList is called to build the breadcrumbs from the topics list", func() {
+			breadcrumbObject := CreateBreadcrumbsFromTopicList(baseURL, topicObjectList)
+
+			Convey("Then the breadcrumbs object should contain a TaxonomyNode for each topic ", func() {
+				So(breadcrumbObject, ShouldHaveLength, 3)
+				So(breadcrumbObject[0].Title, ShouldEqual, "Home")
+				So(breadcrumbObject[0].URI, ShouldEqual, "https://www.ons.gov.uk/")
+				So(breadcrumbObject[1].Title, ShouldEqual, "Topic One")
+				So(breadcrumbObject[1].URI, ShouldEqual, "https://www.ons.gov.uk/slug1")
+				So(breadcrumbObject[2].Title, ShouldEqual, "Topic Two")
+				So(breadcrumbObject[2].URI, ShouldEqual, "https://www.ons.gov.uk/slug1/slug2")
+			})
+		})
+	})
 }

--- a/mapper/static_base.go
+++ b/mapper/static_base.go
@@ -18,9 +18,19 @@ import (
 func CreateStaticBasePage(basePage coreModel.Page, d dpDatasetApiModels.Dataset, version dpDatasetApiModels.Version,
 	allVersions []dpDatasetApiModels.Version, isEnableMultivariate bool,
 ) static.Page {
+	var editionStr string
+
 	p := static.Page{
 		Page: basePage,
 	}
+
+	// Use edition title string if available
+	if version.EditionTitle != "" {
+		editionStr = version.EditionTitle
+	} else {
+		editionStr = version.Edition
+	}
+	p.Version.Edition = editionStr
 
 	hasOtherVersions := false
 	initialVersionReleaseDate := ""

--- a/mapper/static_base_test.go
+++ b/mapper/static_base_test.go
@@ -3,30 +3,46 @@ package mapper
 import (
 	"testing"
 
+	dpDatasetApiModels "github.com/ONSdigital/dp-dataset-api/models"
+	coreModel "github.com/ONSdigital/dp-renderer/v2/model"
 	dpTopicApiModels "github.com/ONSdigital/dp-topic-api/models"
 	. "github.com/smartystreets/goconvey/convey"
 )
 
 func TestCreateStaticBasePage(t *testing.T) {
-	Convey("Given a topicObjectList with two topics", t, func() {
-		topicObjectList := []dpTopicApiModels.Topic{
-			{Title: "Topic One", Slug: "slug1"},
-			{Title: "Topic Two", Slug: "slug2"},
+	basePage := coreModel.Page{}
+	dataset := dpDatasetApiModels.Dataset{}
+	allVersions := []dpDatasetApiModels.Version{}
+	isEnableMultivariate := true
+	topicObjectList := []dpTopicApiModels.Topic{}
+
+	Convey("If `version.EditionTitle` field value is valid", t, func() {
+		editionTitleStr := "My edition title"
+		editionSlug := "my-edition-title"
+		version := dpDatasetApiModels.Version{
+			EditionTitle: editionTitleStr,
+			Edition:      editionSlug,
 		}
+		Convey("When CreateStaticBasePage is called", func() {
+			staticPage := CreateStaticBasePage(basePage, dataset, version, allVersions, isEnableMultivariate, topicObjectList)
 
-		baseURL := "https://www.ons.gov.uk/"
+			Convey("Then the resulting static.Page should have expected values", func() {
+				So(staticPage.Version.Edition, ShouldEqual, editionTitleStr)
+			})
+		})
+	})
+	Convey("If `version.EditionTitle` field value is not valid", t, func() {
+		editionTitleStr := ""
+		editionSlug := "my-edition-title"
+		version := dpDatasetApiModels.Version{
+			EditionTitle: editionTitleStr,
+			Edition:      editionSlug,
+		}
+		Convey("When CreateStaticBasePage is called", func() {
+			staticPage := CreateStaticBasePage(basePage, dataset, version, allVersions, isEnableMultivariate, topicObjectList)
 
-		Convey("When CreateBreadcrumbsFromTopicList is called to build the breadcrumbs from the topics list", func() {
-			breadcrumbObject := CreateBreadcrumbsFromTopicList(baseURL, topicObjectList)
-
-			Convey("Then the breadcrumbs object should contain a TaxonomyNode for each topic ", func() {
-				So(breadcrumbObject, ShouldHaveLength, 3)
-				So(breadcrumbObject[0].Title, ShouldEqual, "Home")
-				So(breadcrumbObject[0].URI, ShouldEqual, "https://www.ons.gov.uk/")
-				So(breadcrumbObject[1].Title, ShouldEqual, "Topic One")
-				So(breadcrumbObject[1].URI, ShouldEqual, "https://www.ons.gov.uk/slug1")
-				So(breadcrumbObject[2].Title, ShouldEqual, "Topic Two")
-				So(breadcrumbObject[2].URI, ShouldEqual, "https://www.ons.gov.uk/slug1/slug2")
+			Convey("Then the resulting static.Page should have expected values", func() {
+				So(staticPage.Version.Edition, ShouldEqual, editionSlug)
 			})
 		})
 	})


### PR DESCRIPTION
### What

[DIS-3219](https://jira.ons.gov.uk/browse/DIS-3219) Append edition to title of overview page

- Updated `assets/templates/static.tmpl` to include conditional rendering of the version edition if it exists in the page context
- Updated `mapper/static_base.go` to add version edition to the page context in `CreateStaticBasePage` mapper. This will use the version `EditionTitle` field value if available, otherwise will just use the `Edition` field value
- Updated `mapper/mapper_test.go` to move `TestCreateBreadcrumbsFromTopicList` as the function under test is in `mapper/mapper.go`
- Updated `mapper/static_base_test.go` to add new tests for `CreateStaticBasePage` mapper edition string conditional  in `TestCreateStaticBasePage`

### How to review

Check out locally, view http://localhost:20200/datasets/static-test-dataset/editions/time-series/versions/1 and see that the edition is appended to the dataset title 
