### PR TITLE
Adding alert banner message for CMD overview page

### DIFF
--- a/assets/templates/filterable.tmpl
+++ b/assets/templates/filterable.tmpl
@@ -6,6 +6,11 @@
                <span class="page-intro__type padding-top--0 padding-bottom--0">Dataset:</span>
                <strong>{{ .Metadata.Title }}{{ if .DatasetLandingPage.ShowEditionName }}: {{ .DatasetLandingPage.Edition }} {{ end }}</strong>
             </h1>
+            <section>
+               {{range .DatasetLandingPage.Alerts}}
+                  <div class="margin-bottom--4"><span class="dataset-alert">{{ .Type }} - {{dateFormat .Date }}: {{ .Description }}</span></div>
+               {{ end }}
+            </section>
             {{ template "partials/release-alert" . }}
          </div>
       </div>

--- a/handlers/filterable_landing_page.go
+++ b/handlers/filterable_landing_page.go
@@ -203,7 +203,6 @@ func filterableLanding(responseWriter http.ResponseWriter, request *http.Request
 				log.Warn(ctx, "unable to get breadcrumb for dataset uri", log.FormatErrors([]error{err}), log.Data{"taxonomy_url": taxonomyURL})
 			}
 		}
-
 		// filterable landing mapper
 		m := mapper.CreateFilterableLandingPage(ctx, basePage, datasetDetails, version, datasetID, opts,
 			dims, displayOtherVersionsLink, bc, latestVersionNumber, latestVersionURL, apiRouterVersion,

--- a/handlers/filterable_landing_page.go
+++ b/handlers/filterable_landing_page.go
@@ -203,6 +203,7 @@ func filterableLanding(responseWriter http.ResponseWriter, request *http.Request
 				log.Warn(ctx, "unable to get breadcrumb for dataset uri", log.FormatErrors([]error{err}), log.Data{"taxonomy_url": taxonomyURL})
 			}
 		}
+
 		// filterable landing mapper
 		m := mapper.CreateFilterableLandingPage(ctx, basePage, datasetDetails, version, datasetID, opts,
 			dims, displayOtherVersionsLink, bc, latestVersionNumber, latestVersionURL, apiRouterVersion,

--- a/mapper/mapper.go
+++ b/mapper/mapper.go
@@ -229,6 +229,17 @@ func CreateFilterableLandingPage(ctx context.Context, basePage dpRendererModel.P
 		}
 	}
 
+	if ver.Alerts != nil {
+		fmt.Println(ver.Alerts)
+		for _, alert := range *ver.Alerts {
+			p.DatasetLandingPage.Alerts = append(p.DatasetLandingPage.Alerts, filterable.Alert{
+				Type:        cases.Title(language.Und, cases.NoLower).String(string(alert.Type)), // Casts the first letter to uppercase so it can be used in a label
+				Description: alert.Description,
+				Date:        alert.Date,
+			})
+		}
+	}
+
 	var v sharedModel.Version
 	v.Title = d.Title
 	v.Description = d.Description

--- a/mapper/mapper.go
+++ b/mapper/mapper.go
@@ -230,7 +230,6 @@ func CreateFilterableLandingPage(ctx context.Context, basePage dpRendererModel.P
 	}
 
 	if ver.Alerts != nil {
-		fmt.Println(ver.Alerts)
 		for _, alert := range *ver.Alerts {
 			p.DatasetLandingPage.Alerts = append(p.DatasetLandingPage.Alerts, filterable.Alert{
 				Type:        cases.Title(language.Und, cases.NoLower).String(string(alert.Type)), // Casts the first letter to uppercase so it can be used in a label

--- a/mapper/mapper_test.go
+++ b/mapper/mapper_test.go
@@ -74,6 +74,12 @@ func TestUnitMapper(t *testing.T) {
 		Type:    "nomis",
 	}
 
+	alert := dpDatasetApiModels.Alert{
+		Type:        dpDatasetApiModels.AlertTypeAlert,
+		Description: "Some alert",
+		Date:        "2026-04-25T16:00:00.000Z",
+	}
+
 	v := []dpDatasetApiModels.Version{
 		{
 			CollectionID: "abcdefg",
@@ -85,6 +91,7 @@ func TestUnitMapper(t *testing.T) {
 					HRef: "/datasets/83jd98fkflg/editions/124/versions/1",
 				},
 			},
+			Alerts: &[]dpDatasetApiModels.Alert{alert},
 			Dimensions: []dpDatasetApiModels.Dimension{
 				{
 					ID:    "city",
@@ -203,6 +210,9 @@ func TestUnitMapper(t *testing.T) {
 		So(p.DatasetLandingPage.Dimensions[1].Values, ShouldHaveLength, 1)
 		So(p.DatasetLandingPage.Dimensions[1].Title, ShouldEqual, "Time")
 		So(p.DatasetLandingPage.Dimensions[1].Values[0], ShouldEqual, "All months between January 2005 and February 2005")
+		So(p.DatasetLandingPage.Alerts[0].Type, ShouldEqual, "Alert")
+		So(p.DatasetLandingPage.Alerts[0].Description, ShouldEqual, "Some alert")
+		So(p.DatasetLandingPage.Alerts[0].Date, ShouldEqual, "2026-04-25T16:00:00.000Z")
 
 		v0 := p.DatasetLandingPage.Version
 		So(v0.Title, ShouldEqual, d.Title)

--- a/model/datasetLandingPageFilterable/model.go
+++ b/model/datasetLandingPageFilterable/model.go
@@ -9,6 +9,15 @@ import (
 	"github.com/ONSdigital/dp-frontend-dataset-controller/model/staticlegacy"
 )
 
+// AlertType defines possible types of alerts
+type AlertType string
+
+// Define the possible values for the AlertType enum
+const (
+	AlertTypeAlert      AlertType = "alert"
+	AlertTypeCorrection AlertType = "correction"
+)
+
 // Page contains data re-used for each page type a Data struct for data specific to the page type
 type Page struct {
 	model.Page
@@ -38,6 +47,7 @@ type DatasetLandingPage struct {
 	Methodologies            []Methodology           `json:"methodology"`
 	NomisReferenceURL        string                  `json:"nomis_reference_url,omitempty"`
 	UsageNotes               []UsageNote             `json:"UsageNotes"`
+	Alerts                   []Alert                 `json:"alerts"`
 	OSRLogo                  osrlogo.OSRLogo         `json:"osr_logo"`
 }
 
@@ -45,6 +55,13 @@ type DatasetLandingPage struct {
 type UsageNote struct {
 	Note  string `json:"note,omitempty"`
 	Title string `json:"title,omitempty"`
+}
+
+// Alert represents data for a single alert
+type Alert struct {
+	Date        string `json:"date,omitempty"`
+	Description string `json:"description,omitempty"`
+	Type        string `json:"type,omitempty"`
 }
 
 // Publication represents the data for a single publication


### PR DESCRIPTION
### What

Added a label to display alerts on CMD dataset overview pages.

### How to review

Ensure the tests pass and the changes make sense.
For a more detailed review, add the sixteens container to the dataset-catalogue dp-compose stack and run the applications.  Add an alert object such as the following to the alerts array in mongodb for the cpih01 instance:
```
 {
            "date" : "2026-04-30T11:00:00.000Z",
            "description" : "Something something.",
            "type" : "alert"
        }
```
Access the overview page via the dataset controller using the URL http://localhost:20200/datasets/cpih01/editions/time-series/versions/1.  If the frontend-dataset-controller and associated services are running in publishing you'll need to log in using the stub first.  The alert should appear under the title of the dataset as plain text.

### Who can review

Anyone.
