### PR TITLE
Feature/display qmi section on edition page

### DIFF
--- a/assets/locales/service.cy.toml
+++ b/assets/locales/service.cy.toml
@@ -488,3 +488,35 @@ one = "Privacy notice"
 [AboutUs]
 description = "About us"
 one = "About us"
+
+[QualityAndMethodologyInformation]
+description = "Quality and methodology information"
+one = "Quality and methodology information"
+
+[QMIIncludes]
+description = "Includes heading for QMI section"
+one = "Includes:"
+
+[QMIDataSource]
+description = "Where the data comes from (source)"
+one = "Where the data comes from (source)"
+
+[QMIAccuracy]
+description = "The accuracy and reliability of the data"
+one = "The accuracy and reliability of the data"
+
+[QMIRelevance]
+description = "The relevance of the data to certain application or uses"
+one = "The relevance of the data to certain application or uses"
+
+[QMIReadFullPrefix]
+description = "QMI read full link prefix"
+one = "Read the full"
+
+[QMILinkText]
+description = "QMI link text"
+one = "Quality and methodology information (QMI)"
+
+[QMIReadFullSuffix]
+description = "QMI read full link suffix"
+one = "for this dataset."

--- a/assets/locales/service.en.toml
+++ b/assets/locales/service.en.toml
@@ -469,3 +469,35 @@ one = "Privacy notice"
 [AboutUs]
 description = "About us"
 one = "About us"
+
+[QualityAndMethodologyInformation]
+description = "Quality and methodology information"
+one = "Quality and methodology information"
+
+[QMIIncludes]
+description = "Includes heading for QMI section"
+one = "Includes:"
+
+[QMIDataSource]
+description = "Where the data comes from (source)"
+one = "Where the data comes from (source)"
+
+[QMIAccuracy]
+description = "The accuracy and reliability of the data"
+one = "The accuracy and reliability of the data"
+
+[QMIRelevance]
+description = "The relevance of the data to certain application or uses"
+one = "The relevance of the data to certain application or uses"
+
+[QMIReadFullPrefix]
+description = "QMI read full link prefix"
+one = "Read the full"
+
+[QMILinkText]
+description = "QMI link text"
+one = "Quality and methodology information (QMI)"
+
+[QMIReadFullSuffix]
+description = "QMI read full link suffix"
+one = "for this dataset."

--- a/assets/templates/partials/static/quality-and-methodology-information.tmpl
+++ b/assets/templates/partials/static/quality-and-methodology-information.tmpl
@@ -1,0 +1,13 @@
+<section id="quality-and-methodology-information" aria-label="{{ localise "QualityAndMethodologyInformation" .Language 1 }}">
+    <h2 class="ons-u-mt-xl ons-u-pb-no ons-u-pt-no">{{ localise "QualityAndMethodologyInformation" .Language 1 }}</h2>
+
+    <p>{{ localise "QMIIncludes" .Language 1 }}</p>
+    <ul class="ons-list">
+        <li class="ons-list__item">{{ localise "QMIDataSource" .Language 1 }}</li>
+        <li class="ons-list__item">{{ localise "QMIAccuracy" .Language 1 }}</li>
+        <li class="ons-list__item">{{ localise "QMIRelevance" .Language 1 }}</li>
+    </ul>
+    <p class="ons-u-mt-m">{{ localise "QMIReadFullPrefix" .Language 1 }} <a href="{{ .DatasetLandingPage.QMIURL }}">{{ localise "QMILinkText" .Language 1 }}</a> {{ localise "QMIReadFullSuffix" .Language 1 }}</p>
+
+    {{ template "partials/census/back-to-contents" . }}
+</section>

--- a/assets/templates/static.tmpl
+++ b/assets/templates/static.tmpl
@@ -87,6 +87,9 @@
     </div>
     <div class="ons-grid__col ons-col-8@m ons-u-pl-no">
       {{ template "partials/static/get-data" . }}
+      {{ if .DatasetLandingPage.QMIURL }}
+      {{ template "partials/static/quality-and-methodology-information" . }}
+      {{ end }}
       {{ if .UsageNotes}}
       {{ template "partials/static/usage-notes" . }}
       {{ end }}

--- a/ci/audit.yml
+++ b/ci/audit.yml
@@ -5,7 +5,7 @@ image_resource:
   type: docker-image
   source:
     repository: onsdigital/dp-concourse-tools-vulncheck
-    tag: 1.26.3-vulncheck-0.5.0
+    tag: 1.26.4-vulncheck-0.5.0
 
 inputs:
   - name: dp-frontend-dataset-controller

