### PR TITLE
Remove 304 if etag match

### DIFF
--- a/handlers/legacy_landing.go
+++ b/handlers/legacy_landing.go
@@ -105,11 +105,6 @@ func (lp legacyLandingPage) Build(w http.ResponseWriter, req *http.Request) {
 	}
 
 	generatedETag := response.GenerateETag(b, true)
-	requestedETag := req.Header.Get("If-None-Match")
-	if requestedETag == generatedETag {
-		w.WriteHeader(http.StatusNotModified)
-		return
-	}
 	response.SetETag(w, generatedETag)
 
 	lp.RenderClient.BuildPage(w, m, "static-legacy")

--- a/handlers/legacy_landing_test.go
+++ b/handlers/legacy_landing_test.go
@@ -81,37 +81,6 @@ func TestLegacyLanding(t *testing.T) {
 			So(w.Code, ShouldEqual, http.StatusOK)
 		})
 
-		Convey("when the requested content has not changed", func() {
-			dlp := zebedee.DatasetLandingPage{URI: "https://helloworld.com"}
-			dlp.Datasets = append(dlp.Datasets, zebedee.Link{Title: "A dataset!", URI: "dataset.com"})
-
-			mockZebedeeClient.EXPECT().GetDatasetLandingPage(ctx, userAuthToken, collectionID, locale, "/somelegacypage").Return(dlp, nil)
-			mockZebedeeClient.EXPECT().GetBreadcrumb(ctx, userAuthToken, collectionID, locale, dlp.URI)
-			mockZebedeeClient.EXPECT().GetDataset(ctx, userAuthToken, collectionID, locale, "dataset.com")
-			mockZebedeeClient.EXPECT().GetHomepageContent(ctx, userAuthToken, collectionID, locale, "/")
-
-			mockRend := NewMockRenderClient(mockCtrl)
-			mockRend.EXPECT().NewBasePageModel().Return(coreModel.NewPage(cfg.PatternLibraryAssetsPath, cfg.SiteDomain))
-
-			w := httptest.NewRecorder()
-			req, _ := http.NewRequest(http.MethodGet, "/somelegacypage", http.NoBody)
-
-			ctxOther := context.Background()
-			mockCacheList, err := cache.GetMockCacheList(ctxOther, cfg.SupportedLanguages)
-			So(err, ShouldBeNil)
-
-			Convey("And the request has a matching If-None-Match header", func() {
-				eTag := `W/"f5fe18be7b633201e9301b8a4ff519e1cc9c5d2b"`
-				req.Header.Set("If-None-Match", eTag)
-
-				LegacyLanding(mockZebedeeClient, mockDatasetClient, mockFilesAPIClient, mockRend, mockCacheList, cfg).ServeHTTP(w, req)
-
-				Convey("Then it returns 304", func() {
-					So(w.Code, ShouldEqual, http.StatusNotModified)
-				})
-			})
-		})
-
 		Convey("test status 500 returned when zebedee client returns error retrieving landing page", func() {
 			dlp := zebedee.DatasetLandingPage{}
 			mockZebedeeClient.EXPECT().GetDatasetLandingPage(ctx, userAuthToken, collectionID, locale, "/somelegacypage").Return(dlp, errors.New("something went wrong :("))


### PR DESCRIPTION
### What

Remove 304s if etag match due to clashing with legacy-cache-proxy

### How to review

Check looks ok.

### Who can review

Not me.