### PR TITLE
Breadcrumb urls should be constructed using relative URLs

### DIFF
--- a/mapper/mapper.go
+++ b/mapper/mapper.go
@@ -398,9 +398,7 @@ func CreateEditionsListForStaticDatasetType(ctx context.Context, basePage dpRend
 	p.DatasetLandingPage.DatasetID = datasetID
 
 	// BREADCRUMBS
-	baseURL := "https://www.ons.gov.uk/"
-
-	p.Breadcrumb = CreateBreadcrumbsFromTopicList(baseURL, topicObjectList)
+	p.Breadcrumb = CreateBreadcrumbsFromTopicList(topicObjectList)
 
 	// Get editions list
 	editionItems := editions.Items
@@ -707,22 +705,18 @@ func buildEditionsListTableOfContents(d dpDatasetApiModels.Dataset) dpRendererMo
 	return tableOfContents
 }
 
-func CreateBreadcrumbsFromTopicList(baseURL string, topicObjectList []dpTopicApiModels.Topic) []dpRendererModel.TaxonomyNode {
+func CreateBreadcrumbsFromTopicList(topicObjectList []dpTopicApiModels.Topic) []dpRendererModel.TaxonomyNode {
 	breadcrumbsObject := []dpRendererModel.TaxonomyNode{
 		{
 			Title: "Home",
-			URI:   baseURL,
+			URI:   "/",
 		},
 	}
-	path := baseURL
+	path := ""
 
-	for i, topicObject := range topicObjectList {
-		if i == 0 {
-			path += topicObject.Slug
-		} else {
-			// topic1 URI => /slug1 ... topic2 URI => /slug1/slug2... etc..
-			path += "/" + topicObject.Slug
-		}
+	for _, topicObject := range topicObjectList {
+		// topic1 URI => /slug1 ... topic2 URI => /slug1/slug2... etc..
+		path += "/" + topicObject.Slug
 		breadcrumbsObject = append(breadcrumbsObject, dpRendererModel.TaxonomyNode{
 			Title: topicObject.Title,
 			URI:   path,

--- a/mapper/mapper_test.go
+++ b/mapper/mapper_test.go
@@ -657,19 +657,17 @@ func TestCreateBreadcrumbsFromTopicList(t *testing.T) {
 			{Title: "Topic Two", Slug: "slug2"},
 		}
 
-		baseURL := "https://www.ons.gov.uk/"
-
 		Convey("When CreateBreadcrumbsFromTopicList is called to build the breadcrumbs from the topics list", func() {
-			breadcrumbObject := CreateBreadcrumbsFromTopicList(baseURL, topicObjectList)
+			breadcrumbObject := CreateBreadcrumbsFromTopicList(topicObjectList)
 
 			Convey("Then the breadcrumbs object should contain a TaxonomyNode for each topic ", func() {
 				So(breadcrumbObject, ShouldHaveLength, 3)
 				So(breadcrumbObject[0].Title, ShouldEqual, "Home")
-				So(breadcrumbObject[0].URI, ShouldEqual, "https://www.ons.gov.uk/")
+				So(breadcrumbObject[0].URI, ShouldEqual, "/")
 				So(breadcrumbObject[1].Title, ShouldEqual, "Topic One")
-				So(breadcrumbObject[1].URI, ShouldEqual, "https://www.ons.gov.uk/slug1")
+				So(breadcrumbObject[1].URI, ShouldEqual, "/slug1")
 				So(breadcrumbObject[2].Title, ShouldEqual, "Topic Two")
-				So(breadcrumbObject[2].URI, ShouldEqual, "https://www.ons.gov.uk/slug1/slug2")
+				So(breadcrumbObject[2].URI, ShouldEqual, "/slug1/slug2")
 			})
 		})
 	})

--- a/mapper/static_base.go
+++ b/mapper/static_base.go
@@ -85,9 +85,7 @@ func CreateStaticBasePage(basePage coreModel.Page, d dpDatasetApiModels.Dataset,
 	p.ShowCensusBranding = false
 
 	// BREADCRUMBS
-	baseURL := "https://www.ons.gov.uk/"
-
-	breadcrumbsObject := CreateBreadcrumbsFromTopicList(baseURL, topicObjectList)
+	breadcrumbsObject := CreateBreadcrumbsFromTopicList(topicObjectList)
 
 	editionsListURL := "/datasets/" + d.ID + "/editions"
 


### PR DESCRIPTION
### What

Previously the breadcrumb URLs were constructed using an absolute path, with a base URL defined as "ons.go.uk" This logic has been modified in order to ensure the URLs are built as relative paths. 

This was outlined here: https://jira.ons.gov.uk/browse/DIS-3359

### How to review

Create a static dataset locally and test that the breadcrumbs successfully take the user to the relative paths attached to each breadcrumb defined. 

Ensure all tests pass 

### Who can review

Anyone