--- a/ci/build.yml
+++ b/ci/build.yml
@@ -6,7 +6,7 @@ image_resource:
   type: docker-image
   source:
     repository: golang
-    tag: 1.26.3-bookworm
+    tag: 1.26.4-bookworm
 
 inputs:
   - name: dp-frontend-dataset-controller

--- a/ci/component.yml
+++ b/ci/component.yml
@@ -6,7 +6,7 @@ image_resource:
   type: docker-image
   source:
     repository: golang
-    tag: 1.26.3-bookworm
+    tag: 1.26.4-bookworm
 
 inputs:
   - name: dp-frontend-dataset-controller

--- a/ci/lint.yml
+++ b/ci/lint.yml
@@ -6,7 +6,7 @@ image_resource:
   type: docker-image
   source:
     repository: onsdigital/dp-concourse-tools-lint-go
-    tag: 1.26.3-bookworm-golangci-lint-2
+    tag: 1.26.4-bookworm-golangci-lint-2
 
 inputs:
   - name: dp-frontend-dataset-controller

--- a/ci/unit.yml
+++ b/ci/unit.yml
@@ -6,7 +6,7 @@ image_resource:
   type: docker-image
   source:
     repository: golang
-    tag: 1.26.3-bookworm
+    tag: 1.26.4-bookworm
 
 inputs:
   - name: dp-frontend-dataset-controller

--- a/mapper/static_base.go
+++ b/mapper/static_base.go
@@ -85,6 +85,10 @@ func CreateStaticBasePage(basePage core.Page, d dpDatasetApiModels.Dataset, vers
 	p.DatasetLandingPage.OSRLogo = helpers.GetOSRLogoDetails(basePage.Language)
 	p.DatasetLandingPage.NextRelease = d.NextRelease
 
+	if d.QMI != nil {
+		p.DatasetLandingPage.QMIURL = d.QMI.HRef
+	}
+
 	// CENSUS BRANDING
 	p.ShowCensusBranding = false
 
@@ -221,6 +225,16 @@ func buildStaticTableOfContents(p static.Page, d dpDatasetApiModels.Dataset, has
 		},
 	}
 	displayOrder = append(displayOrder, "get-data")
+
+	if p.DatasetLandingPage.QMIURL != "" {
+		sections["quality-and-methodology-information"] = core.ContentSection{
+			Title: core.Localisation{
+				LocaleKey: "QualityAndMethodologyInformation",
+				Plural:    1,
+			},
+		}
+		displayOrder = append(displayOrder, "quality-and-methodology-information")
+	}
 
 	if len(p.UsageNotes) > 0 {
 		sections["usage-notes"] = core.ContentSection{

--- a/mapper/static_base_test.go
+++ b/mapper/static_base_test.go
@@ -51,4 +51,18 @@ func TestCreateStaticBasePage(t *testing.T) {
 			})
 		})
 	})
+
+	Convey("If dataset has QMI details", t, func() {
+		datasetWithQMI := dataset
+		datasetWithQMI.QMI = &dpDatasetApiModels.GeneralDetails{HRef: "https://example.com/qmi"}
+		version := dpDatasetApiModels.Version{}
+
+		Convey("When CreateStaticBasePage is called", func() {
+			staticPage := CreateStaticBasePage(basePage, datasetWithQMI, version, allVersions, isEnableMultivariate, topicObjectList)
+
+			Convey("Then the resulting static.Page should include QMI URL", func() {
+				So(staticPage.DatasetLandingPage.QMIURL, ShouldEqual, "https://example.com/qmi")
+			})
+		})
+	})
 }

--- a/model/static/model.go
+++ b/model/static/model.go
@@ -43,6 +43,7 @@ type DatasetLandingPage struct {
 	NextRelease         string                           `json:"next_release"`
 	OSRLogo             osrlogo.OSRLogo                  `json:"osr_logo"`
 	Panels              []Panel                          `json:"panels"`
+	QMIURL              string                           `json:"qmi_url"`
 	QualityStatements   []Panel                          `json:"quality_statements"`
 	RelatedContentItems []sharedModel.RelatedContentItem `json:"related_content_items"`
 	SDC                 []Panel                          `json:"sdc"`


### PR DESCRIPTION
### What

Ticket: https://officefornationalstatistics.atlassian.net/browse/DIS-4742

- Display QMI section on edition pages if it exists

### How to review

- Create a dataset and edition with the QMI field populated with a link
- Check the edition overview page displays the QMI section as shown in the design and section is linked in the table of contents
- If QMI does not exist at series level then it should not be on the page

### Who can review

- Anyone
