### PR TITLE
Feature/redirect when incorrect topic is provided

### DIFF
--- a/handlers/data.go
+++ b/handlers/data.go
@@ -58,9 +58,22 @@ func datasetData(r *http.Request, w http.ResponseWriter, datasetAPIClient client
 	}
 
 	topicSlugs := helpers.ExtractTopicSlugs(topicList)
-	if len(topicSlugs) == 0 || topicSlugs[0] != topicSlug {
-		log.Error(ctx, "dataset topic does not match URL topic", errDatasetTopicMismatch, logData)
-		setStatusCode(ctx, w, errDatasetTopicMismatch)
+	if len(topicSlugs) == 0 {
+		log.Error(ctx, "no topics found for dataset", errDatasetHasNoTopics, logData)
+		setStatusCode(ctx, w, errDatasetHasNoTopics)
+		return
+	}
+
+	expectedTopicSlug := topicSlugs[0]
+	if expectedTopicSlug != topicSlug {
+		logData["providedTopicSlug"] = topicSlug
+		logData["expectedTopicSlug"] = expectedTopicSlug
+		log.Info(ctx, "incorrect topic slug provided, redirecting to correct topic", logData)
+
+		redirectPath := helpers.ReplaceFirstPathSegment(r.URL.Path, expectedTopicSlug)
+
+		//nolint:gosec // false positive as this is a relative URL which can only redirect to the same host
+		http.Redirect(w, r, redirectPath, http.StatusFound)
 		return
 	}
 
@@ -122,9 +135,22 @@ func editionData(r *http.Request, w http.ResponseWriter, datasetAPIClient client
 	}
 
 	topicSlugs := helpers.ExtractTopicSlugs(topicList)
-	if len(topicSlugs) == 0 || topicSlugs[0] != topicSlug {
-		log.Error(ctx, "dataset topic does not match URL topic", errDatasetTopicMismatch, logData)
-		setStatusCode(ctx, w, errDatasetTopicMismatch)
+	if len(topicSlugs) == 0 {
+		log.Error(ctx, "no topics found for dataset", errDatasetHasNoTopics, logData)
+		setStatusCode(ctx, w, errDatasetHasNoTopics)
+		return
+	}
+
+	expectedTopicSlug := topicSlugs[0]
+	if expectedTopicSlug != topicSlug {
+		logData["providedTopicSlug"] = topicSlug
+		logData["expectedTopicSlug"] = expectedTopicSlug
+		log.Info(ctx, "incorrect topic slug provided, redirecting to correct topic", logData)
+
+		redirectPath := helpers.ReplaceFirstPathSegment(r.URL.Path, expectedTopicSlug)
+
+		//nolint:gosec // false positive as this is a relative URL which can only redirect to the same host
+		http.Redirect(w, r, redirectPath, http.StatusFound)
 		return
 	}
 
@@ -206,9 +232,22 @@ func versionData(r *http.Request, w http.ResponseWriter, datasetAPIClient client
 	}
 
 	topicSlugs := helpers.ExtractTopicSlugs(topicList)
-	if len(topicSlugs) == 0 || topicSlugs[0] != topicSlug {
-		log.Error(ctx, "dataset topic does not match URL topic", errDatasetTopicMismatch, logData)
-		setStatusCode(ctx, w, errDatasetTopicMismatch)
+	if len(topicSlugs) == 0 {
+		log.Error(ctx, "no topics found for dataset", errDatasetHasNoTopics, logData)
+		setStatusCode(ctx, w, errDatasetHasNoTopics)
+		return
+	}
+
+	expectedTopicSlug := topicSlugs[0]
+	if expectedTopicSlug != topicSlug {
+		logData["providedTopicSlug"] = topicSlug
+		logData["expectedTopicSlug"] = expectedTopicSlug
+		log.Info(ctx, "incorrect topic slug provided, redirecting to correct topic", logData)
+
+		redirectPath := helpers.ReplaceFirstPathSegment(r.URL.Path, expectedTopicSlug)
+
+		//nolint:gosec // false positive as this is a relative URL which can only redirect to the same host
+		http.Redirect(w, r, redirectPath, http.StatusFound)
 		return
 	}
 

--- a/handlers/data_test.go
+++ b/handlers/data_test.go
@@ -219,6 +219,24 @@ func TestDatasetData(t *testing.T) {
 			})
 		})
 
