### PR TITLE
Bugfix/redirect to latest version of edition

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/ONSdigital/dp-authorisation/v2 v2.34.0
 	github.com/ONSdigital/dp-cache v0.6.1
 	github.com/ONSdigital/dp-cookies v0.7.1
-	github.com/ONSdigital/dp-dataset-api v1.106.0
+	github.com/ONSdigital/dp-dataset-api v1.119.0
 	github.com/ONSdigital/dp-healthcheck v1.6.4
 	github.com/ONSdigital/dp-net/v3 v3.11.0
 	github.com/ONSdigital/dp-otel-go v0.0.8

--- a/go.sum
+++ b/go.sum
@@ -10,8 +10,8 @@ github.com/ONSdigital/dp-cache v0.6.1 h1:wiYvxRIef9nu3Uk1//il5vNLTeKgajZ2kYacwkF
 github.com/ONSdigital/dp-cache v0.6.1/go.mod h1:d95JP5gBSNE0L206aNvFDtI1m0oTEGWN9ZetmnN/7hk=
 github.com/ONSdigital/dp-cookies v0.7.1 h1:cjMcMhjD4WWTKyvIBXzVkA4Smx8PLdiYcZc+u6Q3kNU=
 github.com/ONSdigital/dp-cookies v0.7.1/go.mod h1:eLdOwxXJk5DBYsiqSP2hz/yw+Uz3COaUvDjUQ3DG8iM=
-github.com/ONSdigital/dp-dataset-api v1.106.0 h1:Nn+PaEWBH7l22QCMxuh/jELVKoZj8TF25Co8jjmnHtI=
-github.com/ONSdigital/dp-dataset-api v1.106.0/go.mod h1:AK2gpeRf6MrfnWgyXTM3M13SK+9ECzuQhst/kL7LrmE=
+github.com/ONSdigital/dp-dataset-api v1.119.0 h1:gUFfTYOlzv5ZS8VxCJD31PQWjmd6Zr/0sR0CeLLO/ZY=
+github.com/ONSdigital/dp-dataset-api v1.119.0/go.mod h1:DMEWSTkzaDwACnhAvCtyxq/b19ASp75gcMSonpvAspk=
 github.com/ONSdigital/dp-healthcheck v1.6.4 h1:FhWOuVmob36dYq7AzCdbgyf0Vk58IFitSl8y8pWJ8ck=
 github.com/ONSdigital/dp-healthcheck v1.6.4/go.mod h1:j3UNbGT4ZJg1chrRkPLE6YUVYCg1su3AAQ8frcBrvgc=
 github.com/ONSdigital/dp-mocking v0.11.0 h1:laln6e2JD4vtsYbg0cTw9ur1Xf390AUYdd85cG2UNQw=

--- a/handlers/static_landing.go
+++ b/handlers/static_landing.go
@@ -86,15 +86,24 @@ func staticLanding(r *http.Request, w http.ResponseWriter, datasetAPIClient clie
 	}
 
 	// If versionID is missing then request came from /{topic}/datasets/{datasetID}/editions/{editionID} or /{topic}/datasets/{datasetID}/editions/{editionID}/versions.
