### PR TITLE
Added return after redirect

### DIFF
--- a/handlers/editions_list.go
+++ b/handlers/editions_list.go
@@ -62,6 +62,7 @@ func editionsList(w http.ResponseWriter, req *http.Request, dc DatasetAPISdkClie
 		latestVersionPath := helpers.DatasetVersionURL(datasetID, datasetEditions.Items[0].Edition, datasetEditions.Items[0].Links.LatestVersion.ID)
 		log.Info(ctx, "only one edition, therefore redirecting to latest version", log.Data{"latestVersionPath": latestVersionPath})
 		http.Redirect(w, req, latestVersionPath, http.StatusFound)
+		return
 	}
 
 	// Fetch homepage content


### PR DESCRIPTION
### What

Added return after redirect to fix bug where  a crash would occur if a cantabular dataset url was truncated i.e. so that it no longer included an edition.

### How to review

LGTM

### Who can review

Anyone