+		Convey("When no topics are returned for the dataset", func() {
+			datasetWithNoTopics := dataset
+			datasetWithNoTopics.Topics = []string{}
+
+			mockDatasetClient.EXPECT().GetDataset(ctx, testDatasetHeaders, datasetID).
+				Return(datasetWithNoTopics, nil)
+
+			w := httptest.NewRecorder()
+			r := httptest.NewRequest(http.MethodGet, requestPath, http.NoBody)
+			r = mux.SetURLVars(r, urlVars)
+
+			datasetData(r, w, mockDatasetClient, mockTopicClient, false, testUserAccessToken)
+
+			Convey("Then the response status code should be 500 Internal Server Error", func() {
+				So(w.Code, ShouldEqual, http.StatusInternalServerError)
+			})
+		})
+
 		Convey("When canonical topic does not match topic slug in URL", func() {
 			mockDatasetClient.EXPECT().GetDataset(ctx, testDatasetHeaders, datasetID).
 				Return(dataset, nil)
@@ -235,8 +253,9 @@ func TestDatasetData(t *testing.T) {
 
 			datasetData(r, w, mockDatasetClient, mockTopicClient, false, testUserAccessToken)
 
-			Convey("Then the response status code should be 404 Not Found", func() {
-				So(w.Code, ShouldEqual, http.StatusNotFound)
+			Convey("Then the response status code should be 302 Found and redirect to correct topic", func() {
+				So(w.Code, ShouldEqual, http.StatusFound)
+				So(w.Header().Get("Location"), ShouldEqual, fmt.Sprintf("/%s/datasets/%s/data", "different-topic", datasetID))
 			})
 		})
 
@@ -405,6 +424,24 @@ func TestEditionData(t *testing.T) {
 			})
 		})
 
+		Convey("When no topics are returned for the dataset", func() {
+			datasetWithNoTopics := dataset
+			datasetWithNoTopics.Topics = []string{}
+
+			mockDatasetClient.EXPECT().GetDataset(ctx, testDatasetHeaders, datasetID).
+				Return(datasetWithNoTopics, nil)
+
+			w := httptest.NewRecorder()
+			r := httptest.NewRequest(http.MethodGet, requestPath, http.NoBody)
+			r = mux.SetURLVars(r, urlVars)
+
+			editionData(r, w, mockDatasetClient, mockTopicClient, false, testUserAccessToken)
+
+			Convey("Then the response status code should be 500 Internal Server Error", func() {
+				So(w.Code, ShouldEqual, http.StatusInternalServerError)
+			})
+		})
+
 		Convey("When canonical topic does not match topic slug in URL", func() {
 			mockDatasetClient.EXPECT().GetDataset(ctx, testDatasetHeaders, datasetID).
 				Return(dataset, nil)
@@ -421,8 +458,9 @@ func TestEditionData(t *testing.T) {
 
 			editionData(r, w, mockDatasetClient, mockTopicClient, false, testUserAccessToken)
 
-			Convey("Then the response status code should be 404 Not Found", func() {
-				So(w.Code, ShouldEqual, http.StatusNotFound)
+			Convey("Then the response status code should be 302 Found and redirect to correct topic", func() {
+				So(w.Code, ShouldEqual, http.StatusFound)
+				So(w.Header().Get("Location"), ShouldEqual, fmt.Sprintf("/%s/datasets/%s/editions/%s/data", "different-topic", datasetID, editionID))
 			})
 		})
 
@@ -623,6 +661,24 @@ func TestVersionData(t *testing.T) {
 			})
 		})
 