-	// Redirect to the latest version of the dataset.
+	// Redirect to the latest version of the requested edition.
 	if versionID == "" {
 		log.Info(ctx, "versionID not provided in URL, redirecting to latest version", logData)
-		redirectPath, err := helpers.PrefixPathWithTopic(topicSlug, dataset.Links.LatestVersion.HRef)
+
+		edition, err := datasetAPIClient.GetEdition(ctx, datasetAPIClientHeaders, datasetID, editionID)
 		if err != nil {
-			log.Error(ctx, "failed to create redirect path for latest version", err, logData)
+			log.Error(ctx, "failed to fetch edition", err, logData)
 			setStatusCode(ctx, w, err)
 			return
 		}
+
+		if edition.Links == nil || edition.Links.LatestVersion == nil || edition.Links.LatestVersion.ID == "" {
+			log.Error(ctx, "edition does not have a latest version link", errMissingLatestVersionLink, logData)
+			setStatusCode(ctx, w, errMissingLatestVersionLink)
+			return
+		}
+
+		redirectPath := helpers.DatasetVersionURLWithTopic(topicSlug, datasetID, editionID, edition.Links.LatestVersion.ID)
 
 		//nolint:gosec // false positive as this is a relative URL which can only redirect to the same host
 		http.Redirect(w, r, redirectPath, http.StatusFound)

--- a/handlers/static_landing_test.go
+++ b/handlers/static_landing_test.go
@@ -67,12 +67,21 @@ func TestStaticLanding(t *testing.T) {
 		Topics: []string{"topic1", "topic2"},
 		Links: &datasetAPIModels.DatasetLinks{
 			LatestVersion: &datasetAPIModels.LinkObject{
+				HRef: "/v1/datasets/static-dataset/editions/2026/versions/9",
+				ID:   "9",
+			},
+		},
+	}
+	editionID := "2025"
+	edition := datasetAPIModels.Edition{
+		Edition: editionID,
+		Links: &datasetAPIModels.EditionUpdateLinks{
+			LatestVersion: &datasetAPIModels.LinkObject{
 				HRef: "/v1/datasets/static-dataset/editions/2025/versions/2",
 				ID:   "2",
 			},
 		},
 	}
-	editionID := "2025"
 	versionID := "1"
 	version := datasetAPIModels.Version{
 		Distributions: &[]datasetAPIModels.Distribution{
@@ -238,19 +247,39 @@ func TestStaticLanding(t *testing.T) {
 		})
 	})
 
