### PR TITLE
Feature/display edition titles in editions list static

### DIFF
--- a/Dockerfile.concourse
+++ b/Dockerfile.concourse
@@ -1,4 +1,4 @@
-FROM onsdigital/dp-concourse-tools-ubuntu-22:ubuntu22.4-jammy-20250126
+FROM onsdigital/dp-concourse-tools-ubuntu-22:ubuntu22.4-jammy-20260509
 
 RUN apt-get update && apt-get install tzdata
 

--- a/ci/audit.yml
+++ b/ci/audit.yml
@@ -5,7 +5,7 @@ image_resource:
   type: docker-image
   source:
     repository: onsdigital/dp-concourse-tools-vulncheck
-    tag: 1.26.5-vulncheck-0.6.0
+    tag: 1.26.6-vulncheck-0.6.1
 
 inputs:
   - name: dp-frontend-dataset-controller

--- a/ci/build.yml
+++ b/ci/build.yml
@@ -6,7 +6,7 @@ image_resource:
   type: docker-image
   source:
     repository: golang
-    tag: 1.26.5-bookworm
+    tag: 1.26.6-bookworm
 
 inputs:
   - name: dp-frontend-dataset-controller

--- a/ci/component.yml
+++ b/ci/component.yml
@@ -6,7 +6,7 @@ image_resource:
   type: docker-image
   source:
     repository: golang
-    tag: 1.26.5-bookworm
+    tag: 1.26.6-bookworm
 
 inputs:
   - name: dp-frontend-dataset-controller

--- a/ci/lint.yml
+++ b/ci/lint.yml
@@ -6,7 +6,7 @@ image_resource:
   type: docker-image
   source:
     repository: onsdigital/dp-concourse-tools-lint-go
-    tag: 1.26.5-bookworm-golangci-lint-2
+    tag: 1.26.6-bookworm-golangci-lint-2
 
 inputs:
   - name: dp-frontend-dataset-controller

--- a/ci/unit.yml
+++ b/ci/unit.yml
@@ -6,7 +6,7 @@ image_resource:
   type: docker-image
   source:
     repository: golang
-    tag: 1.26.5-bookworm
+    tag: 1.26.6-bookworm
 
 inputs:
   - name: dp-frontend-dataset-controller

--- a/mapper/mapper.go
+++ b/mapper/mapper.go
@@ -417,7 +417,7 @@ func CreateEditionsListForStaticDatasetType(ctx context.Context, basePage dpRend
 	if len(editionItems) > 0 {
 		for i := range editionItems {
 			var el edition.List
-			el.Title = editionItems[i].Edition
+			el.Title = editionItems[i].EditionTitle
 			el.LatestVersionURL = helpers.DatasetVersionURLWithTopic(topicObjectList[0].Slug, datasetID, editionItems[i].Edition, editionItems[i].Links.LatestVersion.ID)
 			p.Editions = append(p.Editions, el)
 		}


### PR DESCRIPTION
### What

Ticket: https://officefornationalstatistics.atlassian.net/browse/DIS-5299

- Display edition titles in editions list rather than editionID. (only for static datasets)

### How to review

- Create a dataset with multiple editions
- Go to `http://localhost:20200/{topic_slug}/datasets/{dataset_id}/editions`
- Editions list should show edition titles

### Who can review

- Anyone