+		Convey("When no topics are returned for the dataset", func() {
+			datasetWithNoTopics := dataset
+			datasetWithNoTopics.Topics = []string{}
+
+			mockDatasetClient.EXPECT().GetDataset(ctx, testDatasetHeaders, datasetID).
+				Return(datasetWithNoTopics, nil)
+
+			w := httptest.NewRecorder()
+			r := httptest.NewRequest(http.MethodGet, requestPath, http.NoBody)
+			r = mux.SetURLVars(r, urlVars)
+
+			versionData(r, w, mockDatasetClient, mockTopicClient, false, testUserAccessToken)
+
+			Convey("Then the response status code should be 500 Internal Server Error", func() {
+				So(w.Code, ShouldEqual, http.StatusInternalServerError)
+			})
+		})
+
 		Convey("When canonical topic does not match topic slug in URL", func() {
 			mockDatasetClient.EXPECT().GetDataset(ctx, testDatasetHeaders, datasetID).
 				Return(dataset, nil)
@@ -639,8 +695,9 @@ func TestVersionData(t *testing.T) {
 
 			versionData(r, w, mockDatasetClient, mockTopicClient, false, testUserAccessToken)
 
-			Convey("Then the response status code should be 404 Not Found", func() {
-				So(w.Code, ShouldEqual, http.StatusNotFound)
+			Convey("Then the response status code should be 302 Found and redirect to correct topic", func() {
+				So(w.Code, ShouldEqual, http.StatusFound)
+				So(w.Header().Get("Location"), ShouldEqual, fmt.Sprintf("/%s/datasets/%s/editions/%s/versions/%s/data", "different-topic", datasetID, editionID, versionID))
 			})
 		})
 

--- a/handlers/errors.go
+++ b/handlers/errors.go
@@ -8,13 +8,13 @@ import (
 // List of errors used within the handlers package
 var (
 	errDatasetTypeNotSupported  = errors.New("dataset type is not supported")
-	errDatasetTopicMismatch     = errors.New("dataset topic does not match topic in URL")
+	errDatasetHasNoTopics       = errors.New("no topics found for dataset")
 	errMissingLatestVersionLink = errors.New("latest version link is missing from dataset API response")
 )
 
 // Map of errors to HTTP status codes
 var errorToStatusCodeMap = map[error]int{
 	errDatasetTypeNotSupported:  http.StatusNotFound,
-	errDatasetTopicMismatch:     http.StatusNotFound,
+	errDatasetHasNoTopics:       http.StatusInternalServerError,
 	errMissingLatestVersionLink: http.StatusInternalServerError,
 }

--- a/handlers/static_editions_list.go
+++ b/handlers/static_editions_list.go
@@ -56,9 +56,25 @@ func staticEditionsList(r *http.Request, w http.ResponseWriter, datasetAPIClient
 		return
 	}
 
-	if len(topicList) == 0 || topicList[0].Slug != topicSlug {
-		log.Error(ctx, "dataset topic does not match URL topic", errDatasetTopicMismatch, logData)
-		setStatusCode(ctx, w, errDatasetTopicMismatch)
+	if len(topicList) == 0 {
+		log.Error(ctx, "no topics found for dataset", errDatasetHasNoTopics, logData)
+		setStatusCode(ctx, w, errDatasetHasNoTopics)
+		return
+	}
+
+	expectedTopicSlug := topicList[0].Slug
+
+	// If the URL topic slug doesn't match the dataset's primary topic slug, redirect to the expected one
+	if expectedTopicSlug != topicSlug {
+		logData["providedTopicSlug"] = topicSlug
+		logData["expectedTopicSlug"] = expectedTopicSlug
+		log.Info(ctx, "incorrect topic slug provided, redirecting to correct topic", logData)
+
+		// Reconstruct the request path with the expected topic slug
+		redirectPath := helpers.ReplaceFirstPathSegment(r.URL.Path, expectedTopicSlug)
+
+		//nolint:gosec // false positive as this is a relative URL which can only redirect to the same host
+		http.Redirect(w, r, redirectPath, http.StatusFound)
 		return
 	}
 

--- a/handlers/static_editions_list_test.go
+++ b/handlers/static_editions_list_test.go
@@ -158,6 +158,29 @@ func TestStaticEditionsList(t *testing.T) {
 		})
 	})
 
+	Convey("When no topics are returned for the dataset", t, func() {
+		mockDatasetClient.EXPECT().GetDataset(ctx, testUserDatasetSDKHeaders, datasetID).
+			Return(datasetAPIModels.Dataset{
+				ID:     datasetID,
+				Type:   DatasetTypeStatic,
+				Topics: []string{},
+				Links:  dataset.Links,
+			}, nil)
+
+		w := httptest.NewRecorder()
+		r := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/%s/datasets/%s", "topic1-slug", datasetID), http.NoBody)
+		r = mux.SetURLVars(r, map[string]string{
+			"topic":     "topic1-slug",
+			"datasetID": datasetID,
+		})
+
+		staticEditionsList(r, w, mockDatasetClient, mockRenderClient, mockZebedeeClient, mockTopicAPIClient, cfg, apiRouterVersion, testUserAccessToken, lang, collectionID)
+
+		Convey("Then the response status code should be 500 Internal Server Error", func() {
+			So(w.Code, ShouldEqual, http.StatusInternalServerError)
+		})
+	})
+
 	Convey("When the first topic in the dataset does not match the topic in the URL", t, func() {
 		mockDatasetClient.EXPECT().GetDataset(ctx, testUserDatasetSDKHeaders, datasetID).
 			Return(dataset, nil)
@@ -176,8 +199,9 @@ func TestStaticEditionsList(t *testing.T) {
 
 		staticEditionsList(r, w, mockDatasetClient, mockRenderClient, mockZebedeeClient, mockTopicAPIClient, cfg, apiRouterVersion, testUserAccessToken, lang, collectionID)
 
-		Convey("Then the response status code should be 404 Not Found", func() {
-			So(w.Code, ShouldEqual, http.StatusNotFound)
+		Convey("Then the response status code should be 302 Found and redirect to correct topic", func() {
+			So(w.Code, ShouldEqual, http.StatusFound)
+			So(w.Header().Get("Location"), ShouldEqual, fmt.Sprintf("/%s/datasets/%s", testTopic1.Slug, datasetID))
 		})
 	})
 

--- a/handlers/static_landing.go
+++ b/handlers/static_landing.go
@@ -63,9 +63,25 @@ func staticLanding(r *http.Request, w http.ResponseWriter, datasetAPIClient clie
 		return
 	}
 
-	if len(topicList) == 0 || topicList[0].Slug != topicSlug {
-		log.Error(ctx, "dataset topic does not match URL topic", errDatasetTopicMismatch, logData)
-		setStatusCode(ctx, w, errDatasetTopicMismatch)
+	if len(topicList) == 0 {
+		log.Error(ctx, "no topics found for dataset", errDatasetHasNoTopics, logData)
+		setStatusCode(ctx, w, errDatasetHasNoTopics)
+		return
+	}
+
+	expectedTopicSlug := topicList[0].Slug
+
+	// If the URL topic slug doesn't match the dataset's primary topic slug, redirect to the expected one
+	if expectedTopicSlug != topicSlug {
+		logData["providedTopicSlug"] = topicSlug
+		logData["expectedTopicSlug"] = expectedTopicSlug
+		log.Info(ctx, "incorrect topic slug provided, redirecting to correct topic", logData)
+
+		// Reconstruct the request path with the expected topic slug
+		redirectPath := helpers.ReplaceFirstPathSegment(r.URL.Path, expectedTopicSlug)
+
+		//nolint:gosec // false positive as this is a relative URL which can only redirect to the same host
+		http.Redirect(w, r, redirectPath, http.StatusFound)
 		return
 	}
 

--- a/handlers/static_landing_test.go
+++ b/handlers/static_landing_test.go
@@ -187,6 +187,31 @@ func TestStaticLanding(t *testing.T) {
 		})
 	})
 
+	Convey("When no topics are returned for the dataset", t, func() {
+		mockDatasetClient.EXPECT().GetDataset(ctx, testUserDatasetSDKHeaders, datasetID).
+			Return(datasetAPIModels.Dataset{
+				ID:     datasetID,
+				Type:   DatasetTypeStatic,
+				Topics: []string{},
+				Links:  dataset.Links,
+			}, nil)
+
+		w := httptest.NewRecorder()
+		r := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/%s/datasets/%s/editions/%s/versions/%s", "topic1-slug", datasetID, editionID, versionID), http.NoBody)
+		r = mux.SetURLVars(r, map[string]string{
+			"topic":     "topic1-slug",
+			"datasetID": datasetID,
+			"editionID": editionID,
+			"versionID": versionID,
+		})
+
+		staticLanding(r, w, mockDatasetClient, mockRenderClient, mockZebedeeClient, mockTopicAPIClient, cfg, mockAuthMiddleware, testUserAccessToken, lang, collectionID)
+
+		Convey("Then the response status code should be 500 Internal Server Error", func() {
+			So(w.Code, ShouldEqual, http.StatusInternalServerError)
+		})
+	})
+
 	Convey("When the first topic in the dataset does not match the topic in the URL", t, func() {
 		mockDatasetClient.EXPECT().GetDataset(ctx, testUserDatasetSDKHeaders, datasetID).
 			Return(dataset, nil)
@@ -207,8 +232,9 @@ func TestStaticLanding(t *testing.T) {
 
 		staticLanding(r, w, mockDatasetClient, mockRenderClient, mockZebedeeClient, mockTopicAPIClient, cfg, mockAuthMiddleware, testUserAccessToken, lang, collectionID)
 
-		Convey("Then the response status code should be 404 Not Found", func() {
-			So(w.Code, ShouldEqual, http.StatusNotFound)
+		Convey("Then the response status code should be 302 Found and redirect to correct topic", func() {
+			So(w.Code, ShouldEqual, http.StatusFound)
+			So(w.Header().Get("Location"), ShouldEqual, fmt.Sprintf("/%s/datasets/%s/editions/%s/versions/%s", testTopic1.Slug, datasetID, editionID, versionID))
 		})
 	})
 

--- a/helpers/url.go
+++ b/helpers/url.go
@@ -7,6 +7,20 @@ import (
 	"strings"
 )
 
+// ReplaceFirstPathSegment returns a path where the first segment is replaced
+// by the provided segment.
+func ReplaceFirstPathSegment(oldPath, newSegment string) string {
+	trimmed := strings.Trim(oldPath, "/")
+	if trimmed == "" {
+		return "/" + newSegment
+	}
+
+	parts := strings.Split(trimmed, "/")
+	parts[0] = newSegment
+
+	return "/" + strings.Join(parts, "/")
+}
+
 // PrefixPathWithTopic returns the path of rawURL prefixed with topicID.
 // The first path segment (assumed to be the API Router version) is always removed
 // because frontend routes do not include the API version prefix.

--- a/helpers/url_test.go
+++ b/helpers/url_test.go
@@ -60,3 +60,44 @@ func TestPrefixPathWithTopic(t *testing.T) {
 		})
 	})
 }
+
+func TestReplaceFirstPathSegment(t *testing.T) {
+	testCases := []struct {
+		name        string
+		rawPath     string
+		replaceWith string
+		expected    string
+	}{
+		{
+			name:        "path with multiple segments",
+			rawPath:     "/path/with/multiple/segments",
+			replaceWith: "new",
+			expected:    "/new/with/multiple/segments",
+		},
+		{
+			name:        "path without leading slash",
+			rawPath:     "path/without/leading/slash",
+			replaceWith: "new",
+			expected:    "/new/without/leading/slash",
+		},
+		{
+			name:        "root path",
+			rawPath:     "/",
+			replaceWith: "new",
+			expected:    "/new",
+		},
+		{
+			name:        "empty path",
+			rawPath:     "",
+			replaceWith: "new",
+			expected:    "/new",
+		},
+	}
+
+	for _, tc := range testCases {
+		Convey(tc.name, t, func() {
+			result := ReplaceFirstPathSegment(tc.rawPath, tc.replaceWith)
+			So(result, ShouldEqual, tc.expected)
+		})
+	}
+}


### PR DESCRIPTION
### What

Ticket: https://officefornationalstatistics.atlassian.net/browse/DIS-5018

- Update all `/{topic}` prefix handlers to redirect (302) to the correct overview page when an incorrect topic slug is provided

### How to review

- Create a dataset version
- Check all the following endpoints return a 302 redirect when an incorrect topic slug is provided:
  - `/{topic}/datasets/{datasetID}/data`
  - `/{topic}/datasets/{datasetID}/editions/{editionID}/data`
  - `/{topic}/datasets/{datasetID}/editions/{editionID}/versions/{versionID}/data`
  - `/{topic}/datasets/{datasetID}`
  - `/{topic}/datasets/{datasetID}/editions`
  - `/{topic}/datasets/{datasetID}/editions/{editionID}`
  - `/{topic}/datasets/{datasetID}/editions/{editionID}/versions`
  - `/{topic}/datasets/{datasetID}/editions/{editionID}/versions/{versionID}`

### Who can review

- Anyone