-	Convey("When versionID is not provided in the URL and the dataset has an invalid latest version link", t, func() {
+	Convey("When versionID is not provided in the URL and the edition has no latest version link", t, func() {
 		mockDatasetClient.EXPECT().GetDataset(ctx, testUserDatasetSDKHeaders, datasetID).
-			Return(datasetAPIModels.Dataset{
-				ID:     datasetID,
-				Type:   DatasetTypeStatic,
-				Topics: []string{"topic1", "topic2"},
-				Links: &datasetAPIModels.DatasetLinks{
-					LatestVersion: &datasetAPIModels.LinkObject{
-						HRef: "://invalid-url",
-						ID:   "2",
-					},
-				},
-			}, nil)
+			Return(dataset, nil)
+
+		mockDatasetClient.EXPECT().GetEdition(ctx, testUserDatasetSDKHeaders, datasetID, editionID).
+			Return(datasetAPIModels.Edition{Edition: editionID, Links: &datasetAPIModels.EditionUpdateLinks{}}, nil)
+
+		mockTopicAPIClient.EXPECT().GetTopicPrivate(ctx, topicAPISDK.Headers{UserAuthToken: testUserAccessToken}, "topic1").
+			Return(&topicAPIModels.TopicResponse{Current: &testTopic1}, nil)
+		mockTopicAPIClient.EXPECT().GetTopicPrivate(ctx, topicAPISDK.Headers{UserAuthToken: testUserAccessToken}, "topic2").
+			Return(&topicAPIModels.TopicResponse{Current: &testTopic2}, nil)
+
+		w := httptest.NewRecorder()
+		r := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/%s/datasets/%s/editions/%s", "topic1-slug", datasetID, editionID), http.NoBody)
+		r = mux.SetURLVars(r, map[string]string{
+			"topic":     "topic1-slug",
+			"datasetID": datasetID,
+			"editionID": editionID,
+		})
+
+		staticLanding(r, w, mockDatasetClient, mockRenderClient, mockZebedeeClient, mockTopicAPIClient, cfg, mockAuthMiddleware, testUserAccessToken, lang, collectionID)
+
+		Convey("Then the response status code should be 500 Internal Server Error", func() {
+			So(w.Code, ShouldEqual, http.StatusInternalServerError)
+		})
+	})
+
+	Convey("When versionID is not provided in the URL and GetEdition fails", t, func() {
+		mockDatasetClient.EXPECT().GetDataset(ctx, testUserDatasetSDKHeaders, datasetID).
+			Return(dataset, nil)
+
+		mockDatasetClient.EXPECT().GetEdition(ctx, testUserDatasetSDKHeaders, datasetID, editionID).
+			Return(datasetAPIModels.Edition{}, errors.New("GetEdition failed"))
 
 		mockTopicAPIClient.EXPECT().GetTopicPrivate(ctx, topicAPISDK.Headers{UserAuthToken: testUserAccessToken}, "topic1").
 			Return(&topicAPIModels.TopicResponse{Current: &testTopic1}, nil)
@@ -277,6 +306,9 @@ func TestStaticLanding(t *testing.T) {
 		mockDatasetClient.EXPECT().GetDataset(ctx, testUserDatasetSDKHeaders, datasetID).
 			Return(dataset, nil)
 
+		mockDatasetClient.EXPECT().GetEdition(ctx, testUserDatasetSDKHeaders, datasetID, editionID).
+			Return(edition, nil)
+
 		mockTopicAPIClient.EXPECT().GetTopicPrivate(ctx, topicAPISDK.Headers{UserAuthToken: testUserAccessToken}, "topic1").
 			Return(&topicAPIModels.TopicResponse{Current: &testTopic1}, nil)
 		mockTopicAPIClient.EXPECT().GetTopicPrivate(ctx, topicAPISDK.Headers{UserAuthToken: testUserAccessToken}, "topic2").
@@ -294,7 +326,7 @@ func TestStaticLanding(t *testing.T) {
 
 		Convey("Then the response should be a redirect to the latest version", func() {
 			So(w.Code, ShouldEqual, http.StatusFound)
-			expectedLocation := fmt.Sprintf("/%s/datasets/%s/editions/%s/versions/%s", "topic1-slug", datasetID, editionID, dataset.Links.LatestVersion.ID)
+			expectedLocation := fmt.Sprintf("/%s/datasets/%s/editions/%s/versions/%s", "topic1-slug", datasetID, editionID, edition.Links.LatestVersion.ID)
 			So(w.Header().Get("Location"), ShouldEqual, expectedLocation)
 		})
 	})
@@ -303,6 +335,9 @@ func TestStaticLanding(t *testing.T) {
 	Convey("When versionID not provided in the URL, redirect to latest version", t, func() {
 		mockDatasetClient.EXPECT().GetDataset(ctx, testUserDatasetSDKHeaders, datasetID).
 			Return(dataset, nil)
+
+		mockDatasetClient.EXPECT().GetEdition(ctx, testUserDatasetSDKHeaders, datasetID, editionID).
+			Return(edition, nil)
 
 		mockTopicAPIClient.EXPECT().GetTopicPrivate(ctx, topicAPISDK.Headers{UserAuthToken: testUserAccessToken}, "topic1").
 			Return(&topicAPIModels.TopicResponse{Current: &testTopic1}, nil)
@@ -321,7 +356,7 @@ func TestStaticLanding(t *testing.T) {
 
 		Convey("Then the response should be a redirect to the latest version", func() {
 			So(w.Code, ShouldEqual, http.StatusFound)
-			expectedLocation := fmt.Sprintf("/%s/datasets/%s/editions/%s/versions/%s", "topic1-slug", datasetID, editionID, dataset.Links.LatestVersion.ID)
+			expectedLocation := fmt.Sprintf("/%s/datasets/%s/editions/%s/versions/%s", "topic1-slug", datasetID, editionID, edition.Links.LatestVersion.ID)
 			So(w.Header().Get("Location"), ShouldEqual, expectedLocation)
 		})
 	})


### PR DESCRIPTION
### What

Ticket: https://officefornationalstatistics.atlassian.net/browse/DIS-5324

- Fix bug where `/{topic}/datasets/{datasetID}/editions/{editionID}` and `/{topic}/datasets/{datasetID}/editions/{editionID}/versions` would redirect to the latest version of the latest edition of the dataset instead of redirecting the latest version of the `editionID` provided in the URL

### How to review

- Create an edition with two versions
- Create another edition with 1 version
- Go to `/{topic}/datasets/{datasetID}/editions/{editionID}` and `/{topic}/datasets/{datasetID}/editions/{editionID}/versions` using the `editionID` of the first edition you created.
- Both pages should redirect to the latest version of the edition you provided in the URL.

### Who can review

- Anyone
