### PR TITLE
added labels to contact details

### DIFF
--- a/assets/locales/service.cy.toml
+++ b/assets/locales/service.cy.toml
@@ -126,6 +126,14 @@ one = "Manylion cyswllt ar gyfer y set ddata hon"
 description = "Contact details"
 one = "Contact details"
 
+[Name]
+description = "Name"
+one = "Name"
+
+[Team]
+description = "Team"
+one = "Team"
+
 [Email]
 description = "Email"
 one = "Email"

--- a/assets/locales/service.en.toml
+++ b/assets/locales/service.en.toml
@@ -114,6 +114,10 @@ one = "Contact details"
 description = "Name"
 one = "Name"
 
+[Team]
+description = "Team"
+one = "Team"
+
 [Email]
 description = "Email"
 one = "Email"

--- a/assets/templates/partials/static/contact-details.tmpl
+++ b/assets/templates/partials/static/contact-details.tmpl
@@ -2,16 +2,18 @@
     <h2 class="ons-u-mt-xl ons-u-pb-no ons-u-pt-no" id="contact-details">{{ localise "DatasetContactDetailsStatic" .Language 1 }}</h2>
         <div class="ons-text-indent">
         {{ if .ContactDetails.Name }}
-            <p class="ons-u-mb-no">{{ .ContactDetails.Name }}</p>
+            <p class="ons-u-mb-no">
+                <b>{{ localise "Team" .Language 1 }}:</b> {{ .ContactDetails.Name }}
+            </p>
         {{ end }}
         {{ if .ContactDetails.Email }}
             <p class="ons-u-mb-no">
-                <a href="mailto:{{.ContactDetails.Email}}">{{ .ContactDetails.Email }}</a>
+                <b>{{ localise "Email" .Language 1 }}:</b> <a href="mailto:{{.ContactDetails.Email}}">{{ .ContactDetails.Email }}</a>
             </p>
         {{ end }}
         {{ if .ContactDetails.Telephone }}
             <p class="ons-u-mb-no">
-                {{ localise "Telephone" .Language 1 }}: <a href="tel:{{ .ContactDetails.Telephone | safeHTML }}">{{ .ContactDetails.Telephone }}</a>
+                <b>{{ localise "Telephone" .Language 1 }}:</b> <a href="tel:{{ .ContactDetails.Telephone | safeHTML }}">{{ .ContactDetails.Telephone }}</a>
             </p>
         {{ end }}
         </div>                


### PR DESCRIPTION
### What

[DIS-3221](https://jira.ons.gov.uk/browse/DIS-3219) Append edition to title of overview page

- Updated `assets/locales/service.cy.toml` and `assets/locales/service.en.toml` to include new `Team` translation
- Updated `assets/templates/partials/static/contact-details.tmpl` to add the bold labels to the contact details indented text

### How to review

Checkout locally and look at http://localhost:20200/datasets/static-test-dataset/editions/time-series/versions/1. Contact details should now look like this:

<img width="380" alt="image" src="https://github.com/user-attachments/assets/07b06e6f-2cbb-4180-b16a-bea2aafb78fe" />