### PR TITLE
Bugfix/use topic slug within approval route

### DIFF
--- a/handlers/approve.go
+++ b/handlers/approve.go
@@ -14,25 +14,29 @@ import (
 // ApproveDatasetVersion handles the approve button click on static dataset version pages
 func ApproveDatasetVersion(dc DatasetAPISdkClient, cfg config.Config) http.HandlerFunc {
 	return handlers.ControllerHandler(func(w http.ResponseWriter, req *http.Request, lang, collectionID, userAccessToken string) {
-		approveDatasetVersion(w, req, dc, collectionID, userAccessToken, lang)
+		approveDatasetVersion(w, req, dc, userAccessToken)
 	})
 }
 
-func approveDatasetVersion(w http.ResponseWriter, req *http.Request, dc DatasetAPISdkClient, collectionID, userAccessToken, lang string) {
+func approveDatasetVersion(w http.ResponseWriter, req *http.Request, dc DatasetAPISdkClient, userAccessToken string) {
 	ctx := req.Context()
 
 	vars := mux.Vars(req)
+	topicSlug := vars["topic"]
 	datasetID := vars["datasetID"]
 	editionID := vars["editionID"]
 	versionID := vars["versionID"]
 
 	headers := dpDatasetApiSdk.Headers{
-		CollectionID:         collectionID,
-		DownloadServiceToken: "",
-		AccessToken:          userAccessToken,
+		AccessToken: userAccessToken,
 	}
 
-	logData := log.Data{"datasetID": datasetID, "editionID": editionID, "versionID": versionID}
+	logData := log.Data{
+		"topicSlug": topicSlug,
+		"datasetID": datasetID,
+		"editionID": editionID,
+		"versionID": versionID,
+	}
 
 	err := dc.PutVersionState(ctx, headers, datasetID, editionID, versionID, "approved")
 	if err != nil {
@@ -41,6 +45,6 @@ func approveDatasetVersion(w http.ResponseWriter, req *http.Request, dc DatasetA
 		log.Info(ctx, "dataset version approval successful", logData)
 	}
 
-	uri := fmt.Sprintf("/datasets/%s/editions/%s/versions/%s", datasetID, editionID, versionID)
+	uri := fmt.Sprintf("/%s/datasets/%s/editions/%s/versions/%s", topicSlug, datasetID, editionID, versionID)
 	http.Redirect(w, req, uri, http.StatusTemporaryRedirect)
 }

--- a/handlers/approve_test.go
+++ b/handlers/approve_test.go
@@ -23,9 +23,7 @@ func TestApproveDatasetVersion(t *testing.T) {
 			mockClient := NewMockDatasetAPISdkClient(mockCtrl)
 
 			headers := dpDatasetApiSdk.Headers{
-				CollectionID:         collectionID,
-				DownloadServiceToken: "",
-				AccessToken:          userAuthToken,
+				AccessToken: userAuthToken,
 			}
 
 			mockClient.
@@ -34,24 +32,22 @@ func TestApproveDatasetVersion(t *testing.T) {
 				Return(nil)
 
 			w := httptest.NewRecorder()
-			req := httptest.NewRequest("GET", "/datasets/12345/editions/2017/versions/1/approve", http.NoBody)
+			req := httptest.NewRequest("GET", "/topicSlug/datasets/12345/editions/2017/versions/1/approve", http.NoBody)
 
 			router := mux.NewRouter()
-			router.HandleFunc("/datasets/{datasetID}/editions/{editionID}/versions/{versionID}/approve", ApproveDatasetVersion(mockClient, config.Config{}))
+			router.HandleFunc("/{topic}/datasets/{datasetID}/editions/{editionID}/versions/{versionID}/approve", ApproveDatasetVersion(mockClient, config.Config{}))
 
 			router.ServeHTTP(w, req)
 
 			So(w.Code, ShouldEqual, http.StatusTemporaryRedirect)
-			So(w.Header().Get("Location"), ShouldEqual, "/datasets/12345/editions/2017/versions/1")
+			So(w.Header().Get("Location"), ShouldEqual, "/topicSlug/datasets/12345/editions/2017/versions/1")
 		})
 
 		Convey("logs error from dataset client but still redirects", func() {
 			mockClient := NewMockDatasetAPISdkClient(mockCtrl)
 
 			headers := dpDatasetApiSdk.Headers{
-				CollectionID:         collectionID,
-				DownloadServiceToken: "",
-				AccessToken:          userAuthToken,
+				AccessToken: userAuthToken,
 			}
 
 			mockClient.
@@ -60,15 +56,15 @@ func TestApproveDatasetVersion(t *testing.T) {
 				Return(errors.New("approval failed"))
 
 			w := httptest.NewRecorder()
-			req := httptest.NewRequest("GET", "/datasets/12345/editions/2017/versions/1/approve", http.NoBody)
+			req := httptest.NewRequest("GET", "/topicSlug/datasets/12345/editions/2017/versions/1/approve", http.NoBody)
 
 			router := mux.NewRouter()
-			router.HandleFunc("/datasets/{datasetID}/editions/{editionID}/versions/{versionID}/approve", ApproveDatasetVersion(mockClient, config.Config{}))
+			router.HandleFunc("/{topic}/datasets/{datasetID}/editions/{editionID}/versions/{versionID}/approve", ApproveDatasetVersion(mockClient, config.Config{}))
 
 			router.ServeHTTP(w, req)
 
 			So(w.Code, ShouldEqual, http.StatusTemporaryRedirect)
-			So(w.Header().Get("Location"), ShouldEqual, "/datasets/12345/editions/2017/versions/1")
+			So(w.Header().Get("Location"), ShouldEqual, "/topicSlug/datasets/12345/editions/2017/versions/1")
 		})
 	})
 }

--- a/handlers/create_filter_id.go
+++ b/handlers/create_filter_id.go
@@ -14,6 +14,8 @@ import (
 	"github.com/gorilla/mux"
 )
 
+const maxFormBytes = 8 * 1024 // 8KB as only one form value is expected
+
 // CreateFilterID controls the creating of a filter idea when a new user journey is requested
 func CreateFilterID(c FilterClient, dc APIClientsGoDatasetClient) http.HandlerFunc {
 	return handlers.ControllerHandler(func(w http.ResponseWriter, req *http.Request, lang, collectionID, userAccessToken string) {
@@ -65,6 +67,7 @@ func CreateFilterFlexID(fc FilterClient, dc APIClientsGoDatasetClient) http.Hand
 		version := vars["versionID"]
 		ctx := req.Context()
 
+		req.Body = http.MaxBytesReader(w, req.Body, maxFormBytes)
 		if err := req.ParseForm(); err != nil {
 			log.Error(ctx, "unable to parse request form", err)
 			w.WriteHeader(http.StatusInternalServerError)
@@ -116,6 +119,7 @@ func CreateFilterFlexIDFromOutput(fc FilterClient) http.HandlerFunc {
 		filterOutputID := vars["filterOutputID"]
 		ctx := req.Context()
 
+		req.Body = http.MaxBytesReader(w, req.Body, maxFormBytes)
 		if err := req.ParseForm(); err != nil {
 			log.Error(ctx, "unable to parse request form", err)
 			w.WriteHeader(http.StatusInternalServerError)

--- a/main.go
+++ b/main.go
@@ -207,7 +207,7 @@ func run(ctx context.Context) error {
 	router.Path("/{topic}/datasets/{datasetID}/editions/{editionID}/versions/{versionID}").Methods("GET").HandlerFunc(handlers.StaticLanding(datasetAPISdkClient, rend, zc, tc, *cfg, authorisation))
 
 	if cfg.IsPublishing {
-		router.Path("/datasets/{datasetID}/editions/{editionID}/versions/{versionID}/approve").Methods("GET").HandlerFunc(handlers.ApproveDatasetVersion(datasetAPISdkClient, *cfg))
+		router.Path("/{topic}/datasets/{datasetID}/editions/{editionID}/versions/{versionID}/approve").Methods("GET").HandlerFunc(handlers.ApproveDatasetVersion(datasetAPISdkClient, *cfg))
 	}
 
 	router.PathPrefix("/dataset/").Methods("GET").Handler(http.StripPrefix("/dataset/", handlers.DatasetPage(zc, rend, fc, cacheList)))


### PR DESCRIPTION
### What

Ticket:
https://officefornationalstatistics.atlassian.net/browse/DIS-4676

- Since the new URL format must start with `/{topic}`, the approval route must also accept the same prefix. It will also redirect correctly once the approval button has been pressed.
- `maxFormBytes` set to 8KB to fix lint error. Only one field ("dimension") is being read from the form so this max size should be more than enough

### How to review

- Run the dataset-catalogue with `IS_PUBLISHING` set to true
- `dis-design-system-go` should be running with `make debug`
- Create a dataset version and go to the landing page. Then click the approval button and ensure the version is now `approved` and the page has refreshed showing the version has been approved

### Who can review

- Anyone
