### PR TITLE
Edition used within dataset title in lieu of edition title 

### DIFF
--- a/mapper/static_base.go
+++ b/mapper/static_base.go
@@ -25,11 +25,11 @@ func CreateStaticBasePage(basePage coreModel.Page, d dpDatasetApiModels.Dataset,
 		Page: basePage,
 	}
 
-	// Use edition title string if available
-	if version.EditionTitle != "" {
-		editionStr = version.EditionTitle
+	// Use edition for use in title if available
+	if version.Edition != "" {
+		editionStr = version.Edition 
 	} else {
-		editionStr = version.Edition
+		editionStr = "Edition not found"
 	}
 	p.Version.Edition = editionStr
 	p.Version.Version = strconv.Itoa(version.Version)


### PR DESCRIPTION
### What

Previously the edition title was used within the title of a dataset overview page. This has been changed since the Edition ID should be used instead

### How to review

Create a static dataset with multiple editions and confirm that for each edition the title includes the edition ID

### Who can review

Anyone
