### PR TITLE
move status code handling and handle other dataset API SDK errors

### DIFF
--- a/handlers/errors.go
+++ b/handlers/errors.go
@@ -1,12 +1,20 @@
 package handlers
 
 import (
+	"context"
 	"errors"
 	"net/http"
+	"strconv"
+
+	datasetAPIErrors "github.com/ONSdigital/dp-dataset-api/apierrors"
+	datasetAPIModels "github.com/ONSdigital/dp-dataset-api/models"
+	"github.com/ONSdigital/dp-frontend-dataset-controller/clients"
+	"github.com/ONSdigital/log.go/v2/log"
 )
 
 // List of errors used within the handlers package
 var (
+	errTooManyOptions           = errors.New("too many options in dimension")
 	errDatasetTypeNotSupported  = errors.New("dataset type is not supported")
 	errDatasetHasNoTopics       = errors.New("no topics found for dataset")
 	errMissingLatestVersionLink = errors.New("latest version link is missing from dataset API response")
@@ -17,4 +25,60 @@ var errorToStatusCodeMap = map[error]int{
 	errDatasetTypeNotSupported:  http.StatusNotFound,
 	errDatasetHasNoTopics:       http.StatusInternalServerError,
 	errMissingLatestVersionLink: http.StatusInternalServerError,
+}
+
+// 404 errors within the dataset API.
+var datasetAPINotFoundErrors = []error{
+	datasetAPIErrors.ErrDatasetNotFound,
+	datasetAPIErrors.ErrEditionNotFound,
+	datasetAPIErrors.ErrEditionsNotFound,
+	datasetAPIErrors.ErrVersionNotFound,
+	datasetAPIErrors.ErrVersionsNotFound,
+	datasetAPIErrors.ErrInstanceNotFound,
+	datasetAPIErrors.ErrDimensionNotFound,
+	datasetAPIErrors.ErrDimensionsNotFound,
+	datasetAPIErrors.ErrDimensionNodeNotFound,
+	datasetAPIErrors.ErrDimensionOptionNotFound,
+	datasetAPIErrors.ErrFileMetadataNotFound,
+}
+
+// setStatusCode sets the appropriate HTTP status code based on the error type.
+func setStatusCode(ctx context.Context, w http.ResponseWriter, err error) {
+	status := http.StatusInternalServerError
+
+	if err == errTooManyOptions {
+		status = http.StatusRequestEntityTooLarge
+	}
+
+	if clientErr, ok := err.(clients.ClientError); ok {
+		if clientErr.Code() == http.StatusNotFound {
+			status = clientErr.Code()
+		}
+	}
+
+	if datasetErr, ok := err.(datasetAPIModels.Error); ok {
+		errCode, atoiErr := strconv.Atoi(datasetErr.Code)
+		if atoiErr != nil {
+			log.Error(ctx, "failed to convert error code to int", atoiErr, log.Data{"code": datasetErr.Code})
+		} else if errCode == http.StatusNotFound {
+			status = errCode
+		}
+	}
+
+	// The dataset API SDK can return errors either as a datasetAPIModels.Error (handled above) or as a plain error
+	// constructed from the response body string (handled here).
+	for _, notFoundErr := range datasetAPINotFoundErrors {
+		if err.Error() == notFoundErr.Error() {
+			status = http.StatusNotFound
+			break
+		}
+	}
+
+	// Check if the error is a known error with a mapped status code.
+	if mappedStatusCode, exists := errorToStatusCodeMap[err]; exists {
+		status = mappedStatusCode
+	}
+
+	log.Error(ctx, "client error", err, log.Data{"setting-response-status": status})
+	w.WriteHeader(status)
 }

--- a/handlers/errors.go
+++ b/handlers/errors.go
@@ -23,6 +23,7 @@ var (
 // Map of errors to HTTP status codes
 var errorToStatusCodeMap = map[error]int{
 	errDatasetTypeNotSupported:  http.StatusNotFound,
+	errTooManyOptions:           http.StatusRequestEntityTooLarge,
 	errDatasetHasNoTopics:       http.StatusInternalServerError,
 	errMissingLatestVersionLink: http.StatusInternalServerError,
 }
@@ -45,10 +46,6 @@ var datasetAPINotFoundErrors = []error{
 // setStatusCode sets the appropriate HTTP status code based on the error type.
 func setStatusCode(ctx context.Context, w http.ResponseWriter, err error) {
 	status := http.StatusInternalServerError
-
-	if err == errTooManyOptions {
-		status = http.StatusRequestEntityTooLarge
-	}
 
 	if clientErr, ok := err.(clients.ClientError); ok {
 		if clientErr.Code() == http.StatusNotFound {

--- a/handlers/errors_test.go
+++ b/handlers/errors_test.go
@@ -1,0 +1,59 @@
+package handlers
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	datasetAPIErrors "github.com/ONSdigital/dp-dataset-api/apierrors"
+	datasetAPIModels "github.com/ONSdigital/dp-dataset-api/models"
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestSetStatusCode(t *testing.T) {
+	ctx := context.Background()
+
+	Convey("test setStatusCode", t, func() {
+		testCases := []struct {
+			name     string
+			err      error
+			expected int
+		}{
+			{
+				name:     "test status code handles 404 response from client",
+				err:      &testCliError{},
+				expected: http.StatusNotFound,
+			},
+			{
+				name:     "test status code handles internal server error",
+				err:      errors.New("internal server error"),
+				expected: http.StatusInternalServerError,
+			},
+			{
+				name:     "test status code handles known errors with mapped status codes",
+				err:      errDatasetTypeNotSupported,
+				expected: http.StatusNotFound,
+			},
+			{
+				name:     "test status code handles dataset API client error",
+				err:      datasetAPIModels.Error{Code: "404"},
+				expected: http.StatusNotFound,
+			},
+			{
+				name:     "test status code handles known dataset API not found error",
+				err:      datasetAPIErrors.ErrDatasetNotFound,
+				expected: http.StatusNotFound,
+			},
+		}
+
+		for _, tc := range testCases {
+			Convey(tc.name, func() {
+				w := httptest.NewRecorder()
+				setStatusCode(ctx, w, tc.err)
+				So(w.Code, ShouldEqual, tc.expected)
+			})
+		}
+	})
+}

--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -37,39 +37,6 @@ const (
 	templateNameStaticEditionsList = "edition-list-static"
 )
 
-var errTooManyOptions = errors.New("too many options in dimension")
-
-func setStatusCode(ctx context.Context, w http.ResponseWriter, err error) {
-	status := http.StatusInternalServerError
-
-	if err == errTooManyOptions {
-		status = http.StatusRequestEntityTooLarge
-	}
-
-	if clientErr, ok := err.(clients.ClientError); ok {
-		if clientErr.Code() == http.StatusNotFound {
-			status = clientErr.Code()
-		}
-	}
-
-	if datasetErr, ok := err.(dpDatasetApiModels.Error); ok {
-		errCode, atoiErr := strconv.Atoi(datasetErr.Code)
-		if atoiErr != nil {
-			log.Error(ctx, "failed to convert error code to int", atoiErr, log.Data{"code": datasetErr.Code})
-		} else if errCode == http.StatusNotFound {
-			status = errCode
-		}
-	}
-
-	// Check if the error is a known error with a mapped status code
-	if mappedStatusCode, exists := errorToStatusCodeMap[err]; exists {
-		status = mappedStatusCode
-	}
-
-	log.Error(ctx, "client error", err, log.Data{"setting-response-status": status})
-	w.WriteHeader(status)
-}
-
 // getOptionsSummary requests a maximum of numOpts for each dimension, and returns the array of Options structs for each dimension, each one containing up to numOpts options.
 func getOptionsSummary(ctx context.Context, dc clients.DatasetAPISdkClient, userAccessToken, collectionID, datasetID, edition, version string, dimensions dpDatasetApiSdk.VersionDimensionsList, numOpts int) (opts []dpDatasetApiSdk.VersionDimensionOptionsList, err error) {
 	headers := dpDatasetApiSdk.Headers{

--- a/handlers/handlers_test.go
+++ b/handlers/handlers_test.go
@@ -1,16 +1,12 @@
 package handlers
 
 import (
-	coreContext "context"
-	"errors"
 	"net/http"
-	"net/http/httptest"
 	"testing"
 
 	"github.com/ONSdigital/dp-api-clients-go/v2/dataset"
 	"github.com/ONSdigital/dp-api-clients-go/v2/population"
 	"github.com/ONSdigital/dp-frontend-dataset-controller/config"
-	"github.com/golang/mock/gomock"
 	. "github.com/smartystreets/goconvey/convey"
 )
 
@@ -57,39 +53,6 @@ func slice(full []dataset.Option, offset, limit int) (sliced []dataset.Option) {
 	}
 
 	return full[offset:end]
-}
-
-func TestUnitHandlers(t *testing.T) {
-	mockCtrl := gomock.NewController(t)
-	defer mockCtrl.Finish()
-	ctx := coreContext.Background()
-
-	Convey("test setStatusCode", t, func() {
-		Convey("test status code handles 404 response from client", func() {
-			w := httptest.NewRecorder()
-			err := &testCliError{}
-
-			setStatusCode(ctx, w, err)
-
-			So(w.Code, ShouldEqual, http.StatusNotFound)
-		})
-
-		Convey("test status code handles internal server error", func() {
-			w := httptest.NewRecorder()
-			err := errors.New("internal server error")
-
-			setStatusCode(ctx, w, err)
-
-			So(w.Code, ShouldEqual, http.StatusInternalServerError)
-		})
-		Convey("test status code handles known errors with mapped status codes", func() {
-			w := httptest.NewRecorder()
-			err := errDatasetTypeNotSupported // Known 404 error
-
-			setStatusCode(ctx, w, err)
-			So(w.Code, ShouldEqual, http.StatusNotFound)
-		})
-	})
 }
 
 func TestSortOptionsByCode(t *testing.T) {


### PR DESCRIPTION
### What

Ticket: https://officefornationalstatistics.atlassian.net/browse/DIS-5112

- Fix bug where 500 status codes were being returned for 404 errors from the dataset-api SDK.

Notes:
- The root cause of the issue is that the dataset-api SDK returns multiple error types. Some may be returned in a defined `ErrorResponse` model and some may be returned as a generic `errors.new()` error. This causes issues for users of the SDK since the `.Code()` method is not available for all SDK errors and therefore may be handled as 500 responses (such as in this service). This will be logged as tech debt since making the change to the SDK will be a breaking change for SDK users. ([Tech Debt ticket](https://officefornationalstatistics.atlassian.net/browse/DIS-5124))

### How to review

- Create a dataset version and navigate to the overview page.
- Use the incorrect dataset ID and a 404 "page not found" screen should appear

### Who can review

- Anyone
