### PR TITLE
Publisher details brought in on dataset overview page

### DIFF
--- a/assets/locales/service.cy.toml
+++ b/assets/locales/service.cy.toml
@@ -262,6 +262,10 @@ one = "Last updated"
 description = "See version history"
 one = "See version history"
 
+[Publisher]
+description = "Publisher:"
+one = "Publisher:"
+
 [PublisherName]
 description = "Publisher name:"
 one = "Publisher name:"
@@ -273,6 +277,10 @@ one = "Publisher URL:"
 [VersionHistory]
 description = "Version history"
 one = "Version history"
+
+[Version]
+description = "Version:"
+one = "Version:"
 
 [UpdateReasonHeading]
 description = "Update reason"

--- a/assets/locales/service.en.toml
+++ b/assets/locales/service.en.toml
@@ -243,6 +243,10 @@ one = "Last updated"
 description = "See version history"
 one = "See version history"
 
+[Publisher]
+description = "Publisher:"
+one = "Publisher:"
+
 [PublisherName]
 description = "Publisher name:"
 one = "Publisher name:"
@@ -254,6 +258,10 @@ one = "Publisher URL:"
 [VersionHistory]
 description = "Version history"
 one = "Version history"
+
+[Version]
+description = "Version:"
+one = "Version:"
 
 [UpdateReasonHeading]
 description = "Update reason heading"

--- a/assets/templates/static.tmpl
+++ b/assets/templates/static.tmpl
@@ -49,18 +49,18 @@
             </dd>
           </div>
         </div>
-        <div class="ons-grid__col ons-col-4@m ons-u-mt-xs">       
+        {{ if and .Publisher.Name .Publisher.URL }}
+        <div class="ons-grid__col ons-col-4@m ons-u-mt-xs">
           <div class="ons-metadata__item">
-              <dt class="ons-metadata__term ons-u-mr-xs">{{ localise "NextRelease" .Language 1 }}</dt>
-              <dd class="ons-metadata__value ons-u-f-no">
-              {{ if .DatasetLandingPage.NextRelease }}
-                {{ dateFormat .DatasetLandingPage.NextRelease }}
-              {{ else }}
-                {{ localise "TBA" .Language 1 }}
-              {{ end }}
-              </dd>
+          <dt class="ons-metadata__term ons-u-mr-xs">
+            {{ localise "Publisher" .Language 1 }}
+          </dt>
+          <dd class="ons-metadata__value ons-u-f-no">
+            <a href="{{.Publisher.URL}}">{{.Publisher.Name}}</a>
+          </dd>
           </div>
         </div>
+        {{ end }}
       </div>
     </div>
   </div>

--- a/mapper/static_base.go
+++ b/mapper/static_base.go
@@ -38,6 +38,7 @@ func CreateStaticBasePage(basePage coreModel.Page, d dpDatasetApiModels.Dataset,
 	isNationalStatistic := false
 	latestVersionNumber := 1
 
+
 	// Loop through versions to find info
 	for i := range allVersions {
 		singleVersion := &allVersions[i]

--- a/mapper/static_base.go
+++ b/mapper/static_base.go
@@ -39,7 +39,6 @@ func CreateStaticBasePage(basePage coreModel.Page, d dpDatasetApiModels.Dataset,
 	isNationalStatistic := false
 	latestVersionNumber := 1
 
-
 	// Loop through versions to find info
 	for i := range allVersions {
 		singleVersion := &allVersions[i]


### PR DESCRIPTION
### What

- publisher details brought into hero of the dataset overview page

### How to review

- make a static dataset and check that the publisher details display when they are available. They should follow the look and feel of the designs here: https://new-ons-website.framer.website/dataset-editions/child-mortality-(death-cohort)-tables-in-england-and-wales-2022

### Who can review

Anyone
