### PR TITLE
added aligning of contact details

### DIFF
--- a/assets/templates/partials/static/contact-details.tmpl
+++ b/assets/templates/partials/static/contact-details.tmpl
@@ -1,21 +1,26 @@
 <section id="contact" aria-label="{{ localise "RelatedLinksForCensus" .Language 1 }}">
     <h2 class="ons-u-mt-xl ons-u-pb-no ons-u-pt-no" id="contact-details">{{ localise "DatasetContactDetailsStatic" .Language 1 }}</h2>
         <div class="ons-text-indent">
-        {{ if .ContactDetails.Name }}
-            <p class="ons-u-mb-no">
-                <b>{{ localise "Team" .Language 1 }}:</b> {{ .ContactDetails.Name }}
-            </p>
-        {{ end }}
-        {{ if .ContactDetails.Email }}
-            <p class="ons-u-mb-no">
-                <b>{{ localise "Email" .Language 1 }}:</b> <a href="mailto:{{.ContactDetails.Email}}">{{ .ContactDetails.Email }}</a>
-            </p>
-        {{ end }}
-        {{ if .ContactDetails.Telephone }}
-            <p class="ons-u-mb-no">
-                <b>{{ localise "Telephone" .Language 1 }}:</b> <a href="tel:{{ .ContactDetails.Telephone | safeHTML }}">{{ .ContactDetails.Telephone }}</a>
-            </p>
-        {{ end }}
+            <dl class="ons-description-list ons-description-list__items ons-grid ons-grid--gutterless ons-u-cf ons-u-mb-no" title="Contact details for this dataset series version" aria-label="Contact details for this dataset series version">
+            {{ if .ContactDetails.Name }}
+            <div class="ons-description-list__item">
+                <dt class="ons-description-list__term ons-grid__col ons-col-2@m">{{ localise "Team" .Language 1 }}:</dt>
+                <dd class="ons-description-list__value ons-grid__col ons-col-10@m">{{ .ContactDetails.Name }}</dd>
+            </div>
+            {{ end }}
+             {{ if .ContactDetails.Email }}
+            <div class="ons-description-list__item">
+                <dt class="ons-description-list__term ons-grid__col ons-col-2@m">{{ localise "Email" .Language 1 }}:</dt>
+                <dd class="ons-description-list__value ons-grid__col ons-col-10@m"><a href="mailto:{{.ContactDetails.Email}}">{{ .ContactDetails.Email }}</a></dd>
+            </div>
+            {{ end }}
+            {{ if .ContactDetails.Telephone }}
+            <div class="ons-description-list__item">
+                <dt class="ons-description-list__term ons-grid__col ons-col-2@m">{{ localise "Telephone" .Language 1 }}:</dt>
+                <dd class="ons-description-list__value ons-grid__col ons-col-10@m"><a href="tel:{{ .ContactDetails.Telephone | safeHTML }}">{{ .ContactDetails.Telephone }}</a></dd>
+            </div>
+            {{ end }}
+            </dl>
         </div>                
     {{ template "partials/census/back-to-contents" . }}
 </section>


### PR DESCRIPTION
### What

[DIS-3221](https://jira.ons.gov.uk/browse/DIS-3219) Append edition to title of overview page

- Updated `assets/templates/partials/static/contact-details.tmpl` to use description list component within the indented text for contact details

### How to review

Checkout locally and look at http://localhost:20200/datasets/static-test-dataset/editions/time-series/versions/1. Contact details should now look like this:

<img width="463" alt="image" src="https://github.com/user-attachments/assets/0f89760e-8f96-4742-8991-51357493b0ae" />

